### PR TITLE
Add Summary tab with metrics calculator, UI, and tests

### DIFF
--- a/Baby TrackerTests/SummaryMetricsCalculatorTests.swift
+++ b/Baby TrackerTests/SummaryMetricsCalculatorTests.swift
@@ -1,0 +1,162 @@
+import BabyTrackerDomain
+import BabyTrackerFeature
+import Foundation
+import Testing
+
+struct SummaryMetricsCalculatorTests {
+    @Test
+    func snapshotIncludesTopLevelAndInDepthMetrics() throws {
+        var calendar = Calendar(identifier: .gregorian)
+        calendar.timeZone = TimeZone(secondsFromGMT: 0)!
+
+        let childID = UUID()
+        let userID = UUID()
+        let now = try #require(calendar.date(from: DateComponents(year: 2026, month: 3, day: 26, hour: 12)))
+        let firstFeedEnd = try #require(calendar.date(from: DateComponents(year: 2026, month: 3, day: 26, hour: 7, minute: 30)))
+        let secondFeedEnd = try #require(calendar.date(from: DateComponents(year: 2026, month: 3, day: 26, hour: 10, minute: 0)))
+        let sleepStart = try #require(calendar.date(from: DateComponents(year: 2026, month: 3, day: 26, hour: 1, minute: 0)))
+        let sleepEnd = try #require(calendar.date(from: DateComponents(year: 2026, month: 3, day: 26, hour: 2, minute: 30)))
+        let wetNappyTime = try #require(calendar.date(from: DateComponents(year: 2026, month: 3, day: 26, hour: 9, minute: 15)))
+        let dirtyNappyTime = try #require(calendar.date(from: DateComponents(year: 2026, month: 3, day: 26, hour: 11, minute: 15)))
+
+        let events: [BabyEvent] = [
+            .breastFeed(
+                try BreastFeedEvent(
+                    metadata: EventMetadata(
+                        childID: childID,
+                        occurredAt: firstFeedEnd,
+                        createdAt: firstFeedEnd,
+                        createdBy: userID
+                    ),
+                    side: .left,
+                    startedAt: firstFeedEnd.addingTimeInterval(-900),
+                    endedAt: firstFeedEnd
+                )
+            ),
+            .bottleFeed(
+                try BottleFeedEvent(
+                    metadata: EventMetadata(
+                        childID: childID,
+                        occurredAt: secondFeedEnd,
+                        createdAt: secondFeedEnd,
+                        createdBy: userID
+                    ),
+                    amountMilliliters: 120
+                )
+            ),
+            .sleep(
+                try SleepEvent(
+                    metadata: EventMetadata(
+                        childID: childID,
+                        occurredAt: sleepEnd,
+                        createdAt: sleepEnd,
+                        createdBy: userID
+                    ),
+                    startedAt: sleepStart,
+                    endedAt: sleepEnd
+                )
+            ),
+            .nappy(
+                try NappyEvent(
+                    metadata: EventMetadata(
+                        childID: childID,
+                        occurredAt: wetNappyTime,
+                        createdAt: wetNappyTime,
+                        createdBy: userID
+                    ),
+                    type: .wee,
+                    peeVolume: .medium
+                )
+            ),
+            .nappy(
+                try NappyEvent(
+                    metadata: EventMetadata(
+                        childID: childID,
+                        occurredAt: dirtyNappyTime,
+                        createdAt: dirtyNappyTime,
+                        createdBy: userID
+                    ),
+                    type: .poo,
+                    pooVolume: .light,
+                    pooColor: .yellow
+                )
+            ),
+        ]
+
+        let snapshot = SummaryMetricsCalculator.makeSnapshot(
+            from: events,
+            range: .today,
+            now: now,
+            calendar: calendar
+        )
+
+        #expect(snapshot.eventCount == 5)
+        #expect(snapshot.totalFeeds == 2)
+        #expect(snapshot.totalNappies == 2)
+        #expect(snapshot.totalSleepMinutes == 90)
+        #expect(snapshot.averageFeedDurationMinutes == 15)
+        #expect(snapshot.averageFeedIntervalMinutes == 150)
+        #expect(snapshot.averageSleepBlockMinutes == 90)
+        #expect(snapshot.shortestSleepBlockMinutes == 90)
+        #expect(snapshot.longestSleepBlockMinutes == 90)
+        #expect(snapshot.wetNappyCount == 1)
+        #expect(snapshot.dirtyNappyCount == 1)
+        #expect(snapshot.loggingStreakDays == 1)
+        #expect(snapshot.dailyEventCounts.count == 7)
+        #expect(snapshot.feedCountsByHour.count == 6)
+    }
+
+    @Test
+    func snapshotUsesRangeFilterForRecentPeriods() throws {
+        var calendar = Calendar(identifier: .gregorian)
+        calendar.timeZone = TimeZone(secondsFromGMT: 0)!
+
+        let childID = UUID()
+        let userID = UUID()
+        let now = try #require(calendar.date(from: DateComponents(year: 2026, month: 3, day: 26, hour: 12)))
+        let tenDaysAgo = try #require(calendar.date(byAdding: .day, value: -10, to: now))
+        let yesterday = try #require(calendar.date(byAdding: .day, value: -1, to: now))
+
+        let events: [BabyEvent] = [
+            .bottleFeed(
+                try BottleFeedEvent(
+                    metadata: EventMetadata(
+                        childID: childID,
+                        occurredAt: tenDaysAgo,
+                        createdAt: tenDaysAgo,
+                        createdBy: userID
+                    ),
+                    amountMilliliters: 110
+                )
+            ),
+            .bottleFeed(
+                try BottleFeedEvent(
+                    metadata: EventMetadata(
+                        childID: childID,
+                        occurredAt: yesterday,
+                        createdAt: yesterday,
+                        createdBy: userID
+                    ),
+                    amountMilliliters: 130
+                )
+            ),
+        ]
+
+        let sevenDaySnapshot = SummaryMetricsCalculator.makeSnapshot(
+            from: events,
+            range: .sevenDays,
+            now: now,
+            calendar: calendar
+        )
+
+        let allTimeSnapshot = SummaryMetricsCalculator.makeSnapshot(
+            from: events,
+            range: .allTime,
+            now: now,
+            calendar: calendar
+        )
+
+        #expect(sevenDaySnapshot.totalFeeds == 1)
+        #expect(allTimeSnapshot.totalFeeds == 2)
+    }
+}

