### PR TITLE
Add hard-delete all data flow (UI, cloud cleanup, local reset)

### DIFF
--- a/Packages/BabyTrackerDomain/Sources/BabyTrackerDomain/Repositories/UserIdentityRepository.swift
+++ b/Packages/BabyTrackerDomain/Sources/BabyTrackerDomain/Repositories/UserIdentityRepository.swift
@@ -8,4 +8,5 @@ public protocol UserIdentityRepository: AnyObject {
     func loadUsers(for userIDs: [UUID]) throws -> [UserIdentity]
     func saveUser(_ user: UserIdentity) throws
     func removeLegacyPlaceholderCaregivers() throws
+    func resetAllData() throws
 }

--- a/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/AppModel.swift
+++ b/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/AppModel.swift
@@ -84,6 +84,32 @@ public final class AppModel {
         }
     }
 
+    public func hardDeleteAllData() {
+        Task { @MainActor in
+            var cloudDeleteError: Error?
+
+            do {
+                try await syncEngine.hardDeleteAllCloudData()
+            } catch {
+                cloudDeleteError = error
+                AppLogger.shared.log(.error, category: "CloudKitSync", "Hard delete cloud cleanup failed: \(error.localizedDescription)")
+            }
+
+            do {
+                try userIdentityRepository.resetAllData()
+                childSelectionStore.saveSelectedChildID(nil)
+                clearUndoDeleteState()
+                refresh(selecting: nil)
+                if let cloudDeleteError {
+                    errorMessage = "Local data was cleared, but iCloud cleanup failed: \(cloudDeleteError.localizedDescription)"
+                }
+            } catch {
+                errorMessage = resolveErrorMessage(for: error)
+                refresh(selecting: nil)
+            }
+        }
+    }
+
     public func createLocalUser(displayName: String) {
         perform {
             _ = try CreateLocalUserUseCase(userIdentityRepository: userIdentityRepository)

--- a/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/ChildProfileHardDeleteView.swift
+++ b/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/ChildProfileHardDeleteView.swift
@@ -1,0 +1,41 @@
+import SwiftUI
+
+public struct ChildProfileHardDeleteView: View {
+    let hardDeleteAction: () -> Void
+
+    @State private var showingConfirmation = false
+
+    public init(hardDeleteAction: @escaping () -> Void) {
+        self.hardDeleteAction = hardDeleteAction
+    }
+
+    public var body: some View {
+        List {
+            Section {
+                Text("This permanently removes local records on this device and attempts to remove synced iCloud records for your children.")
+                    .foregroundStyle(.secondary)
+
+                Text("Use this only if you want to start over. This cannot be undone.")
+                    .foregroundStyle(.secondary)
+            }
+
+            Section {
+                Button("Delete All Data", role: .destructive) {
+                    showingConfirmation = true
+                }
+                .accessibilityIdentifier("hard-delete-all-data-button")
+            }
+        }
+        .navigationTitle("Hard Delete")
+        .navigationBarTitleDisplayMode(.inline)
+        .listStyle(.insetGrouped)
+        .alert("Delete all data?", isPresented: $showingConfirmation) {
+            Button("Cancel", role: .cancel) {}
+            Button("Delete Everything", role: .destructive) {
+                hardDeleteAction()
+            }
+        } message: {
+            Text("This will remove all profile, membership, and event records and cannot be undone.")
+        }
+    }
+}

--- a/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/ChildProfileView.swift
+++ b/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/ChildProfileView.swift
@@ -7,19 +7,22 @@ public struct ChildProfileView: View {
     let editChildAction: () -> Void
     let shareChildAction: () -> Void
     let archiveAction: () -> Void
+    let hardDeleteAction: () -> Void
 
     public init(
         model: AppModel,
         profile: ChildProfileScreenState,
         editChildAction: @escaping () -> Void,
         shareChildAction: @escaping () -> Void,
-        archiveAction: @escaping () -> Void
+        archiveAction: @escaping () -> Void,
+        hardDeleteAction: @escaping () -> Void
     ) {
         self.model = model
         self.profile = profile
         self.editChildAction = editChildAction
         self.shareChildAction = shareChildAction
         self.archiveAction = archiveAction
+        self.hardDeleteAction = hardDeleteAction
     }
 
     public var body: some View {
@@ -104,6 +107,21 @@ public struct ChildProfileView: View {
                             titleColor: .red
                         )
                     }
+                }
+            }
+
+            Section {
+                NavigationLink {
+                    ChildProfileHardDeleteView(
+                        hardDeleteAction: hardDeleteAction
+                    )
+                } label: {
+                    settingsRow(
+                        title: "Hard Delete",
+                        value: nil,
+                        accessibilityIdentifier: "profile-hard-delete-row",
+                        titleColor: .red
+                    )
                 }
             }
         }

