### PR TITLE
Add in-app logging screen accessible from Profile tab

### DIFF
--- a/Baby Tracker/App/CloudKitShareAcceptanceBridge.swift
+++ b/Baby Tracker/App/CloudKitShareAcceptanceBridge.swift
@@ -1,3 +1,4 @@
+import BabyTrackerDomain
 import BabyTrackerSync
 import CloudKit
 import Foundation
@@ -12,6 +13,7 @@ final class CloudKitShareAcceptanceBridge {
             guard let handler, let queued = queuedMetadata else { return }
             print("[BabyTracker][2/5] Handler set — flushing queued share metadata")
             logger.info("[2/5] Handler set — flushing queued share metadata")
+            AppLogger.shared.log(.info, category: "ShareAcceptance", "[2/5] Handler set — flushing queued share metadata")
             queuedMetadata = nil
             handler.accept(metadata: queued)
         }
@@ -23,14 +25,18 @@ final class CloudKitShareAcceptanceBridge {
     private init() {}
 
     func handle(metadata: CKShare.Metadata) {
-        print("[BabyTracker][2/5] Bridge.handle called — handler is \(handler == nil ? "nil (queuing)" : "ready")")
+        let handlerState = handler == nil ? "nil (queuing)" : "ready"
+        print("[BabyTracker][2/5] Bridge.handle called — handler is \(handlerState)")
         logger.info("[2/5] Bridge.handle called — handler is \(self.handler == nil ? "nil (queuing)" : "ready", privacy: .public)")
+        AppLogger.shared.log(.info, category: "ShareAcceptance", "[2/5] Bridge.handle called — handler is \(handlerState)")
         guard let handler else {
             logger.warning("[2/5] Handler not set yet — queuing metadata for when handler is assigned")
+            AppLogger.shared.log(.warning, category: "ShareAcceptance", "[2/5] Handler not set yet — queuing metadata for when handler is assigned")
             queuedMetadata = metadata
             return
         }
         logger.info("[2/5] Forwarding share metadata to ShareAcceptanceHandler")
+        AppLogger.shared.log(.info, category: "ShareAcceptance", "[2/5] Forwarding share metadata to ShareAcceptanceHandler")
         handler.accept(metadata: metadata)
     }
 }

--- a/Baby Tracker/App/CloudKitShareAppDelegate.swift
+++ b/Baby Tracker/App/CloudKitShareAppDelegate.swift
@@ -1,3 +1,4 @@
+import BabyTrackerDomain
 import CloudKit
 import os
 import UIKit
@@ -28,6 +29,7 @@ final class CloudKitShareAppDelegate: NSObject, UIApplicationDelegate {
         let zone = cloudKitShareMetadata.share.recordID.zoneID.zoneName
         print("[BabyTracker][1/5] UIApplicationDelegate fired (non-scene path) — title: \(title), zone: \(zone)")
         logger.info("[1/5] UIApplicationDelegate fired (non-scene path) — title: '\(title, privacy: .private)', zone: \(zone, privacy: .public)")
+        AppLogger.shared.log(.info, category: "ShareAcceptance", "[1/5] UIApplicationDelegate fired (non-scene path) — zone: \(zone)")
         CloudKitShareAcceptanceBridge.shared.handle(metadata: cloudKitShareMetadata)
     }
 }

--- a/Baby Tracker/App/CloudKitShareSceneDelegate.swift
+++ b/Baby Tracker/App/CloudKitShareSceneDelegate.swift
@@ -1,3 +1,4 @@
+import BabyTrackerDomain
 import CloudKit
 import os
 import UIKit
@@ -17,6 +18,7 @@ final class CloudKitShareSceneDelegate: NSObject, UIWindowSceneDelegate {
         print("[BabyTracker][1/5] SceneDelegate fired — title: \(title), zone: \(zone)")
         logger.info("[1/5] SceneDelegate fired — share title: '\(title, privacy: .private)', zone: \(zone, privacy: .public)")
         Task { @MainActor in
+            AppLogger.shared.log(.info, category: "ShareAcceptance", "[1/5] SceneDelegate fired — zone: \(zone)")
             CloudKitShareAcceptanceBridge.shared.handle(metadata: cloudKitShareMetadata)
         }
     }