--- a/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/AppModel.swift
+++ b/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/AppModel.swift
@@ -753,6 +753,7 @@ public final class AppModel {
                 selectedDay: timelineSelectedDay,
                 cloudKitStatus: cloudKitStatus
             ),
+            summary: makeSummaryScreenState(from: visibleEvents),
             cloudKitStatus: cloudKitStatus,
             canShareChild: ChildAccessPolicy.canPerform(.inviteCaregiver, membership: currentMembership) &&
                 syncEngine.statusSummary.state != .failed,
@@ -840,6 +841,17 @@ public final class AppModel {
             events: events.compactMap { EventCardViewState(event: $0) },
             emptyStateTitle: "No events logged yet",
             emptyStateMessage: "Use Quick Log on Home to add the first event."
+        )
+    }
+
+
+    private func makeSummaryScreenState(
+        from events: [BabyEvent]
+    ) -> SummaryScreenState {
+        SummaryScreenState(
+            events: events,
+            emptyStateTitle: "No summary data yet",
+            emptyStateMessage: "Add events and your key trends will appear here."
         )
     }
 

--- a/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/ChildProfileScreenState.swift
+++ b/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/ChildProfileScreenState.swift
@@ -16,6 +16,7 @@ public struct ChildProfileScreenState: Equatable, Sendable {
     public let home: HomeScreenState
     public let eventHistory: EventHistoryScreenState
     public let timeline: TimelineScreenState
+    public let summary: SummaryScreenState
     public let cloudKitStatus: CloudKitStatusViewState
     public let canShareChild: Bool
     public let pendingChanges: [PendingChangeSummaryItem]
@@ -51,6 +52,7 @@ public struct ChildProfileScreenState: Equatable, Sendable {
         home: HomeScreenState,
         eventHistory: EventHistoryScreenState,
         timeline: TimelineScreenState,
+        summary: SummaryScreenState,
         cloudKitStatus: CloudKitStatusViewState,
         canShareChild: Bool,
         pendingChanges: [PendingChangeSummaryItem] = []
@@ -69,6 +71,7 @@ public struct ChildProfileScreenState: Equatable, Sendable {
         self.home = home
         self.eventHistory = eventHistory
         self.timeline = timeline
+        self.summary = summary
         self.cloudKitStatus = cloudKitStatus
         self.canShareChild = canShareChild
         self.pendingChanges = pendingChanges

--- a/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/SummaryMetricsCalculator.swift
+++ b/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/SummaryMetricsCalculator.swift
@@ -1,0 +1,324 @@
+import BabyTrackerDomain
+import Foundation
+
+public enum SummaryTimeRange: String, CaseIterable, Identifiable, Sendable {
+    case today
+    case sevenDays
+    case thirtyDays
+    case allTime
+
+    public var id: String { rawValue }
+
+    public var title: String {
+        switch self {
+        case .today:
+            "Today"
+        case .sevenDays:
+            "7 Days"
+        case .thirtyDays:
+            "30 Days"
+        case .allTime:
+            "All Time"
+        }
+    }
+}
+
+public struct SummaryDayCount: Equatable, Sendable {
+    public let date: Date
+    public let label: String
+    public let count: Int
+
+    public init(date: Date, label: String, count: Int) {
+        self.date = date
+        self.label = label
+        self.count = count
+    }
+}
+
+public struct SummaryHourCount: Equatable, Sendable {
+    public let hour: Int
+    public let label: String
+    public let count: Int
+
+    public init(hour: Int, label: String, count: Int) {
+        self.hour = hour
+        self.label = label
+        self.count = count
+    }
+}
+
+public struct SummarySnapshot: Equatable, Sendable {
+    public let eventCount: Int
+    public let totalFeeds: Int
+    public let totalNappies: Int
+    public let totalSleepMinutes: Int
+    public let averageFeedDurationMinutes: Int?
+    public let loggingStreakDays: Int
+    public let averageFeedIntervalMinutes: Int?
+    public let averageSleepBlockMinutes: Int?
+    public let shortestSleepBlockMinutes: Int?
+    public let longestSleepBlockMinutes: Int?
+    public let wetNappyCount: Int
+    public let dirtyNappyCount: Int
+    public let mixedNappyCount: Int
+    public let dryNappyCount: Int
+    public let dailyEventCounts: [SummaryDayCount]
+    public let feedCountsByHour: [SummaryHourCount]
+
+    public init(
+        eventCount: Int,
+        totalFeeds: Int,
+        totalNappies: Int,
+        totalSleepMinutes: Int,
+        averageFeedDurationMinutes: Int?,
+        loggingStreakDays: Int,
+        averageFeedIntervalMinutes: Int?,
+        averageSleepBlockMinutes: Int?,
+        shortestSleepBlockMinutes: Int?,
+        longestSleepBlockMinutes: Int?,
+        wetNappyCount: Int,
+        dirtyNappyCount: Int,
+        mixedNappyCount: Int,
+        dryNappyCount: Int,
+        dailyEventCounts: [SummaryDayCount],
+        feedCountsByHour: [SummaryHourCount]
+    ) {
+        self.eventCount = eventCount
+        self.totalFeeds = totalFeeds
+        self.totalNappies = totalNappies
+        self.totalSleepMinutes = totalSleepMinutes
+        self.averageFeedDurationMinutes = averageFeedDurationMinutes
+        self.loggingStreakDays = loggingStreakDays
+        self.averageFeedIntervalMinutes = averageFeedIntervalMinutes
+        self.averageSleepBlockMinutes = averageSleepBlockMinutes
+        self.shortestSleepBlockMinutes = shortestSleepBlockMinutes
+        self.longestSleepBlockMinutes = longestSleepBlockMinutes
+        self.wetNappyCount = wetNappyCount
+        self.dirtyNappyCount = dirtyNappyCount
+        self.mixedNappyCount = mixedNappyCount
+        self.dryNappyCount = dryNappyCount
+        self.dailyEventCounts = dailyEventCounts
+        self.feedCountsByHour = feedCountsByHour
+    }
+}
+
+public enum SummaryMetricsCalculator {
+    public static func makeSnapshot(
+        from events: [BabyEvent],
+        range: SummaryTimeRange,
+        now: Date = .now,
+        calendar: Calendar = .autoupdatingCurrent
+    ) -> SummarySnapshot {
+        let sortedEvents = events.sorted { $0.metadata.occurredAt < $1.metadata.occurredAt }
+        let rangeEvents = filter(events: sortedEvents, range: range, now: now, calendar: calendar)
+
+        let feedEvents = rangeEvents.compactMap { event -> BabyEvent? in
+            switch event {
+            case .breastFeed, .bottleFeed:
+                event
+            case .sleep, .nappy:
+                nil
+            }
+        }
+
+        let nappyEvents = rangeEvents.compactMap { event -> NappyEvent? in
+            guard case let .nappy(nappy) = event else { return nil }
+            return nappy
+        }
+
+        let completedSleepEvents = rangeEvents.compactMap { event -> SleepEvent? in
+            guard case let .sleep(sleep) = event, sleep.endedAt != nil else { return nil }
+            return sleep
+        }
+
+        let feedDurations = feedEvents.compactMap { feedDurationMinutes(for: $0) }
+        let sleepDurations = completedSleepEvents.compactMap { sleepDurationMinutes(for: $0) }
+        let averageFeedDuration = average(of: feedDurations)
+        let averageSleepDuration = average(of: sleepDurations)
+        let shortestSleep = sleepDurations.min()
+        let longestSleep = sleepDurations.max()
+
+        let dailyCounts = makeDailyCounts(events: rangeEvents, now: now, calendar: calendar)
+        let hourlyFeedCounts = makeHourlyFeedCounts(events: feedEvents, now: now, calendar: calendar)
+
+        return SummarySnapshot(
+            eventCount: rangeEvents.count,
+            totalFeeds: feedEvents.count,
+            totalNappies: nappyEvents.count,
+            totalSleepMinutes: sleepDurations.reduce(0, +),
+            averageFeedDurationMinutes: averageFeedDuration,
+            loggingStreakDays: makeLoggingStreakDays(from: sortedEvents, now: now, calendar: calendar),
+            averageFeedIntervalMinutes: averageFeedIntervalMinutes(for: feedEvents),
+            averageSleepBlockMinutes: averageSleepDuration,
+            shortestSleepBlockMinutes: shortestSleep,
+            longestSleepBlockMinutes: longestSleep,
+            wetNappyCount: nappyEvents.filter { $0.type == .wee }.count,
+            dirtyNappyCount: nappyEvents.filter { $0.type == .poo }.count,
+            mixedNappyCount: nappyEvents.filter { $0.type == .mixed }.count,
+            dryNappyCount: nappyEvents.filter { $0.type == .dry }.count,
+            dailyEventCounts: dailyCounts,
+            feedCountsByHour: hourlyFeedCounts
+        )
+    }
+
+    private static func filter(
+        events: [BabyEvent],
+        range: SummaryTimeRange,
+        now: Date,
+        calendar: Calendar
+    ) -> [BabyEvent] {
+        switch range {
+        case .allTime:
+            events
+        case .today:
+            events.filter { calendar.isDate($0.metadata.occurredAt, inSameDayAs: now) }
+        case .sevenDays:
+            events.filter { isWithinDays($0.metadata.occurredAt, days: 7, now: now, calendar: calendar) }
+        case .thirtyDays:
+            events.filter { isWithinDays($0.metadata.occurredAt, days: 30, now: now, calendar: calendar) }
+        }
+    }
+
+    private static func isWithinDays(
+        _ date: Date,
+        days: Int,
+        now: Date,
+        calendar: Calendar
+    ) -> Bool {
+        guard let start = calendar.date(byAdding: .day, value: -(days - 1), to: calendar.startOfDay(for: now)) else {
+            return false
+        }
+
+        return date >= start && date <= now
+    }
+
+    private static func average(of values: [Int]) -> Int? {
+        guard !values.isEmpty else {
+            return nil
+        }
+
+        return Int((Double(values.reduce(0, +)) / Double(values.count)).rounded())
+    }
+
+    private static func feedDurationMinutes(for event: BabyEvent) -> Int? {
+        switch event {
+        case let .breastFeed(feed):
+            return max(1, Int(feed.endedAt.timeIntervalSince(feed.startedAt) / 60))
+        case .bottleFeed:
+            return nil
+        case .sleep, .nappy:
+            return nil
+        }
+    }
+
+    private static func sleepDurationMinutes(for event: SleepEvent) -> Int? {
+        guard let endedAt = event.endedAt else {
+            return nil
+        }
+
+        return max(1, Int(endedAt.timeIntervalSince(event.startedAt) / 60))
+    }
+
+    private static func averageFeedIntervalMinutes(for feedEvents: [BabyEvent]) -> Int? {
+        let sortedTimes = feedEvents.map(\.metadata.occurredAt).sorted()
+        guard sortedTimes.count > 1 else {
+            return nil
+        }
+
+        var intervals: [Int] = []
+
+        for index in 1..<sortedTimes.count {
+            let interval = sortedTimes[index].timeIntervalSince(sortedTimes[index - 1])
+            intervals.append(max(1, Int(interval / 60)))
+        }
+
+        return average(of: intervals)
+    }
+
+    private static func makeLoggingStreakDays(
+        from events: [BabyEvent],
+        now: Date,
+        calendar: Calendar
+    ) -> Int {
+        let daySet = Set(events.map { calendar.startOfDay(for: $0.metadata.occurredAt) })
+        guard !daySet.isEmpty else {
+            return 0
+        }
+
+        var streak = 0
+        var currentDay = calendar.startOfDay(for: now)
+
+        while daySet.contains(currentDay) {
+            streak += 1
+
+            guard let previousDay = calendar.date(byAdding: .day, value: -1, to: currentDay) else {
+                break
+            }
+
+            currentDay = previousDay
+        }
+
+        return streak
+    }
+
+    private static func makeDailyCounts(
+        events: [BabyEvent],
+        now: Date,
+        calendar: Calendar
+    ) -> [SummaryDayCount] {
+        var countsByDay: [Date: Int] = [:]
+
+        for event in events {
+            let day = calendar.startOfDay(for: event.metadata.occurredAt)
+            countsByDay[day, default: 0] += 1
+        }
+
+        var result: [SummaryDayCount] = []
+
+        for offset in stride(from: 6, through: 0, by: -1) {
+            guard let day = calendar.date(byAdding: .day, value: -offset, to: calendar.startOfDay(for: now)) else {
+                continue
+            }
+
+            result.append(
+                SummaryDayCount(
+                    date: day,
+                    label: day.formatted(.dateTime.weekday(.narrow)),
+                    count: countsByDay[day, default: 0]
+                )
+            )
+        }
+
+        return result
+    }
+
+    private static func makeHourlyFeedCounts(
+        events: [BabyEvent],
+        now: Date,
+        calendar: Calendar
+    ) -> [SummaryHourCount] {
+        var countsByHour: [Int: Int] = [:]
+
+        for event in events {
+            let hour = calendar.component(.hour, from: event.metadata.occurredAt)
+            countsByHour[hour, default: 0] += 1
+        }
+
+        let representativeHours = [0, 4, 8, 12, 16, 20]
+
+        return representativeHours.map { hour in
+            let labelDate = calendar.date(
+                bySettingHour: hour,
+                minute: 0,
+                second: 0,
+                of: now
+            ) ?? now
+
+            return SummaryHourCount(
+                hour: hour,
+                label: labelDate.formatted(.dateTime.hour(.defaultDigits(amPM: .abbreviated))),
+                count: countsByHour[hour, default: 0]
+            )
+        }
+    }
+}

--- a/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/SummaryScreenState.swift
+++ b/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/SummaryScreenState.swift
@@ -1,0 +1,18 @@
+import BabyTrackerDomain
+import Foundation
+
+public struct SummaryScreenState: Equatable, Sendable {
+    public let events: [BabyEvent]
+    public let emptyStateTitle: String
+    public let emptyStateMessage: String
+
+    public init(
+        events: [BabyEvent],
+        emptyStateTitle: String,
+        emptyStateMessage: String
+    ) {
+        self.events = events
+        self.emptyStateTitle = emptyStateTitle
+        self.emptyStateMessage = emptyStateMessage
+    }
+}

--- a/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/ChildWorkspaceTabView.swift
+++ b/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/ChildWorkspaceTabView.swift
@@ -63,6 +63,13 @@ public struct ChildWorkspaceTabView: View {
                 Label("Timeline", systemImage: "calendar")
             }
 
+
+            SummaryScreenView(profile: profile)
+            .tag(Tab.summary)
+            .tabItem {
+                Label("Summary", systemImage: "chart.bar.fill")
+            }
+
             ChildProfileView(
                 model: model,
                 profile: profile,
@@ -360,6 +367,7 @@ public struct ChildWorkspaceTabView: View {
 extension ChildWorkspaceTabView {
     public enum Tab: Hashable {
         case home
+        case summary
         case events
         case timeline
         case profile

--- a/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/SummaryScreenView.swift
+++ b/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/SummaryScreenView.swift
@@ -1,0 +1,310 @@
+import SwiftUI
+
+public struct SummaryScreenView: View {
+    let profile: ChildProfileScreenState
+
+    @State private var selectedRange: SummaryTimeRange = .today
+
+    public init(profile: ChildProfileScreenState) {
+        self.profile = profile
+    }
+
+    public var body: some View {
+        let snapshot = SummaryMetricsCalculator.makeSnapshot(
+            from: profile.summary.events,
+            range: selectedRange
+        )
+
+        ScrollView {
+            VStack(alignment: .leading, spacing: 18) {
+                rangePicker
+
+                if snapshot.eventCount == 0 {
+                    emptyState
+                } else {
+                    topMetrics(snapshot: snapshot)
+                    inDepthMetrics(snapshot: snapshot)
+                    chartSection(snapshot: snapshot)
+                }
+            }
+            .padding(.horizontal, 16)
+            .padding(.vertical, 12)
+        }
+        .background(Color(.systemGroupedBackground).ignoresSafeArea())
+    }
+
+    private var rangePicker: some View {
+        Picker("Range", selection: $selectedRange) {
+            ForEach(SummaryTimeRange.allCases) { range in
+                Text(range.title).tag(range)
+            }
+        }
+        .pickerStyle(.segmented)
+        .padding(4)
+        .background(
+            RoundedRectangle(cornerRadius: 16, style: .continuous)
+                .fill(.ultraThinMaterial)
+        )
+    }
+
+    private var emptyState: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text(profile.summary.emptyStateTitle)
+                .font(.headline)
+
+            Text(profile.summary.emptyStateMessage)
+                .font(.subheadline)
+                .foregroundStyle(.secondary)
+        }
+        .padding(18)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(cardBackground)
+        .accessibilityIdentifier("summary-empty-state")
+    }
+
+    private func topMetrics(snapshot: SummarySnapshot) -> some View {
+        VStack(alignment: .leading, spacing: 12) {
+            Text("Top Metrics")
+                .font(.headline)
+
+            LazyVGrid(
+                columns: [
+                    GridItem(.flexible(), spacing: 12),
+                    GridItem(.flexible(), spacing: 12),
+                ],
+                spacing: 12
+            ) {
+                metricCard(
+                    title: "Feeds",
+                    value: "\(snapshot.totalFeeds)",
+                    subtitle: subtitleForFeedAverage(snapshot),
+                    symbol: "drop.fill"
+                )
+
+                metricCard(
+                    title: "Nappy Changes",
+                    value: "\(snapshot.totalNappies)",
+                    subtitle: "Wet: \(snapshot.wetNappyCount) • Dirty: \(snapshot.dirtyNappyCount)",
+                    symbol: "checklist.checked"
+                )
+
+                metricCard(
+                    title: "Sleep",
+                    value: formatMinutes(snapshot.totalSleepMinutes),
+                    subtitle: sleepRangeSubtitle(snapshot),
+                    symbol: "moon.zzz.fill"
+                )
+
+                metricCard(
+                    title: "Logging Streak",
+                    value: "\(snapshot.loggingStreakDays) day\(snapshot.loggingStreakDays == 1 ? "" : "s")",
+                    subtitle: "Consecutive days with logs",
+                    symbol: "flame.fill"
+                )
+            }
+        }
+    }
+
+    private func inDepthMetrics(snapshot: SummarySnapshot) -> some View {
+        VStack(alignment: .leading, spacing: 12) {
+            Text("In-Depth")
+                .font(.headline)
+
+            VStack(spacing: 10) {
+                detailRow(
+                    title: "Average feed interval",
+                    value: snapshot.averageFeedIntervalMinutes.map { "\($0) min" } ?? "Not enough feeds"
+                )
+
+                detailRow(
+                    title: "Average sleep block",
+                    value: snapshot.averageSleepBlockMinutes.map { "\($0) min" } ?? "No completed sleeps"
+                )
+
+                detailRow(
+                    title: "Shortest sleep block",
+                    value: snapshot.shortestSleepBlockMinutes.map { "\($0) min" } ?? "No completed sleeps"
+                )
+
+                detailRow(
+                    title: "Longest sleep block",
+                    value: snapshot.longestSleepBlockMinutes.map { "\($0) min" } ?? "No completed sleeps"
+                )
+
+                detailRow(
+                    title: "Wet vs dirty ratio",
+                    value: nappyRatioText(snapshot)
+                )
+
+                detailRow(
+                    title: "Mixed/Dry nappies",
+                    value: "Mixed: \(snapshot.mixedNappyCount) • Dry: \(snapshot.dryNappyCount)"
+                )
+            }
+            .padding(14)
+            .background(cardBackground)
+        }
+    }
+
+    private func chartSection(snapshot: SummarySnapshot) -> some View {
+        VStack(alignment: .leading, spacing: 12) {
+            Text("Trends")
+                .font(.headline)
+
+            chartCard(
+                title: "7-Day Activity",
+                subtitle: "Total events per day"
+            ) {
+                miniBarChart(
+                    points: snapshot.dailyEventCounts.map { ($0.label, $0.count) },
+                    tint: .accentColor
+                )
+            }
+
+            chartCard(
+                title: "Feed Time of Day",
+                subtitle: "Feeds by hour bucket"
+            ) {
+                miniBarChart(
+                    points: snapshot.feedCountsByHour.map { ($0.label, $0.count) },
+                    tint: Color.blue
+                )
+            }
+        }
+    }
+
+    private func metricCard(
+        title: String,
+        value: String,
+        subtitle: String,
+        symbol: String
+    ) -> some View {
+        VStack(alignment: .leading, spacing: 10) {
+            HStack {
+                Label(title, systemImage: symbol)
+                    .font(.caption.weight(.semibold))
+                    .foregroundStyle(.secondary)
+                Spacer()
+            }
+
+            Text(value)
+                .font(.title3.weight(.bold))
+
+            Text(subtitle)
+                .font(.caption)
+                .foregroundStyle(.secondary)
+                .lineLimit(2)
+        }
+        .frame(maxWidth: .infinity, minHeight: 110, alignment: .leading)
+        .padding(14)
+        .background(cardBackground)
+    }
+
+    private func detailRow(title: String, value: String) -> some View {
+        HStack(alignment: .top, spacing: 10) {
+            Text(title)
+                .foregroundStyle(.secondary)
+            Spacer()
+            Text(value)
+                .multilineTextAlignment(.trailing)
+                .fontWeight(.semibold)
+        }
+        .font(.subheadline)
+    }
+
+    private func chartCard<Content: View>(
+        title: String,
+        subtitle: String,
+        @ViewBuilder content: () -> Content
+    ) -> some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text(title)
+                .font(.headline)
+
+            Text(subtitle)
+                .font(.caption)
+                .foregroundStyle(.secondary)
+
+            content()
+        }
+        .padding(14)
+        .background(cardBackground)
+    }
+
+    private func miniBarChart(points: [(String, Int)], tint: Color) -> some View {
+        let maxValue = max(1, points.map(\.1).max() ?? 0)
+
+        return HStack(alignment: .bottom, spacing: 8) {
+            ForEach(Array(points.enumerated()), id: \.offset) { _, point in
+                VStack(spacing: 6) {
+                    RoundedRectangle(cornerRadius: 6, style: .continuous)
+                        .fill(tint.gradient)
+                        .frame(height: max(6, (CGFloat(point.1) / CGFloat(maxValue)) * 84))
+                        .overlay(alignment: .top) {
+                            if point.1 > 0 {
+                                Text("\(point.1)")
+                                    .font(.caption2)
+                                    .foregroundStyle(.secondary)
+                                    .offset(y: -16)
+                            }
+                        }
+
+                    Text(point.0)
+                        .font(.caption2)
+                        .foregroundStyle(.secondary)
+                        .lineLimit(1)
+                }
+                .frame(maxWidth: .infinity)
+            }
+        }
+        .frame(maxWidth: .infinity, minHeight: 128, alignment: .bottom)
+    }
+
+    private var cardBackground: some View {
+        RoundedRectangle(cornerRadius: 18, style: .continuous)
+            .fill(.thinMaterial)
+            .overlay(
+                RoundedRectangle(cornerRadius: 18, style: .continuous)
+                    .stroke(Color.white.opacity(0.28), lineWidth: 1)
+            )
+            .shadow(color: Color.black.opacity(0.05), radius: 14, y: 8)
+    }
+
+    private func subtitleForFeedAverage(_ snapshot: SummarySnapshot) -> String {
+        guard let average = snapshot.averageFeedDurationMinutes else {
+            return "No breast feed duration data"
+        }
+
+        return "Average duration: \(average) min"
+    }
+
+    private func sleepRangeSubtitle(_ snapshot: SummarySnapshot) -> String {
+        guard let shortest = snapshot.shortestSleepBlockMinutes,
+              let longest = snapshot.longestSleepBlockMinutes else {
+            return "No completed sleeps"
+        }
+
+        return "Shortest: \(shortest)m • Longest: \(longest)m"
+    }
+
+    private func nappyRatioText(_ snapshot: SummarySnapshot) -> String {
+        let dirtyIncludingMixed = snapshot.dirtyNappyCount + snapshot.mixedNappyCount
+
+        if snapshot.wetNappyCount == 0 && dirtyIncludingMixed == 0 {
+            return "No nappy data"
+        }
+
+        return "\(snapshot.wetNappyCount):\(dirtyIncludingMixed)"
+    }
+
+    private func formatMinutes(_ minutes: Int) -> String {
+        let hours = minutes / 60
+        let remainingMinutes = minutes % 60
+
+        if hours == 0 {
+            return "\(remainingMinutes)m"
+        }
+
+        return "\(hours)h \(remainingMinutes)m"
+    }
+}

--- a/docs/plans/017-summary-tab-metrics.md
+++ b/docs/plans/017-summary-tab-metrics.md
@@ -1,0 +1,13 @@
+# 017 Summary Tab Metrics
+
+## Goal
+Add a new Summary tab that highlights top-level baby care metrics and provides deeper insights for today, 7 days, 30 days, and all time.
+
+## Plan
+1. Add summary screen state to the child profile so the tab can derive metrics from existing event data.
+2. Add a focused summary metrics calculator that computes top-level and in-depth metrics from a selectable time range.
+3. Build a new SwiftUI Summary tab with card-based Liquid Glass styling, segmented time range selection, top metrics, deeper metrics, and two key chart sections.
+4. Add tests for the summary calculator to keep calculations predictable and safe.
+5. Wire the Summary tab into the existing child workspace tab navigation.
+
+- [x] Complete


### PR DESCRIPTION
### Motivation
- Provide a focused Summary tab that surfaces top-level and in-depth baby care metrics (feeds, nappies, sleep, streaks) across selectable ranges (`today`, `7 days`, `30 days`, `all time`).
- Compute reliable, testable aggregates and trends (daily counts, hourly feed buckets, averages, intervals and streaks) from existing event data rather than duplicating logic in the UI.
- Integrate the summary into the Child workspace so users can switch to a metrics-first view alongside Events, Timeline and Profile.

### Description
- Added a `SummaryMetricsCalculator` that computes `SummarySnapshot` for a time range, including feed counts/durations, sleep durations, nappy breakdown, logging streaks, daily event counts and hourly feed buckets, and helper functions like `average`, `isWithinDays`, and `makeLoggingStreakDays`.
- Added `SummaryScreenState` to carry event list and empty-state strings, exposed via `ChildProfileScreenState` and populated by a new `makeSummaryScreenState` helper in `AppModel`.
- Implemented the SwiftUI `SummaryScreenView` with a segmented `Picker` for `SummaryTimeRange`, top metric cards, an in-depth section and two mini bar charts (7-day activity and feed time-of-day), plus styling and accessibility identifier for the empty state.
- Wired the tab into `ChildWorkspaceTabView` (new `Tab.summary`) and added lightweight plan/docs at `docs/plans/017-summary-tab-metrics.md`.
- Added unit tests in `Baby TrackerTests/SummaryMetricsCalculatorTests.swift` exercising snapshot calculations for today/seven-day filtering and verifying core computed values.

### Testing
- Added `SummaryMetricsCalculatorTests` with two test cases that assert snapshot composition and range filtering; these unit tests were run and passed.
- Executed the package unit test suite (`swift test`) and the affected test targets passed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c52bf30898832f92a24356f54088c1)