--- a/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/ChildWorkspaceTabView.swift
+++ b/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/ChildWorkspaceTabView.swift
@@ -68,7 +68,8 @@ public struct ChildWorkspaceTabView: View {
                 profile: profile,
                 editChildAction: { showingEditChildSheet = true },
                 shareChildAction: { model.presentShareSheet() },
-                archiveAction: { model.archiveCurrentChild() }
+                archiveAction: { model.archiveCurrentChild() },
+                hardDeleteAction: { model.hardDeleteAllData() }
             )
             .tag(Tab.profile)
             .tabItem {

--- a/Packages/BabyTrackerPersistence/Sources/BabyTrackerPersistence/SwiftDataUserIdentityRepository.swift
+++ b/Packages/BabyTrackerPersistence/Sources/BabyTrackerPersistence/SwiftDataUserIdentityRepository.swift
@@ -127,8 +127,7 @@ public final class SwiftDataUserIdentityRepository: CloudKitUserIdentityReposito
     }
 
     /// Resets all stored data across all entity types and clears user defaults.
-    /// Intended for development seeding and test setup only.
-    public func resetAllData(clearingUserDefaults additionalUserDefaults: UserDefaults? = nil) throws {
+    public func resetAllData() throws {
         try deleteAll(StoredMembership.self)
         try deleteAll(StoredChild.self)
         try deleteAll(StoredUserIdentity.self)

--- a/Packages/BabyTrackerSync/Sources/BabyTrackerSync/CloudKitSyncEngine.swift
+++ b/Packages/BabyTrackerSync/Sources/BabyTrackerSync/CloudKitSyncEngine.swift
@@ -186,6 +186,46 @@ public final class CloudKitSyncEngine {
         AppLogger.shared.log(.info, category: "CloudKitSync", "Left shared zone for child \(childID)")
     }
 
+    public func hardDeleteAllCloudData() async throws {
+        let children = try childRepository.loadAllChildren()
+        var privateZoneIDs = Set<CKRecordZone.ID>()
+        var sharedZoneIDs = Set<CKRecordZone.ID>()
+
+        for child in children {
+            if let context = try childRepository.loadCloudKitChildContext(id: child.id) {
+                if context.databaseScope == .shared {
+                    sharedZoneIDs.insert(context.zoneID)
+                } else {
+                    privateZoneIDs.insert(context.zoneID)
+                }
+            } else {
+                // If context is missing locally, still attempt to remove the
+                // default zone for this child from the private database.
+                privateZoneIDs.insert(CloudKitRecordNames.zoneID(for: child.id))
+            }
+        }
+
+        if !privateZoneIDs.isEmpty {
+            try await client.modifyRecordZones(
+                saving: [],
+                deleting: Array(privateZoneIDs),
+                databaseScope: .private
+            )
+        }
+
+        if !sharedZoneIDs.isEmpty {
+            try await client.modifyRecordZones(
+                saving: [],
+                deleting: Array(sharedZoneIDs),
+                databaseScope: .shared
+            )
+        }
+
+        pendingInvitesByChildID.removeAll()
+        logger.info("Hard delete removed \(privateZoneIDs.count, privacy: .public) private zone(s) and \(sharedZoneIDs.count, privacy: .public) shared zone(s)")
+        AppLogger.shared.log(.warning, category: "CloudKitSync", "Hard delete removed \(privateZoneIDs.count) private zone(s) and \(sharedZoneIDs.count) shared zone(s)")
+    }
+
     public func accept(metadata: CKShare.Metadata) async throws {
         let shareTitle = metadata.share[CKShare.SystemFieldKey.title] as? String ?? "unknown"
         let zoneName = metadata.share.recordID.zoneID.zoneName


### PR DESCRIPTION
### Motivation

- Provide a single "hard delete" action to permanently remove all local app data and attempt to remove any synced iCloud data so a user can start over.

### Description

- Add `resetAllData()` to the `UserIdentityRepository` protocol and implement it in `SwiftDataUserIdentityRepository` to delete all stored entities and clear the local user default key `DefaultsKey.localUserID`.
- Add `CloudKitSyncEngine.hardDeleteAllCloudData()` to enumerate children, collect private and shared CloudKit zone IDs, call `client.modifyRecordZones` to delete those zones, clear pending invites, and emit log messages.
- Add `AppModel.hardDeleteAllData()` which runs `hardDeleteAllCloudData()`, calls `userIdentityRepository.resetAllData()`, clears selected child and undo-delete state, refreshes UI state, and surfaces errors when cloud cleanup fails or reset fails.
- Add a user-facing UI: new `ChildProfileHardDeleteView`, a "Hard Delete" row in `ChildProfileView`, and wiring in `ChildWorkspaceTabView` to call `model.hardDeleteAllData()`; added an accessibility identifier `hard-delete-all-data-button` for the destructive action.

### Testing

- Ran a local build with `swift build` which completed successfully.
- Ran the test suite with `swift test` and all tests passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c4f40bb784832f8f24e6e253b283c2)