--- a/Packages/BabyTrackerDomain/Sources/BabyTrackerDomain/AppLogger.swift
+++ b/Packages/BabyTrackerDomain/Sources/BabyTrackerDomain/AppLogger.swift
@@ -1,0 +1,47 @@
+import Foundation
+import Observation
+
+public enum LogLevel: String, Sendable, CaseIterable, Codable {
+    case debug
+    case info
+    case warning
+    case error
+}
+
+public struct LogEntry: Identifiable, Sendable {
+    public let id: UUID
+    public let timestamp: Date
+    public let level: LogLevel
+    public let category: String
+    public let message: String
+
+    public init(id: UUID = UUID(), timestamp: Date = .now, level: LogLevel, category: String, message: String) {
+        self.id = id
+        self.timestamp = timestamp
+        self.level = level
+        self.category = category
+        self.message = message
+    }
+}
+
+@MainActor
+@Observable
+public final class AppLogger {
+    public static let shared = AppLogger()
+    public private(set) var entries: [LogEntry] = []
+
+    private static let maxEntries = 2000
+
+    private init() {}
+
+    public func log(_ level: LogLevel, category: String, _ message: String) {
+        entries.append(LogEntry(level: level, category: category, message: message))
+        if entries.count > Self.maxEntries {
+            entries.removeFirst()
+        }
+    }
+
+    public func clear() {
+        entries.removeAll()
+    }
+}

--- a/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/AppModel.swift
+++ b/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/AppModel.swift
@@ -501,6 +501,7 @@ public final class AppModel {
                 userID: localUser.id
             )
             logger.info("refresh — localUserID: \(localUser.id, privacy: .public), active: \(self.activeChildren.count, privacy: .public), archived: \(self.archivedChildren.count, privacy: .public)")
+            AppLogger.shared.log(.info, category: "AppModel", "refresh — active: \(self.activeChildren.count), archived: \(self.archivedChildren.count)")
 
             guard !activeChildren.isEmpty else {
                 route = .noChildren
@@ -579,6 +580,7 @@ public final class AppModel {
                 logger.warning(
                     "loadChildSummaries — skipping child '\(child.name, privacy: .private)': no active membership for local user. Self statuses: [\(statuses, privacy: .public)]. All memberships: [\(allRoles, privacy: .public)]"
                 )
+                AppLogger.shared.log(.warning, category: "AppModel", "loadChildSummaries — skipping child: no active membership for local user. Self statuses: [\(statuses)]. All memberships: [\(allRoles)]")
                 continue
             }
 

--- a/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/ChildProfileView.swift
+++ b/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/ChildProfileView.swift
@@ -65,6 +65,16 @@ public struct ChildProfileView: View {
                     )
                 }
 
