### PR TITLE
Add child profile image support (closes #12)

### DIFF
--- a/Packages/BabyTrackerDomain/Sources/BabyTrackerDomain/Child.swift
+++ b/Packages/BabyTrackerDomain/Sources/BabyTrackerDomain/Child.swift
@@ -7,6 +7,7 @@ public struct Child: Equatable, Identifiable, Sendable {
     public let createdAt: Date
     public let createdBy: UUID
     public var isArchived: Bool
+    public var imageData: Data?
 
     public init(
         id: UUID = UUID(),
@@ -14,7 +15,8 @@ public struct Child: Equatable, Identifiable, Sendable {
         birthDate: Date? = nil,
         createdAt: Date = Date(),
         createdBy: UUID,
-        isArchived: Bool = false
+        isArchived: Bool = false,
+        imageData: Data? = nil
     ) throws {
         let normalizedName = name.trimmedForProfileField()
         guard !normalizedName.isEmpty else {
@@ -27,11 +29,13 @@ public struct Child: Equatable, Identifiable, Sendable {
         self.createdAt = createdAt
         self.createdBy = createdBy
         self.isArchived = isArchived
+        self.imageData = imageData
     }
 
     public func updating(
         name: String,
-        birthDate: Date?
+        birthDate: Date?,
+        imageData: Data? = nil
     ) throws -> Child {
         try Child(
             id: id,
@@ -39,7 +43,8 @@ public struct Child: Equatable, Identifiable, Sendable {
             birthDate: birthDate,
             createdAt: createdAt,
             createdBy: createdBy,
-            isArchived: isArchived
+            isArchived: isArchived,
+            imageData: imageData
         )
     }
 }

--- a/Packages/BabyTrackerDomain/Sources/BabyTrackerDomain/UseCases/CreateChildUseCase.swift
+++ b/Packages/BabyTrackerDomain/Sources/BabyTrackerDomain/UseCases/CreateChildUseCase.swift
@@ -6,11 +6,13 @@ public struct CreateChildUseCase: UseCase {
         public let name: String
         public let birthDate: Date?
         public let localUser: UserIdentity
+        public let imageData: Data?
 
-        public init(name: String, birthDate: Date?, localUser: UserIdentity) {
+        public init(name: String, birthDate: Date?, localUser: UserIdentity, imageData: Data? = nil) {
             self.name = name
             self.birthDate = birthDate
             self.localUser = localUser
+            self.imageData = imageData
         }
     }
 
@@ -32,7 +34,8 @@ public struct CreateChildUseCase: UseCase {
         let child = try Child(
             name: input.name,
             birthDate: input.birthDate,
-            createdBy: input.localUser.id
+            createdBy: input.localUser.id,
+            imageData: input.imageData
         )
         let ownerMembership = Membership.owner(
             childID: child.id,

--- a/Packages/BabyTrackerDomain/Sources/BabyTrackerDomain/UseCases/UpdateCurrentChildUseCase.swift
+++ b/Packages/BabyTrackerDomain/Sources/BabyTrackerDomain/UseCases/UpdateCurrentChildUseCase.swift
@@ -7,12 +7,14 @@ public struct UpdateCurrentChildUseCase: UseCase {
         public let name: String
         public let birthDate: Date?
         public let membership: Membership
+        public let imageData: Data?
 
-        public init(child: Child, name: String, birthDate: Date?, membership: Membership) {
+        public init(child: Child, name: String, birthDate: Date?, membership: Membership, imageData: Data? = nil) {
             self.child = child
             self.name = name
             self.birthDate = birthDate
             self.membership = membership
+            self.imageData = imageData
         }
     }
 
@@ -27,7 +29,7 @@ public struct UpdateCurrentChildUseCase: UseCase {
             throw ChildProfileValidationError.insufficientPermissions
         }
 
-        let updatedChild = try input.child.updating(name: input.name, birthDate: input.birthDate)
+        let updatedChild = try input.child.updating(name: input.name, birthDate: input.birthDate, imageData: input.imageData)
         try childRepository.saveChild(updatedChild)
         return updatedChild
     }

--- a/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/AppModel.swift
+++ b/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/AppModel.swift
@@ -117,18 +117,18 @@ public final class AppModel {
         }
     }
 
-    public func createChild(name: String, birthDate: Date?) {
+    public func createChild(name: String, birthDate: Date?, imageData: Data? = nil) {
         perform {
             guard let localUser else { return }
             _ = try CreateChildUseCase(
                 childRepository: childRepository,
                 membershipRepository: membershipRepository,
                 childSelectionStore: childSelectionStore
-            ).execute(.init(name: name, birthDate: birthDate, localUser: localUser))
+            ).execute(.init(name: name, birthDate: birthDate, localUser: localUser, imageData: imageData))
         }
     }
 
-    public func updateCurrentChild(name: String, birthDate: Date?) {
+    public func updateCurrentChild(name: String, birthDate: Date?, imageData: Data? = nil) {
         perform {
             guard let profile else { return }
             _ = try UpdateCurrentChildUseCase(childRepository: childRepository)
@@ -136,7 +136,8 @@ public final class AppModel {
                     child: profile.child,
                     name: name,
                     birthDate: birthDate,
-                    membership: profile.currentMembership
+                    membership: profile.currentMembership,
+                    imageData: imageData
                 ))
         }
     }

--- a/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/ImageCompressor.swift
+++ b/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/ImageCompressor.swift
@@ -1,0 +1,15 @@
+import UIKit
+
+enum ImageCompressor {
+    static func compress(_ image: UIImage, maxDimension: CGFloat = 400, quality: CGFloat = 0.7) -> Data? {
+        let scale = min(maxDimension / image.size.width, maxDimension / image.size.height, 1.0)
+        let newSize = CGSize(width: image.size.width * scale, height: image.size.height * scale)
+
+        let renderer = UIGraphicsImageRenderer(size: newSize)
+        let resized = renderer.image { _ in
+            image.draw(in: CGRect(origin: .zero, size: newSize))
+        }
+
+        return resized.jpegData(compressionQuality: quality)
+    }
+}

--- a/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/ChildCreationView.swift
+++ b/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/ChildCreationView.swift
@@ -1,4 +1,5 @@
 import BabyTrackerDomain
+import PhotosUI
 import SwiftUI
 
 public struct ChildCreationView: View {
@@ -11,12 +12,33 @@ public struct ChildCreationView: View {
     @State private var childName = ""
     @State private var includesBirthDate = false
     @State private var birthDate = Date()
+    @State private var selectedItem: PhotosPickerItem?
+    @State private var selectedImageData: Data?
 
     public var body: some View {
         Form {
             Section {
                 Text("Create the first child profile. You can add a birth date now or leave it for later.")
                     .foregroundStyle(.secondary)
+            }
+
+            Section {
+                HStack {
+                    Spacer()
+                    PhotosPicker(selection: $selectedItem, matching: .images) {
+                        profileImageView
+                            .overlay(alignment: .bottomTrailing) {
+                                Image(systemName: "pencil.circle.fill")
+                                    .font(.title3)
+                                    .symbolRenderingMode(.palette)
+                                    .foregroundStyle(.white, Color.accentColor)
+                                    .offset(x: 4, y: 4)
+                            }
+                    }
+                    .buttonStyle(.plain)
+                    Spacer()
+                }
+                .listRowBackground(Color.clear)
             }
 
             Section("Child") {
@@ -36,7 +58,8 @@ public struct ChildCreationView: View {
                 Button("Create Child Profile") {
                     model.createChild(
                         name: childName,
-                        birthDate: includesBirthDate ? birthDate : nil
+                        birthDate: includesBirthDate ? birthDate : nil,
+                        imageData: selectedImageData
                     )
                 }
                 .buttonStyle(.borderedProminent)
@@ -56,5 +79,33 @@ public struct ChildCreationView: View {
         }
         .navigationTitle("Add a Child")
         .navigationBarTitleDisplayMode(.inline)
+        .onChange(of: selectedItem) { _, newItem in
+            Task {
+                guard let data = try? await newItem?.loadTransferable(type: Data.self),
+                      let uiImage = UIImage(data: data),
+                      let compressed = ImageCompressor.compress(uiImage) else { return }
+                selectedImageData = compressed
+            }
+        }
+    }
+
+    @ViewBuilder
+    private var profileImageView: some View {
+        if let imageData = selectedImageData, let uiImage = UIImage(data: imageData) {
+            Image(uiImage: uiImage)
+                .resizable()
+                .scaledToFill()
+                .frame(width: 88, height: 88)
+                .clipShape(Circle())
+        } else {
+            ZStack {
+                Circle()
+                    .fill(Color.accentColor.opacity(0.15))
+                    .frame(width: 88, height: 88)
+                Image(systemName: "camera.fill")
+                    .font(.title2)
+                    .foregroundStyle(Color.accentColor)
+            }
+        }
     }
 }

--- a/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/ChildEditSheetView.swift
+++ b/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/ChildEditSheetView.swift
@@ -1,28 +1,53 @@
+import PhotosUI
 import SwiftUI
 
 public struct ChildEditSheetView: View {
     let initialName: String
     let initialBirthDate: Date?
-    let saveAction: (_ name: String, _ birthDate: Date?) -> Void
+    let initialImageData: Data?
+    let saveAction: (_ name: String, _ birthDate: Date?, _ imageData: Data?) -> Void
 
     @Environment(\.dismiss) private var dismiss
     @State private var name = ""
     @State private var includesBirthDate = false
     @State private var birthDate = Date()
+    @State private var selectedItem: PhotosPickerItem?
+    @State private var selectedImageData: Data?
 
     public init(
         initialName: String,
         initialBirthDate: Date?,
-        saveAction: @escaping (_ name: String, _ birthDate: Date?) -> Void
+        initialImageData: Data? = nil,
+        saveAction: @escaping (_ name: String, _ birthDate: Date?, _ imageData: Data?) -> Void
     ) {
         self.initialName = initialName
         self.initialBirthDate = initialBirthDate
+        self.initialImageData = initialImageData
         self.saveAction = saveAction
     }
 
     public var body: some View {
         NavigationStack {
             Form {
+                Section {
+                    HStack {
+                        Spacer()
+                        PhotosPicker(selection: $selectedItem, matching: .images) {
+                            profileImageView
+                                .overlay(alignment: .bottomTrailing) {
+                                    Image(systemName: "pencil.circle.fill")
+                                        .font(.title3)
+                                        .symbolRenderingMode(.palette)
+                                        .foregroundStyle(.white, Color.accentColor)
+                                        .offset(x: 4, y: 4)
+                                }
+                        }
+                        .buttonStyle(.plain)
+                        Spacer()
+                    }
+                    .listRowBackground(Color.clear)
+                }
+
                 Section("Child") {
                     TextField("Child name", text: $name)
                         .textInputAutocapitalization(.words)
@@ -46,7 +71,7 @@ public struct ChildEditSheetView: View {
 
                 ToolbarItem(placement: .confirmationAction) {
                     Button("Save") {
-                        saveAction(name, includesBirthDate ? birthDate : nil)
+                        saveAction(name, includesBirthDate ? birthDate : nil, selectedImageData)
                         dismiss()
                     }
                     .accessibilityIdentifier("save-child-edit-button")
@@ -54,10 +79,39 @@ public struct ChildEditSheetView: View {
             }
             .onAppear {
                 name = initialName
+                selectedImageData = initialImageData
                 if let initialBirthDate {
                     includesBirthDate = true
                     birthDate = initialBirthDate
                 }
+            }
+            .onChange(of: selectedItem) { _, newItem in
+                Task {
+                    guard let data = try? await newItem?.loadTransferable(type: Data.self),
+                          let uiImage = UIImage(data: data),
+                          let compressed = ImageCompressor.compress(uiImage) else { return }
+                    selectedImageData = compressed
+                }
+            }
+        }
+    }
+
+    @ViewBuilder
+    private var profileImageView: some View {
+        if let imageData = selectedImageData, let uiImage = UIImage(data: imageData) {
+            Image(uiImage: uiImage)
+                .resizable()
+                .scaledToFill()
+                .frame(width: 88, height: 88)
+                .clipShape(Circle())
+        } else {
+            ZStack {
+                Circle()
+                    .fill(Color.accentColor.opacity(0.15))
+                    .frame(width: 88, height: 88)
+                Image(systemName: "camera.fill")
+                    .font(.title2)
+                    .foregroundStyle(Color.accentColor)
             }
         }
     }

--- a/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/ChildPickerView.swift
+++ b/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/ChildPickerView.swift
@@ -1,5 +1,6 @@
 import BabyTrackerDomain
 import SwiftUI
+import UIKit
 
 public struct ChildPickerView: View {
     let model: AppModel
@@ -36,15 +37,8 @@ public struct ChildPickerView: View {
             model.selectChild(id: summary.child.id)
         } label: {
             HStack(spacing: 16) {
-                ZStack {
-                    Circle()
-                        .fill(Color.accentColor.opacity(0.15))
-                        .frame(width: 52, height: 52)
-                    Text(summary.child.name.prefix(1).uppercased())
-                        .font(.title2.weight(.semibold))
-                        .foregroundStyle(Color.accentColor)
-                }
-                .accessibilityHidden(true)
+                childAvatar(for: summary.child)
+                    .accessibilityHidden(true)
 
                 VStack(alignment: .leading, spacing: 4) {
                     Text(summary.child.name)
@@ -75,6 +69,26 @@ public struct ChildPickerView: View {
         }
         .buttonStyle(.plain)
         .accessibilityIdentifier("child-picker-\(summary.child.id.uuidString)")
+    }
+
+    @ViewBuilder
+    private func childAvatar(for child: Child) -> some View {
+        if let imageData = child.imageData, let uiImage = UIImage(data: imageData) {
+            Image(uiImage: uiImage)
+                .resizable()
+                .scaledToFill()
+                .frame(width: 52, height: 52)
+                .clipShape(Circle())
+        } else {
+            ZStack {
+                Circle()
+                    .fill(Color.accentColor.opacity(0.15))
+                    .frame(width: 52, height: 52)
+                Text(child.name.prefix(1).uppercased())
+                    .font(.title2.weight(.semibold))
+                    .foregroundStyle(Color.accentColor)
+            }
+        }
     }
 
     @ViewBuilder

--- a/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/ChildProfileDetailsView.swift
+++ b/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/ChildProfileDetailsView.swift
@@ -1,5 +1,6 @@
 import BabyTrackerDomain
 import SwiftUI
+import UIKit
 
 public struct ChildProfileDetailsView: View {
     let profile: ChildProfileScreenState
@@ -15,6 +16,15 @@ public struct ChildProfileDetailsView: View {
 
     public var body: some View {
         List {
+            Section {
+                HStack {
+                    Spacer()
+                    profileImageView
+                    Spacer()
+                }
+                .listRowBackground(Color.clear)
+            }
+
             Section("Child") {
                 LabeledContent("Name") {
                     Text(profile.child.name)
@@ -42,6 +52,26 @@ public struct ChildProfileDetailsView: View {
                     }
                     .accessibilityIdentifier("edit-child-button")
                 }
+            }
+        }
+    }
+
+    @ViewBuilder
+    private var profileImageView: some View {
+        if let imageData = profile.child.imageData, let uiImage = UIImage(data: imageData) {
+            Image(uiImage: uiImage)
+                .resizable()
+                .scaledToFill()
+                .frame(width: 88, height: 88)
+                .clipShape(Circle())
+        } else {
+            ZStack {
+                Circle()
+                    .fill(Color.accentColor.opacity(0.15))
+                    .frame(width: 88, height: 88)
+                Text(profile.child.name.prefix(1).uppercased())
+                    .font(.largeTitle.weight(.semibold))
+                    .foregroundStyle(Color.accentColor)
             }
         }
     }

--- a/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/ChildWorkspaceTabView.swift
+++ b/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/ChildWorkspaceTabView.swift
@@ -87,7 +87,10 @@ public struct ChildWorkspaceTabView: View {
             ChildEditSheetView(
                 initialName: profile.child.name,
                 initialBirthDate: profile.child.birthDate,
-                saveAction: model.updateCurrentChild(name:birthDate:)
+                initialImageData: profile.child.imageData,
+                saveAction: { name, birthDate, imageData in
+                    model.updateCurrentChild(name: name, birthDate: birthDate, imageData: imageData)
+                }
             )
         }
         .sheet(item: $bindableModel.shareSheetState) { shareState in

--- a/Packages/BabyTrackerPersistence/Sources/BabyTrackerPersistence/Models/StoredChild.swift
+++ b/Packages/BabyTrackerPersistence/Sources/BabyTrackerPersistence/Models/StoredChild.swift
@@ -9,6 +9,7 @@ final class StoredChild {
     var createdAt: Date = Date()
     var createdBy: UUID = UUID()
     var isArchived: Bool = false
+    var imageData: Data?
     var cloudKitZoneName: String?
     var cloudKitZoneOwnerName: String?
     var cloudKitShareRecordName: String?
@@ -24,6 +25,7 @@ final class StoredChild {
         createdAt: Date,
         createdBy: UUID,
         isArchived: Bool,
+        imageData: Data? = nil,
         cloudKitZoneName: String? = nil,
         cloudKitZoneOwnerName: String? = nil,
         cloudKitShareRecordName: String? = nil,
@@ -38,6 +40,7 @@ final class StoredChild {
         self.createdAt = createdAt
         self.createdBy = createdBy
         self.isArchived = isArchived
+        self.imageData = imageData
         self.cloudKitZoneName = cloudKitZoneName
         self.cloudKitZoneOwnerName = cloudKitZoneOwnerName
         self.cloudKitShareRecordName = cloudKitShareRecordName

--- a/Packages/BabyTrackerPersistence/Sources/BabyTrackerPersistence/SwiftDataChildRepository.swift
+++ b/Packages/BabyTrackerPersistence/Sources/BabyTrackerPersistence/SwiftDataChildRepository.swift
@@ -49,6 +49,7 @@ public final class SwiftDataChildRepository: CloudKitChildRepository {
         storedChild.createdAt = child.createdAt
         storedChild.createdBy = child.createdBy
         storedChild.isArchived = child.isArchived
+        storedChild.imageData = child.imageData
         markPendingSync(storedChild, errorCode: nil)
 
         if existingStoredChild == nil {
@@ -150,7 +151,8 @@ public final class SwiftDataChildRepository: CloudKitChildRepository {
             birthDate: storedChild.birthDate,
             createdAt: storedChild.createdAt,
             createdBy: storedChild.createdBy,
-            isArchived: storedChild.isArchived
+            isArchived: storedChild.isArchived,
+            imageData: storedChild.imageData
         )
     }
 

--- a/Packages/BabyTrackerSync/Sources/BabyTrackerSync/CloudKitRecordMapper.swift
+++ b/Packages/BabyTrackerSync/Sources/BabyTrackerSync/CloudKitRecordMapper.swift
@@ -19,6 +19,14 @@ public enum CloudKitRecordMapper {
         record["createdAt"] = child.createdAt
         record["createdBy"] = child.createdBy.uuidString
         record["isArchived"] = child.isArchived
+        if let imageData = child.imageData {
+            let tempURL = FileManager.default.temporaryDirectory
+                .appendingPathComponent("child-image-\(child.id.uuidString).jpg")
+            try? imageData.write(to: tempURL)
+            record["imageAsset"] = CKAsset(fileURL: tempURL)
+        } else {
+            record["imageAsset"] = nil
+        }
         return record
     }
 
@@ -76,13 +84,19 @@ public enum CloudKitRecordMapper {
     }
 
     static func child(from record: CKRecord) throws -> Child {
-        try Child(
+        var imageData: Data?
+        if let asset = record["imageAsset"] as? CKAsset,
+           let url = asset.fileURL {
+            imageData = try? Data(contentsOf: url)
+        }
+        return try Child(
             id: extractUUID(prefix: "child.", from: record.recordID.recordName),
             name: record["name"] as? String ?? "",
             birthDate: record["birthDate"] as? Date,
             createdAt: record["createdAt"] as? Date ?? .now,
             createdBy: UUID(uuidString: record["createdBy"] as? String ?? "") ?? UUID(),
-            isArchived: record["isArchived"] as? Bool ?? false
+            isArchived: record["isArchived"] as? Bool ?? false,
+            imageData: imageData
         )
     }
 


### PR DESCRIPTION
- Add `imageData: Data?` to `Child` domain model, `StoredChild`, `CreateChildUseCase`, and `UpdateCurrentChildUseCase`
- Sync profile photos via CloudKit using `CKAsset` (encode on write, decode on read)
- Add `ImageCompressor` helper to resize/JPEG-compress picked photos before saving
- Add `PhotosPicker` to `ChildCreationView` and `ChildEditSheetView` so users can set a photo when creating or editing a child profile
- Display the photo (or initials fallback) in `ChildPickerView` and `ChildProfileDetailsView`

https://claude.ai/code/session_01KdUBWprB9FcCdx3EYdrH33