+                NavigationLink {
+                    LoggingView(appLogger: AppLogger.shared)
+                } label: {
+                    settingsRow(
+                        title: "Logs",
+                        value: nil,
+                        accessibilityIdentifier: "profile-logs-row"
+                    )
+                }
+
                 if profile.canSwitchChildren {
                     Button {
                         model.showChildPicker()

--- a/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/LoggingView.swift
+++ b/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/LoggingView.swift
@@ -1,0 +1,172 @@
+import BabyTrackerDomain
+import SwiftUI
+import UIKit
+
+public struct LoggingView: View {
+    let appLogger: AppLogger
+
+    @State private var searchText = ""
+    @State private var selectedLevel: LogLevel?
+
+    public init(appLogger: AppLogger) {
+        self.appLogger = appLogger
+    }
+
+    public var body: some View {
+        List(filteredEntries) { entry in
+            LogEntryRow(entry: entry)
+        }
+        .listStyle(.plain)
+        .navigationTitle("Logs")
+        .navigationBarTitleDisplayMode(.inline)
+        .searchable(text: $searchText, prompt: "Search logs")
+        .toolbar {
+            ToolbarItem(placement: .navigationBarLeading) {
+                levelFilterMenu
+            }
+            ToolbarItem(placement: .navigationBarTrailing) {
+                actionsMenu
+            }
+        }
+        .overlay {
+            if appLogger.entries.isEmpty {
+                ContentUnavailableView(
+                    "No Logs",
+                    systemImage: "text.justify.left",
+                    description: Text("Logs will appear here as the app runs.")
+                )
+            } else if filteredEntries.isEmpty {
+                ContentUnavailableView.search
+            }
+        }
+    }
+
+    private var levelFilterMenu: some View {
+        Menu {
+            Button {
+                selectedLevel = nil
+            } label: {
+                HStack {
+                    Text("All Levels")
+                    if selectedLevel == nil { Image(systemName: "checkmark") }
+                }
+            }
+            Divider()
+            ForEach(LogLevel.allCases, id: \.self) { level in
+                Button {
+                    selectedLevel = selectedLevel == level ? nil : level
+                } label: {
+                    HStack {
+                        Text(level.displayName)
+                        if selectedLevel == level { Image(systemName: "checkmark") }
+                    }
+                }
+            }
+        } label: {
+            Image(systemName: selectedLevel == nil
+                  ? "line.3.horizontal.decrease.circle"
+                  : "line.3.horizontal.decrease.circle.fill")
+        }
+    }
+
+    private var actionsMenu: some View {
+        Menu {
+            Button {
+                UIPasteboard.general.string = formattedText(for: filteredEntries)
+            } label: {
+                Label("Copy Visible", systemImage: "doc.on.doc")
+            }
+
+            ShareLink(item: formattedText(for: appLogger.entries)) {
+                Label("Export All as File", systemImage: "square.and.arrow.up")
+            }
+
+            Divider()
+
+            Button(role: .destructive) {
+                appLogger.clear()
+            } label: {
+                Label("Clear Logs", systemImage: "trash")
+            }
+        } label: {
+            Image(systemName: "ellipsis.circle")
+        }
+    }
+
+    private var filteredEntries: [LogEntry] {
+        appLogger.entries
+            .filter { entry in
+                if let level = selectedLevel, entry.level != level { return false }
+                guard !searchText.isEmpty else { return true }
+                return entry.message.localizedCaseInsensitiveContains(searchText)
+                    || entry.category.localizedCaseInsensitiveContains(searchText)
+            }
+            .reversed()
+    }
+
+    private func formattedText(for entries: [LogEntry]) -> String {
+        let formatter = ISO8601DateFormatter()
+        return entries.map { entry in
+            "[\(formatter.string(from: entry.timestamp))] [\(entry.level.rawValue.uppercased())] [\(entry.category)] \(entry.message)"
+        }.joined(separator: "\n")
+    }
+}
+
+private struct LogEntryRow: View {
+    let entry: LogEntry
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 4) {
+            HStack(spacing: 6) {
+                Image(systemName: entry.level.symbolName)
+                    .foregroundStyle(entry.level.rowColor)
+                    .imageScale(.small)
+
+                Text(entry.category)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+
+                Spacer()
+
+                Text(entry.timestamp, style: .time)
+                    .font(.caption2)
+                    .foregroundStyle(.tertiary)
+            }
+
+            Text(entry.message)
+                .font(.caption)
+                .foregroundStyle(.primary)
+                .lineLimit(4)
+        }
+        .padding(.vertical, 2)
+    }
+}
+
+private extension LogLevel {
+    var displayName: String {
+        switch self {
+        case .debug: return "Debug"
+        case .info: return "Info"
+        case .warning: return "Warning"
+        case .error: return "Error"
+        }
+    }
+
+    var symbolName: String {
+        switch self {
+        case .debug: return "ant.circle"
+        case .info: return "info.circle"
+        case .warning: return "exclamationmark.triangle"
+        case .error: return "xmark.circle"
+        }
+    }
+
+    var rowColor: Color {
+        switch self {
+        case .debug: return .gray
+        case .info: return .blue
+        case .warning: return .orange
+        case .error: return .red
+        }
+    }
+}

--- a/Packages/BabyTrackerSync/Sources/BabyTrackerSync/CloudKitSyncEngine.swift
+++ b/Packages/BabyTrackerSync/Sources/BabyTrackerSync/CloudKitSyncEngine.swift
@@ -183,6 +183,7 @@ public final class CloudKitSyncEngine {
             databaseScope: .shared
         )
         logger.info("Left shared zone for child \(childID)")
+        AppLogger.shared.log(.info, category: "CloudKitSync", "Left shared zone for child \(childID)")
     }
 
     public func accept(metadata: CKShare.Metadata) async throws {
@@ -190,21 +191,28 @@ public final class CloudKitSyncEngine {
         let zoneName = metadata.share.recordID.zoneID.zoneName
         print("[BabyTracker][4/5] CloudKitSyncEngine.accept — title: \(shareTitle), zone: \(zoneName)")
         logger.info("[4/5] Sync engine accept — title: '\(shareTitle, privacy: .private)', zone: \(zoneName, privacy: .public)")
+        AppLogger.shared.log(.info, category: "CloudKitSync", "[4/5] Sync engine accept — title: '\(shareTitle)', zone: \(zoneName)")
         logger.info("[4/5] Calling client.accept (registers share with CloudKit)")
+        AppLogger.shared.log(.info, category: "CloudKitSync", "[4/5] Calling client.accept (registers share with CloudKit)")
         try await client.accept([metadata])
         logger.info("[4/5] client.accept succeeded — running foreground refresh")
+        AppLogger.shared.log(.info, category: "CloudKitSync", "[4/5] client.accept succeeded — running foreground refresh")
         _ = await refresh(reason: .foreground)
         logger.info("[4/5] Foreground refresh done — ensuring local membership record")
+        AppLogger.shared.log(.info, category: "CloudKitSync", "[4/5] Foreground refresh done — ensuring local membership record")
         try await ensureMembershipForAcceptedShare(metadata: metadata)
         logger.info("[4/5] Membership ensured — running post-write refresh")
+        AppLogger.shared.log(.info, category: "CloudKitSync", "[4/5] Membership ensured — running post-write refresh")
         _ = await refresh(reason: .localWrite)
         logger.info("[5/5] Share acceptance complete")
+        AppLogger.shared.log(.info, category: "CloudKitSync", "[5/5] Share acceptance complete")
     }
 
     private func refresh(reason: RefreshReason) async -> SyncStatusSummary {
         do {
             if reason == .launch {
                 logger.info("Launch sync starting")
+                AppLogger.shared.log(.info, category: "CloudKitSync", "Launch sync starting")
             }
 
             try userIdentityRepository.removeLegacyPlaceholderCaregivers()
@@ -212,6 +220,7 @@ public final class CloudKitSyncEngine {
 
             if reason == .launch {
                 logger.info("iCloud account status: \(accountStatus.logDescription, privacy: .public)")
+                AppLogger.shared.log(.info, category: "CloudKitSync", "iCloud account status: \(accountStatus.logDescription)")
             }
 
             guard accountStatus == .available else {
@@ -222,6 +231,7 @@ public final class CloudKitSyncEngine {
             let userRecordID = try await client.userRecordID()
             if reason == .launch {
                 logger.info("iCloud user record ID: \(userRecordID.recordName, privacy: .private(mask: .hash))")
+                AppLogger.shared.log(.info, category: "CloudKitSync", "iCloud user record ID obtained")
             }
             _ = try userIdentityRepository.linkLocalUser(
                 toCloudKitUserRecordName: userRecordID.recordName
@@ -244,6 +254,7 @@ public final class CloudKitSyncEngine {
         } catch {
             logger.error("Refresh(\(reason.logDescription, privacy: .public)) failed: \(error.localizedDescription, privacy: .public) [\(String(describing: error), privacy: .public)]")
             print("[BabyTracker] Refresh(\(reason.logDescription)) FAILED: \(error)")
+            AppLogger.shared.log(.error, category: "CloudKitSync", "Refresh(\(reason.logDescription)) failed: \(error.localizedDescription)")
             let localSummary = (try? syncStateRepository.loadStatusSummary()) ?? SyncStatusSummary()
             statusSummary = SyncStatusSummary(
                 state: .failed,
@@ -271,15 +282,19 @@ public final class CloudKitSyncEngine {
             zoneName: nil,
             ownerName: nil
         )
-        logger.info("Checking shared database for changes (token: \(anchor == nil ? "none — full fetch" : "incremental", privacy: .public))")
+        let tokenDescription = anchor == nil ? "none — full fetch" : "incremental"
+        logger.info("Checking shared database for changes (token: \(tokenDescription, privacy: .public))")
+        AppLogger.shared.log(.info, category: "CloudKitSync", "Checking shared database for changes (token: \(tokenDescription))")
         let changes = try await client.databaseChanges(
             in: .shared,
             since: anchor?.tokenData
         )
         logger.info("Shared database: \(changes.modifiedZoneIDs.count, privacy: .public) modified zone(s), \(changes.deletedZoneIDs.count, privacy: .public) deleted zone(s)")
+        AppLogger.shared.log(.info, category: "CloudKitSync", "Shared database: \(changes.modifiedZoneIDs.count) modified zone(s), \(changes.deletedZoneIDs.count) deleted zone(s)")
 
         for deletedZoneID in changes.deletedZoneIDs {
             logger.info("Shared zone deleted (access removed): \(deletedZoneID.zoneName, privacy: .public)")
+            AppLogger.shared.log(.info, category: "CloudKitSync", "Shared zone deleted (access removed): \(deletedZoneID.zoneName)")
             let childID = childID(from: deletedZoneID.zoneName)
             try childRepository.purgeChildData(id: childID)
             pendingInvitesByChildID[childID] = []
@@ -287,6 +302,7 @@ public final class CloudKitSyncEngine {
 
         for zoneID in changes.modifiedZoneIDs {
             logger.info("Shared zone modified (new/updated share): \(zoneID.zoneName, privacy: .public)")
+            AppLogger.shared.log(.info, category: "CloudKitSync", "Shared zone modified (new/updated share): \(zoneID.zoneName)")
             let childID = childID(from: zoneID.zoneName)
             let context = CloudKitChildContext(
                 childID: childID,
@@ -313,17 +329,20 @@ public final class CloudKitSyncEngine {
     private func pullKnownChildZones() async throws {
         let children = try childRepository.loadAllChildren()
         logger.info("Found \(children.count, privacy: .public) child(ren) in local store")
+        AppLogger.shared.log(.info, category: "CloudKitSync", "Found \(children.count) child(ren) in local store")
 
         for child in children {
             if let context = try childRepository.loadCloudKitChildContext(id: child.id) {
                 logger.info(
                     "Child '\(child.name, privacy: .private)' — zone: \(context.zoneID.zoneName, privacy: .public), scope: \(context.databaseScope.logDescription, privacy: .public), isArchived: \(child.isArchived, privacy: .public)"
                 )
+                AppLogger.shared.log(.info, category: "CloudKitSync", "Child — zone: \(context.zoneID.zoneName), scope: \(context.databaseScope.logDescription), isArchived: \(child.isArchived)")
                 try await pullZoneSnapshot(context: context)
                 let memberships = try membershipRepository.loadMemberships(for: child.id)
                 logger.info(
                     "Child '\(child.name, privacy: .private)' — \(memberships.count, privacy: .public) membership(s) in local store: \(memberships.map { "userID=\($0.userID) role=\($0.role) status=\($0.status)" }.joined(separator: ", "), privacy: .public)"
                 )
+                AppLogger.shared.log(.info, category: "CloudKitSync", "Child — \(memberships.count) membership(s) in local store")
                 if try repairOrphanedMembershipIfNeeded(for: child, context: context) {
                     try await pushZoneSnapshot(for: child.id, context: context)
                 }
@@ -331,6 +350,7 @@ public final class CloudKitSyncEngine {
             }
 
             logger.info("Child '\(child.name, privacy: .private)' — no CloudKit zone yet, creating private zone")
+            AppLogger.shared.log(.info, category: "CloudKitSync", "Child — no CloudKit zone yet, creating private zone")
             let context = try await ensureZoneContext(for: child.id, preferredScope: .private)
             try await pushZoneSnapshot(for: child.id, context: context)
         }
@@ -366,6 +386,7 @@ public final class CloudKitSyncEngine {
         logger.warning(
             "Repaired orphaned membership for child '\(child.name, privacy: .private)': reassigned userID from \(orphaned.userID, privacy: .public) to \(localUser.id, privacy: .public)"
         )
+        AppLogger.shared.log(.warning, category: "CloudKitSync", "Repaired orphaned membership: reassigned userID from \(orphaned.userID) to \(localUser.id)")
         return true
     }
 
@@ -374,9 +395,11 @@ public final class CloudKitSyncEngine {
 
         if pendingRecords.isEmpty {
             logger.info("pushPendingChanges — nothing pending, skipping")
+            AppLogger.shared.log(.info, category: "CloudKitSync", "pushPendingChanges — nothing pending, skipping")
         } else {
             let summary = pendingRecords.map { "\($0.recordType.rawValue):\($0.recordID)" }.joined(separator: ", ")
             logger.info("pushPendingChanges — \(pendingRecords.count, privacy: .public) pending record(s): \(summary, privacy: .public)")
+            AppLogger.shared.log(.info, category: "CloudKitSync", "pushPendingChanges — \(pendingRecords.count) pending record(s): \(summary)")
         }
 
         // Clear any pending records whose childID no longer has a corresponding child in
@@ -385,6 +408,7 @@ public final class CloudKitSyncEngine {
         let knownChildIDs = Set(try childRepository.loadAllChildren().map(\.id))
         for record in pendingRecords where record.childID != nil && !knownChildIDs.contains(record.childID!) {
             logger.warning("pushPendingChanges — orphaned pending record \(record.recordType.rawValue):\(record.recordID, privacy: .public) has unknown childID \(record.childID!, privacy: .public), marking upToDate")
+            AppLogger.shared.log(.warning, category: "CloudKitSync", "pushPendingChanges — orphaned pending record \(record.recordType.rawValue):\(record.recordID), marking upToDate")
             try syncStateRepository.updateSyncState(
                 for: record,
                 state: .upToDate,
@@ -407,13 +431,16 @@ public final class CloudKitSyncEngine {
 
             guard childHasPending || childHasPendingUsers else {
                 logger.info("pushPendingChanges — '\(child.name, privacy: .private)': nothing pending, skipping")
+                AppLogger.shared.log(.info, category: "CloudKitSync", "pushPendingChanges — child: nothing pending, skipping")
                 continue
             }
 
             let context = try await ensureZoneContext(for: child.id, preferredScope: .private)
             logger.info("pushPendingChanges — '\(child.name, privacy: .private)': pushing zone (scope: \(context.databaseScope.logDescription, privacy: .public))")
+            AppLogger.shared.log(.info, category: "CloudKitSync", "pushPendingChanges — pushing zone (scope: \(context.databaseScope.logDescription))")
             try await pushZoneSnapshot(for: child.id, context: context)
             logger.info("pushPendingChanges — '\(child.name, privacy: .private)': zone push complete")
+            AppLogger.shared.log(.info, category: "CloudKitSync", "pushPendingChanges — zone push complete")
         }
     }
 
@@ -468,6 +495,7 @@ public final class CloudKitSyncEngine {
 
         let savedTypes = filteredSaves.map(\.recordType).joined(separator: ", ")
         logger.info("pushZoneSnapshot '\(child.name, privacy: .private)' — saving \(filteredSaves.count, privacy: .public) record(s) to \(context.databaseScope.logDescription, privacy: .public): [\(savedTypes, privacy: .public)]")
+        AppLogger.shared.log(.info, category: "CloudKitSync", "pushZoneSnapshot — saving \(filteredSaves.count) record(s) to \(context.databaseScope.logDescription): [\(savedTypes)]")
         _ = try await client.modifyRecords(
             saving: filteredSaves,
             deleting: [],
@@ -475,6 +503,7 @@ public final class CloudKitSyncEngine {
             savePolicy: .changedKeys
         )
         logger.info("pushZoneSnapshot '\(child.name, privacy: .private)' — modifyRecords succeeded")
+        AppLogger.shared.log(.info, category: "CloudKitSync", "pushZoneSnapshot — modifyRecords succeeded")
 
         try syncStateRepository.updateSyncState(
             for: SyncRecordReference(recordType: .child, recordID: child.id, childID: child.id),
@@ -485,6 +514,7 @@ public final class CloudKitSyncEngine {
 
         for membership in memberships {
             logger.info("pushZoneSnapshot — marking membership upToDate: id=\(membership.id, privacy: .public) role=\(membership.role.rawValue, privacy: .public)")
+            AppLogger.shared.log(.info, category: "CloudKitSync", "pushZoneSnapshot — marking membership upToDate: id=\(membership.id) role=\(membership.role.rawValue)")
             try syncStateRepository.updateSyncState(
                 for: SyncRecordReference(
                     recordType: .membership,
@@ -549,6 +579,7 @@ public final class CloudKitSyncEngine {
 
         let recordTypes = changes.modifiedRecords.map(\.recordType)
         logger.info("pullZoneSnapshot \(context.zoneID.zoneName, privacy: .public) (\(databaseScope, privacy: .public)): \(changes.modifiedRecords.count, privacy: .public) modified, \(changes.deletions.count, privacy: .public) deleted — types: \(recordTypes.joined(separator: ", "), privacy: .public)")
+        AppLogger.shared.log(.info, category: "CloudKitSync", "pullZoneSnapshot \(context.zoneID.zoneName) (\(databaseScope)): \(changes.modifiedRecords.count) modified, \(changes.deletions.count) deleted — types: \(recordTypes.joined(separator: ", "))")
 
         for record in changes.modifiedRecords {
             try save(record: record, within: context)
@@ -612,11 +643,13 @@ public final class CloudKitSyncEngine {
         case CloudKitConfiguration.membershipRecordType:
             let membership = CloudKitRecordMapper.membership(from: record)
             logger.info("Saving membership from CloudKit — role: \(membership.role.rawValue, privacy: .public), status: \(membership.status.rawValue, privacy: .public), childID: \(membership.childID, privacy: .public)")
+            AppLogger.shared.log(.info, category: "CloudKitSync", "Saving membership from CloudKit — role: \(membership.role.rawValue), status: \(membership.status.rawValue), childID: \(membership.childID)")
             do {
                 try membershipRepository.saveMembership(membership)
             } catch {
                 logger.error("Failed to save membership (role: \(membership.role.rawValue, privacy: .public), status: \(membership.status.rawValue, privacy: .public)): \(error.localizedDescription, privacy: .public)")
                 print("[BabyTracker] saveMembership FAILED role=\(membership.role.rawValue) status=\(membership.status.rawValue): \(error)")
+                AppLogger.shared.log(.error, category: "CloudKitSync", "Failed to save membership (role: \(membership.role.rawValue), status: \(membership.status.rawValue)): \(error.localizedDescription)")
                 throw error
             }
             try syncStateRepository.updateSyncState(
@@ -709,11 +742,13 @@ public final class CloudKitSyncEngine {
     ) async throws {
         guard let localUser = try userIdentityRepository.loadLocalUser() else {
             logger.warning("[4/5] ensureMembership — no local user found, skipping membership creation")
+            AppLogger.shared.log(.warning, category: "CloudKitSync", "[4/5] ensureMembership — no local user found, skipping membership creation")
             return
         }
 
         guard let rootRecordID = metadata.hierarchicalRootRecordID else {
             logger.warning("[4/5] ensureMembership — no hierarchicalRootRecordID in metadata, skipping")
+            AppLogger.shared.log(.warning, category: "CloudKitSync", "[4/5] ensureMembership — no hierarchicalRootRecordID in metadata, skipping")
             return
         }
 
@@ -723,13 +758,16 @@ public final class CloudKitSyncEngine {
             membership.userID == localUser.id && membership.status == .active
         }) else {
             logger.info("[4/5] ensureMembership — active membership already exists, skipping")
+            AppLogger.shared.log(.info, category: "CloudKitSync", "[4/5] ensureMembership — active membership already exists, skipping")
             return
         }
 
         let existingRoles = existingMemberships.map { "\($0.role.rawValue)/\($0.status.rawValue)" }.joined(separator: ", ")
         logger.info("[4/5] ensureMembership — existing memberships for child: [\(existingRoles.isEmpty ? "none" : existingRoles, privacy: .public)]")
         print("[BabyTracker][4/5] ensureMembership — existing memberships: [\(existingRoles.isEmpty ? "none" : existingRoles)]")
+        AppLogger.shared.log(.info, category: "CloudKitSync", "[4/5] ensureMembership — existing memberships: [\(existingRoles.isEmpty ? "none" : existingRoles)]")
         logger.info("[4/5] ensureMembership — creating caregiver membership for zone: \(rootRecordID.zoneID.zoneName, privacy: .public)")
+        AppLogger.shared.log(.info, category: "CloudKitSync", "[4/5] ensureMembership — creating caregiver membership for zone: \(rootRecordID.zoneID.zoneName)")
         let membership = Membership(
             childID: childID,
             userID: localUser.id,
@@ -742,6 +780,7 @@ public final class CloudKitSyncEngine {
         try userIdentityRepository.saveUser(localUser)
         try membershipRepository.saveCloudKitMembership(membership)
         logger.info("[4/5] ensureMembership — saved local membership id=\(membership.id, privacy: .public), marking upToDate immediately (received from CloudKit, not a local write)")
+        AppLogger.shared.log(.info, category: "CloudKitSync", "[4/5] ensureMembership — saved local membership id=\(membership.id), marking upToDate immediately")
         try syncStateRepository.updateSyncState(
             for: SyncRecordReference(
                 recordType: .membership,
@@ -760,6 +799,7 @@ public final class CloudKitSyncEngine {
         )
         try childRepository.saveCloudKitChildContext(context)
         logger.info("[4/5] ensureMembership — membership and CloudKit context saved")
+        AppLogger.shared.log(.info, category: "CloudKitSync", "[4/5] ensureMembership — membership and CloudKit context saved")
     }
 
     private func cachePendingInvites(

--- a/Packages/BabyTrackerSync/Sources/BabyTrackerSync/ShareAcceptanceHandler.swift
+++ b/Packages/BabyTrackerSync/Sources/BabyTrackerSync/ShareAcceptanceHandler.swift
@@ -1,3 +1,4 @@
+import BabyTrackerDomain
 import CloudKit
 import Foundation
 import os
@@ -19,17 +20,21 @@ public final class ShareAcceptanceHandler {
     public func accept(metadata: CKShare.Metadata) {
         print("[BabyTracker][3/5] ShareAcceptanceHandler.accept called")
         logger.info("[3/5] ShareAcceptanceHandler queuing accept task")
+        AppLogger.shared.log(.info, category: "ShareAcceptance", "[3/5] ShareAcceptanceHandler queuing accept task")
         Task { @MainActor in
             print("[BabyTracker][3/5] ShareAcceptanceHandler task running — calling sync engine")
             logger.info("[3/5] ShareAcceptanceHandler task started — calling sync engine")
+            AppLogger.shared.log(.info, category: "ShareAcceptance", "[3/5] ShareAcceptanceHandler task started — calling sync engine")
             do {
                 try await syncEngine.accept(metadata: metadata)
                 print("[BabyTracker][3/5] Sync engine accept returned — calling onAcceptedShare callback")
                 logger.info("[3/5] Sync engine accept returned — calling onAcceptedShare callback")
+                AppLogger.shared.log(.info, category: "ShareAcceptance", "[3/5] Sync engine accept returned — calling onAcceptedShare callback")
                 onAcceptedShare()
             } catch {
                 print("[BabyTracker][3/5] Sync engine accept FAILED: \(error)")
                 logger.error("[3/5] Sync engine accept failed: \(error.localizedDescription, privacy: .public)")
+                AppLogger.shared.log(.error, category: "ShareAcceptance", "[3/5] Sync engine accept failed: \(error.localizedDescription)")
                 onAcceptedShare()
             }
         }


### PR DESCRIPTION
## Summary

- **AppLogger** — new `@MainActor @Observable` singleton in `BabyTrackerDomain` that stores up to 2,000 `LogEntry` values (level, category, timestamp, message), accessible from every package with no new dependency edges
- **LoggingView** — new screen in `BabyTrackerFeature` showing a reverse-chronological, filterable list of log entries with a level filter menu, full-text search, copy-visible and export-all-as-file toolbar actions, and a clear button
- **Dual-write** — all existing `os.Logger` and `print()` calls in `CloudKitSyncEngine`, `ShareAcceptanceHandler`, `CloudKitShareAcceptanceBridge`, `CloudKitShareAppDelegate`, `CloudKitShareSceneDelegate`, and `AppModel` now also write to `AppLogger`; existing console output is unchanged
- **Profile entry** — new "Logs" `NavigationLink` row added to `ChildProfileView` (Profile tab)

## Test plan

- [ ] Build succeeds for all targets (BabyTrackerDomain, BabyTrackerSync, BabyTrackerFeature, main app)
- [ ] Profile tab shows a "Logs" row below iCloud Sync
- [ ] Tapping "Logs" navigates to the logging screen
- [ ] Log entries appear after triggering a CloudKit sync (launch, foreground, local write)
- [ ] Level filter menu correctly narrows results to the selected level
- [ ] Search bar filters entries by message text and category
- [ ] "Copy Visible" places the currently filtered entries on the clipboard
- [ ] "Export All as File" opens the share sheet with a formatted `.txt` payload
- [ ] "Clear Logs" empties the list
- [ ] Existing console logging (Xcode console / OSLog) is unaffected

https://claude.ai/code/session_012SmvSExEAGJAEg1Pja4KMj