### PR TITLE
Fix CloudKit shared child sync

### DIFF
--- a/Baby TrackerTests/CloudKitRecordMapperTests.swift
+++ b/Baby TrackerTests/CloudKitRecordMapperTests.swift
@@ -1,11 +1,64 @@
 import BabyTrackerDomain
 import BabyTrackerFeature
-import BabyTrackerSync
+@testable import BabyTrackerSync
 import CloudKit
 import Foundation
 import Testing
 
 struct CloudKitRecordMapperTests {
+    @Test
+    func sharedHierarchyRecordsPointBackToChild() throws {
+        let childID = UUID()
+        let userID = UUID()
+        let zoneID = CloudKitRecordNames.zoneID(
+            for: childID,
+            ownerName: "probe-owner"
+        )
+        let user = try UserIdentity(
+            id: userID,
+            displayName: "Alex Parent",
+            createdAt: .now,
+            cloudKitUserRecordName: "cloud-user"
+        )
+        let membership = Membership.owner(
+            childID: childID,
+            userID: userID,
+            createdAt: .now
+        )
+        let event = try BottleFeedEvent(
+            metadata: EventMetadata(
+                childID: childID,
+                occurredAt: .now,
+                createdAt: .now,
+                createdBy: userID
+            ),
+            amountMilliliters: 120
+        )
+
+        let expectedParentRecordID = CloudKitRecordNames.childRecordID(
+            childID: childID,
+            zoneID: zoneID
+        )
+
+        let userRecord = CloudKitRecordMapper.userRecord(
+            from: user,
+            childID: childID,
+            zoneID: zoneID
+        )
+        let membershipRecord = CloudKitRecordMapper.membershipRecord(
+            from: membership,
+            zoneID: zoneID
+        )
+        let eventRecord = CloudKitRecordMapper.eventRecord(
+            from: .bottleFeed(event),
+            zoneID: zoneID
+        )
+
+        #expect(userRecord.parent?.recordID == expectedParentRecordID)
+        #expect(membershipRecord.parent?.recordID == expectedParentRecordID)
+        #expect(eventRecord.parent?.recordID == expectedParentRecordID)
+    }
+
     @Test
     func breastFeedMapperRoundTripsOptionalAndBothSides() throws {
         let childID = UUID()

--- a/Baby TrackerTests/CloudKitSyncEngineTests.swift
+++ b/Baby TrackerTests/CloudKitSyncEngineTests.swift
@@ -1,6 +1,6 @@
 import BabyTrackerDomain
 import BabyTrackerPersistence
-import BabyTrackerSync
+@testable import BabyTrackerSync
 import CloudKit
 import Foundation
 import Testing
@@ -189,6 +189,247 @@ struct CloudKitSyncEngineTests {
         let pendingAfterRefresh = try syncStateRepository.loadPendingRecords()
         #expect(!pendingAfterRefresh.contains { $0.recordType == .bottleFeedEvent })
     }
+
+    @Test
+    func forcePullAcceptedSharePerformsFullSharedZoneFetchAndSavesRecordsLocally() async throws {
+        let store = try BabyTrackerModelStore(isStoredInMemoryOnly: true)
+        let userDefaults = UserDefaults(suiteName: "CloudKitSyncEngineTests.forcePullAcceptedShare")!
+        userDefaults.removePersistentDomain(forName: "CloudKitSyncEngineTests.forcePullAcceptedShare")
+        defer {
+            userDefaults.removePersistentDomain(forName: "CloudKitSyncEngineTests.forcePullAcceptedShare")
+        }
+
+        let childRepository = SwiftDataChildRepository(store: store)
+        let userIdentityRepository = SwiftDataUserIdentityRepository(store: store, userDefaults: userDefaults)
+        let membershipRepository = SwiftDataMembershipRepository(store: store)
+        let eventRepository = SwiftDataEventRepository(store: store)
+        let syncStateRepository = SwiftDataSyncStateRepository(store: store)
+        let client = CloudKitClientSpy()
+        let syncEngine = CloudKitSyncEngine(
+            childRepository: childRepository,
+            userIdentityRepository: userIdentityRepository,
+            membershipRepository: membershipRepository,
+            eventRepository: eventRepository,
+            syncStateRepository: syncStateRepository,
+            client: client
+        )
+
+        let owner = try UserIdentity(displayName: "Sam Owner")
+        let child = try Child(name: "Robin", createdBy: owner.id)
+        let ownerMembership = Membership.owner(
+            childID: child.id,
+            userID: owner.id,
+            createdAt: child.createdAt
+        )
+        let event = try BottleFeedEvent(
+            metadata: EventMetadata(
+                childID: child.id,
+                occurredAt: child.createdAt.addingTimeInterval(600),
+                createdAt: child.createdAt.addingTimeInterval(600),
+                createdBy: owner.id
+            ),
+            amountMilliliters: 150
+        )
+
+        let zoneID = CKRecordZone.ID(zoneName: "child-\(child.id.uuidString)", ownerName: "owner-record-name")
+        let rootRecordID = CKRecord.ID(recordName: "child.\(child.id.uuidString)", zoneID: zoneID)
+
+        try await client.modifyRecordZones(
+            saving: [CKRecordZone(zoneID: zoneID)],
+            deleting: [],
+            databaseScope: .shared
+        )
+        _ = try await client.modifyRecords(
+            saving: [
+                CloudKitRecordMapper.childRecord(from: child, zoneID: zoneID),
+                CloudKitRecordMapper.userRecord(from: owner, childID: child.id, zoneID: zoneID),
+                CloudKitRecordMapper.membershipRecord(from: ownerMembership, zoneID: zoneID),
+                CloudKitRecordMapper.eventRecord(from: .bottleFeed(event), zoneID: zoneID)
+            ],
+            deleting: [],
+            databaseScope: .shared,
+            savePolicy: .changedKeys
+        )
+
+        try await syncEngine.forcePullAcceptedShare(
+            rootRecordID: rootRecordID,
+            shareRecordName: "share.child.\(child.id.uuidString)"
+        )
+
+        let savedChild = try #require(try childRepository.loadChild(id: child.id))
+        let savedOwner = try #require(try userIdentityRepository.loadUsers(for: [owner.id]).first)
+        let savedMemberships = try membershipRepository.loadMemberships(for: child.id)
+        let savedEvent = try #require(try eventRepository.loadEvent(id: event.id))
+        let savedContext = try #require(try childRepository.loadCloudKitChildContext(id: child.id))
+
+        #expect(savedChild.name == child.name)
+        #expect(savedOwner.displayName == owner.displayName)
+        #expect(savedMemberships.contains(where: { $0.id == ownerMembership.id }))
+        #expect(savedContext.zoneID == zoneID)
+        #expect(savedContext.databaseScope == .shared)
+        switch savedEvent {
+        case let .bottleFeed(feed):
+            #expect(feed.amountMilliliters == 150)
+        default:
+            Issue.record("Expected a bottle feed event")
+        }
+
+        let zoneRequests = await client.zoneChangeRequests
+        #expect(zoneRequests.contains(where: {
+            $0.zoneID == zoneID &&
+            $0.databaseScope == .shared &&
+            $0.tokenWasNil
+        }))
+    }
+
+    @Test
+    func localWriteRefreshFullyReconcilesOwnerSharedPrivateZoneBeforePush() async throws {
+        let store = try BabyTrackerModelStore(isStoredInMemoryOnly: true)
+        let userDefaults = UserDefaults(suiteName: "CloudKitSyncEngineTests.ownerSharedPrivateZoneReconcile")!
+        userDefaults.removePersistentDomain(forName: "CloudKitSyncEngineTests.ownerSharedPrivateZoneReconcile")
+        defer {
+            userDefaults.removePersistentDomain(forName: "CloudKitSyncEngineTests.ownerSharedPrivateZoneReconcile")
+        }
+
+        let childRepository = SwiftDataChildRepository(store: store)
+        let userIdentityRepository = SwiftDataUserIdentityRepository(store: store, userDefaults: userDefaults)
+        let membershipRepository = SwiftDataMembershipRepository(store: store)
+        let eventRepository = SwiftDataEventRepository(store: store)
+        let syncStateRepository = SwiftDataSyncStateRepository(store: store)
+        let client = CloudKitClientSpy()
+        let syncEngine = CloudKitSyncEngine(
+            childRepository: childRepository,
+            userIdentityRepository: userIdentityRepository,
+            membershipRepository: membershipRepository,
+            eventRepository: eventRepository,
+            syncStateRepository: syncStateRepository,
+            client: client
+        )
+
+        let owner = try UserIdentity(displayName: "Owner")
+        let caregiver = try UserIdentity(displayName: "Caregiver")
+        let child = try Child(name: "Test 3", createdBy: owner.id)
+        let ownerMembership = Membership.owner(
+            childID: child.id,
+            userID: owner.id,
+            createdAt: child.createdAt
+        )
+        let caregiverMembership = Membership(
+            childID: child.id,
+            userID: caregiver.id,
+            role: .caregiver,
+            status: .active,
+            invitedAt: child.createdAt,
+            acceptedAt: child.createdAt
+        )
+        let ownerEvent = try NappyEvent(
+            metadata: EventMetadata(
+                childID: child.id,
+                occurredAt: child.createdAt.addingTimeInterval(60),
+                createdAt: child.createdAt.addingTimeInterval(60),
+                createdBy: owner.id
+            ),
+            type: .mixed
+        )
+        let caregiverEvent = try BottleFeedEvent(
+            metadata: EventMetadata(
+                childID: child.id,
+                occurredAt: child.createdAt.addingTimeInterval(120),
+                createdAt: child.createdAt.addingTimeInterval(120),
+                createdBy: caregiver.id
+            ),
+            amountMilliliters: 90
+        )
+
+        let zoneID = CloudKitRecordNames.zoneID(for: child.id)
+        let shareRecordID = CloudKitRecordNames.shareRecordID(
+            childID: child.id,
+            zoneID: zoneID
+        )
+        let childRecord = CloudKitRecordMapper.childRecord(from: child, zoneID: zoneID)
+        let share = CKShare(
+            rootRecord: childRecord,
+            shareID: shareRecordID
+        )
+
+        try userIdentityRepository.saveLocalUser(owner)
+        try userIdentityRepository.saveUser(caregiver)
+        try childRepository.saveChild(child)
+        try membershipRepository.saveCloudKitMembership(ownerMembership)
+        try membershipRepository.saveCloudKitMembership(caregiverMembership)
+        try eventRepository.saveEvent(.nappy(ownerEvent))
+        try childRepository.saveCloudKitChildContext(
+            CloudKitChildContext(
+                childID: child.id,
+                zoneID: zoneID,
+                shareRecordName: shareRecordID.recordName,
+                databaseScope: .private
+            )
+        )
+
+        try syncStateRepository.updateSyncState(
+            for: SyncRecordReference(recordType: .child, recordID: child.id, childID: child.id),
+            state: .upToDate,
+            lastSyncedAt: .now,
+            lastSyncErrorCode: nil
+        )
+        try syncStateRepository.updateSyncState(
+            for: SyncRecordReference(recordType: .membership, recordID: ownerMembership.id, childID: child.id),
+            state: .upToDate,
+            lastSyncedAt: .now,
+            lastSyncErrorCode: nil
+        )
+        try syncStateRepository.updateSyncState(
+            for: SyncRecordReference(recordType: .membership, recordID: caregiverMembership.id, childID: child.id),
+            state: .upToDate,
+            lastSyncedAt: .now,
+            lastSyncErrorCode: nil
+        )
+        try syncStateRepository.updateSyncState(
+            for: SyncRecordReference(recordType: .nappyEvent, recordID: ownerEvent.id, childID: child.id),
+            state: .upToDate,
+            lastSyncedAt: .now,
+            lastSyncErrorCode: nil
+        )
+
+        try await client.modifyRecordZones(
+            saving: [CKRecordZone(zoneID: zoneID)],
+            deleting: [],
+            databaseScope: .private
+        )
+        _ = try await client.modifyRecords(
+            saving: [
+                childRecord,
+                share,
+                CloudKitRecordMapper.userRecord(from: owner, childID: child.id, zoneID: zoneID),
+                CloudKitRecordMapper.userRecord(from: caregiver, childID: child.id, zoneID: zoneID),
+                CloudKitRecordMapper.membershipRecord(from: ownerMembership, zoneID: zoneID),
+                CloudKitRecordMapper.membershipRecord(from: caregiverMembership, zoneID: zoneID),
+                CloudKitRecordMapper.eventRecord(from: .nappy(ownerEvent), zoneID: zoneID),
+                CloudKitRecordMapper.eventRecord(from: .bottleFeed(caregiverEvent), zoneID: zoneID)
+            ],
+            deleting: [],
+            databaseScope: .private,
+            savePolicy: .changedKeys
+        )
+
+        _ = await syncEngine.refreshAfterLocalWrite()
+
+        let savedCaregiverEvent = try #require(try eventRepository.loadEvent(id: caregiverEvent.id))
+        switch savedCaregiverEvent {
+        case let .bottleFeed(event):
+            #expect(event.amountMilliliters == 90)
+        default:
+            Issue.record("Expected caregiver bottle feed event")
+        }
+
+        let zoneRequests = await client.zoneChangeRequests
+        #expect(zoneRequests.contains(where: {
+            $0.zoneID == zoneID &&
+            $0.databaseScope == .private &&
+            $0.tokenWasNil
+        }))
+    }
 }
 
 private actor CloudKitClientSpy: CloudKitClient {
@@ -198,6 +439,7 @@ private actor CloudKitClientSpy: CloudKitClient {
     private(set) var createdZoneIDs: [CKRecordZone.ID] = []
     private(set) var queriedZoneIDs: [CKRecordZone.ID] = []
     private(set) var zoneChangeZoneIDs: [CKRecordZone.ID] = []
+    private(set) var zoneChangeRequests: [(zoneID: CKRecordZone.ID, databaseScope: CKDatabase.Scope, tokenWasNil: Bool)] = []
     private var recordsByID: [CKRecord.ID: CKRecord] = [:]
     private var knownRecordTypesByZoneID: [CKRecordZone.ID: Set<String>] = [:]
 
@@ -327,6 +569,11 @@ private actor CloudKitClientSpy: CloudKitClient {
         since tokenData: Data?
     ) async throws -> CloudKitRecordZoneChangeSet {
         zoneChangeZoneIDs.append(zoneID)
+        zoneChangeRequests.append((
+            zoneID: zoneID,
+            databaseScope: databaseScope,
+            tokenWasNil: tokenData == nil
+        ))
 
         guard existingZoneIDs.contains(zoneID) else {
             throw CKError(.zoneNotFound)

--- a/Packages/BabyTrackerSync/Sources/BabyTrackerSync/CloudKitRecordMapper.swift
+++ b/Packages/BabyTrackerSync/Sources/BabyTrackerSync/CloudKitRecordMapper.swift
@@ -47,11 +47,15 @@ public enum CloudKitRecordMapper {
         record["status"] = membership.status.rawValue
         record["invitedAt"] = membership.invitedAt
         record["acceptedAt"] = membership.acceptedAt
+        // CloudKit shares follow the root record's hierarchy. Keeping a record
+        // in the same zone is not enough to make it part of the share.
+        record.parent = childReference(childID: membership.childID, zoneID: zoneID)
         return record
     }
 
     static func userRecord(
         from user: UserIdentity,
+        childID: UUID,
         zoneID: CKRecordZone.ID
     ) -> CKRecord {
         let record = CKRecord(
@@ -64,6 +68,9 @@ public enum CloudKitRecordMapper {
         record["displayName"] = user.displayName
         record["createdAt"] = user.createdAt
         record["cloudKitUserRecordName"] = user.cloudKitUserRecordName
+        // User identities are duplicated per child zone so each shared child
+        // can carry the people needed to resolve event attribution locally.
+        record.parent = childReference(childID: childID, zoneID: zoneID)
         return record
     }
 
@@ -152,6 +159,9 @@ public enum CloudKitRecordMapper {
             )
         )
         applyMetadata(event.metadata, to: record)
+        // Events must be descendants of the shared child record or recipients
+        // will only receive the child itself after accepting the share.
+        record.parent = childReference(childID: event.metadata.childID, zoneID: zoneID)
         if let side = event.side {
             record["side"] = side.rawValue
         }
@@ -174,6 +184,7 @@ public enum CloudKitRecordMapper {
             )
         )
         applyMetadata(event.metadata, to: record)
+        record.parent = childReference(childID: event.metadata.childID, zoneID: zoneID)
         record["amountMilliliters"] = event.amountMilliliters
         record["milkType"] = event.milkType?.rawValue
         return record
@@ -191,6 +202,7 @@ public enum CloudKitRecordMapper {
             )
         )
         applyMetadata(event.metadata, to: record)
+        record.parent = childReference(childID: event.metadata.childID, zoneID: zoneID)
         record["startedAt"] = event.startedAt
         record["endedAt"] = event.endedAt
         return record
@@ -208,6 +220,7 @@ public enum CloudKitRecordMapper {
             )
         )
         applyMetadata(event.metadata, to: record)
+        record.parent = childReference(childID: event.metadata.childID, zoneID: zoneID)
         record["type"] = event.type.rawValue
         record["peeVolume"] = event.peeVolume?.rawValue
         record["pooVolume"] = event.pooVolume?.rawValue
@@ -291,5 +304,18 @@ public enum CloudKitRecordMapper {
     ) -> UUID {
         let rawValue = recordName.replacingOccurrences(of: prefix, with: "")
         return UUID(uuidString: rawValue) ?? UUID()
+    }
+
+    private static func childReference(
+        childID: UUID,
+        zoneID: CKRecordZone.ID
+    ) -> CKRecord.Reference {
+        CKRecord.Reference(
+            recordID: CloudKitRecordNames.childRecordID(
+                childID: childID,
+                zoneID: zoneID
+            ),
+            action: .none
+        )
     }
 }

--- a/Packages/BabyTrackerSync/Sources/BabyTrackerSync/CloudKitSyncEngine.swift
+++ b/Packages/BabyTrackerSync/Sources/BabyTrackerSync/CloudKitSyncEngine.swift
@@ -8,6 +8,20 @@ import os
 public final class CloudKitSyncEngine {
     public private(set) var statusSummary = SyncStatusSummary()
 
+    enum ShareAcceptanceError: LocalizedError {
+        case missingRootRecord
+        case refreshFailed(String?)
+
+        var errorDescription: String? {
+            switch self {
+            case .missingRootRecord:
+                return "Accepted share did not include a root record."
+            case let .refreshFailed(message):
+                return message ?? "Sync failed while loading the accepted share."
+            }
+        }
+    }
+
     private let childRepository: any CloudKitChildRepository
     private let userIdentityRepository: any CloudKitUserIdentityRepository
     private let membershipRepository: any CloudKitMembershipRepository
@@ -235,15 +249,23 @@ public final class CloudKitSyncEngine {
         logger.info("[4/5] Calling client.accept (registers share with CloudKit)")
         AppLogger.shared.log(.info, category: "CloudKitSync", "[4/5] Calling client.accept (registers share with CloudKit)")
         try await client.accept([metadata])
-        logger.info("[4/5] client.accept succeeded — running foreground refresh")
-        AppLogger.shared.log(.info, category: "CloudKitSync", "[4/5] client.accept succeeded — running foreground refresh")
-        _ = await refresh(reason: .foreground)
+        // Accepting the share registers access to the shared zone, but it does
+        // not guarantee that the zone contents have been pulled locally yet.
+        logger.info("[4/5] client.accept succeeded — forcing full pull of accepted shared zone")
+        AppLogger.shared.log(.info, category: "CloudKitSync", "[4/5] client.accept succeeded — forcing full pull of accepted shared zone")
+        try await forcePullAcceptedShare(
+            rootRecordID: try acceptedShareRootRecordID(from: metadata),
+            shareRecordName: metadata.share.recordID.recordName
+        )
+        logger.info("[4/5] Full accepted-share pull complete — running foreground refresh")
+        AppLogger.shared.log(.info, category: "CloudKitSync", "[4/5] Full accepted-share pull complete — running foreground refresh")
+        try throwIfRefreshFailed(await refresh(reason: .foreground))
         logger.info("[4/5] Foreground refresh done — ensuring local membership record")
         AppLogger.shared.log(.info, category: "CloudKitSync", "[4/5] Foreground refresh done — ensuring local membership record")
         try await ensureMembershipForAcceptedShare(metadata: metadata)
         logger.info("[4/5] Membership ensured — running post-write refresh")
         AppLogger.shared.log(.info, category: "CloudKitSync", "[4/5] Membership ensured — running post-write refresh")
-        _ = await refresh(reason: .localWrite)
+        try throwIfRefreshFailed(await refresh(reason: .localWrite))
         logger.info("[5/5] Share acceptance complete")
         AppLogger.shared.log(.info, category: "CloudKitSync", "[5/5] Share acceptance complete")
     }
@@ -377,7 +399,20 @@ public final class CloudKitSyncEngine {
                     "Child '\(child.name, privacy: .private)' — zone: \(context.zoneID.zoneName, privacy: .public), scope: \(context.databaseScope.logDescription, privacy: .public), isArchived: \(child.isArchived, privacy: .public)"
                 )
                 AppLogger.shared.log(.info, category: "CloudKitSync", "Child — zone: \(context.zoneID.zoneName), scope: \(context.databaseScope.logDescription), isArchived: \(child.isArchived)")
-                try await pullZoneSnapshot(context: context)
+                if try await shouldForceOwnerSharedZoneReconciliation(
+                    for: child.id,
+                    context: context
+                ) {
+                    // Caregiver edits can already exist in the owner's private
+                    // zone even when incremental zone changes report nothing.
+                    // Force a full pull for shared private zones so the owner
+                    // does not keep reading a stale local snapshot.
+                    logger.info("Child '\(child.name, privacy: .private)' — forcing full pull for owner shared private zone")
+                    AppLogger.shared.log(.info, category: "CloudKitSync", "Child — forcing full pull for owner shared private zone")
+                    try await pullZoneSnapshot(context: context, forceFullFetch: true)
+                } else {
+                    try await pullZoneSnapshot(context: context)
+                }
                 let memberships = try membershipRepository.loadMemberships(for: child.id)
                 logger.info(
                     "Child '\(child.name, privacy: .private)' — \(memberships.count, privacy: .public) membership(s) in local store: \(memberships.map { "userID=\($0.userID) role=\($0.role) status=\($0.status)" }.joined(separator: ", "), privacy: .public)"
@@ -476,6 +511,16 @@ public final class CloudKitSyncEngine {
             }
 
             let context = try await ensureZoneContext(for: child.id, preferredScope: .private)
+            if try await shouldForceOwnerSharedZoneReconciliation(
+                for: child.id,
+                context: context
+            ) {
+                // Reconcile before pushing so a stale owner snapshot never gets
+                // written back over caregiver-authored records.
+                logger.info("pushPendingChanges — '\(child.name, privacy: .private)': reconciling owner shared private zone before push")
+                AppLogger.shared.log(.info, category: "CloudKitSync", "pushPendingChanges — reconciling owner shared private zone before push")
+                try await pullZoneSnapshot(context: context, forceFullFetch: true)
+            }
             logger.info("pushPendingChanges — '\(child.name, privacy: .private)': pushing zone (scope: \(context.databaseScope.logDescription, privacy: .public))")
             AppLogger.shared.log(.info, category: "CloudKitSync", "pushPendingChanges — pushing zone (scope: \(context.databaseScope.logDescription))")
             try await pushZoneSnapshot(for: child.id, context: context)
@@ -501,7 +546,13 @@ public final class CloudKitSyncEngine {
 
         let childRecord = CloudKitRecordMapper.childRecord(from: child, zoneID: context.zoneID)
         var recordsToSave: [CKRecord] = [childRecord]
-        recordsToSave.append(contentsOf: users.map { CloudKitRecordMapper.userRecord(from: $0, zoneID: context.zoneID) })
+        recordsToSave.append(contentsOf: users.map {
+            CloudKitRecordMapper.userRecord(
+                from: $0,
+                childID: childID,
+                zoneID: context.zoneID
+            )
+        })
         recordsToSave.append(contentsOf: memberships.map { CloudKitRecordMapper.membershipRecord(from: $0, zoneID: context.zoneID) })
         recordsToSave.append(contentsOf: events.map { CloudKitRecordMapper.eventRecord(from: $0, zoneID: context.zoneID) })
 
@@ -604,9 +655,30 @@ public final class CloudKitSyncEngine {
         }
     }
 
-    private func pullZoneSnapshot(context: CloudKitChildContext) async throws {
+    func forcePullAcceptedShare(
+        rootRecordID: CKRecord.ID,
+        shareRecordName: String
+    ) async throws {
+        let childID = childID(fromRecordName: rootRecordID.recordName)
+        let context = CloudKitChildContext(
+            childID: childID,
+            zoneID: rootRecordID.zoneID,
+            shareRecordName: shareRecordName,
+            databaseScope: .shared
+        )
+        try await pullZoneSnapshot(
+            context: context,
+            forceFullFetch: true
+        )
+    }
+
+    private func pullZoneSnapshot(
+        context: CloudKitChildContext,
+        forceFullFetch: Bool = false
+    ) async throws {
         let databaseScope = context.databaseScope == .shared ? "shared" : "private"
-        let anchor = try syncStateRepository.loadAnchor(
+        // Clearing the anchor turns this into a complete zone snapshot fetch.
+        let anchor = forceFullFetch ? nil : try syncStateRepository.loadAnchor(
             databaseScope: databaseScope,
             zoneName: context.zoneID.zoneName,
             ownerName: context.zoneID.ownerName
@@ -806,6 +878,8 @@ public final class CloudKitSyncEngine {
         logger.info("[4/5] ensureMembership — existing memberships for child: [\(existingRoles.isEmpty ? "none" : existingRoles, privacy: .public)]")
         print("[BabyTracker][4/5] ensureMembership — existing memberships: [\(existingRoles.isEmpty ? "none" : existingRoles)]")
         AppLogger.shared.log(.info, category: "CloudKitSync", "[4/5] ensureMembership — existing memberships: [\(existingRoles.isEmpty ? "none" : existingRoles)]")
+        // The share recipient may not receive their membership record in the
+        // first pull, so create the local caregiver membership explicitly.
         logger.info("[4/5] ensureMembership — creating caregiver membership for zone: \(rootRecordID.zoneID.zoneName, privacy: .public)")
         AppLogger.shared.log(.info, category: "CloudKitSync", "[4/5] ensureMembership — creating caregiver membership for zone: \(rootRecordID.zoneID.zoneName)")
         let membership = Membership(
@@ -881,6 +955,31 @@ public final class CloudKitSyncEngine {
         return "Pending invitation"
     }
 
+    private func shouldForceOwnerSharedZoneReconciliation(
+        for childID: UUID,
+        context: CloudKitChildContext
+    ) async throws -> Bool {
+        guard context.databaseScope == .private else {
+            return false
+        }
+
+        // `shareRecordName` can be present in locally-created contexts before a
+        // share actually exists, so verify that a real CKShare record is in the
+        // private zone before treating it as an owner-side shared zone.
+        let shareRecordID = CKRecord.ID(
+            recordName: context.shareRecordName ?? CloudKitRecordNames.shareRecordID(
+                childID: childID,
+                zoneID: context.zoneID
+            ).recordName,
+            zoneID: context.zoneID
+        )
+
+        return try await client.records(
+            for: [shareRecordID],
+            databaseScope: context.databaseScope
+        )[shareRecordID] as? CKShare != nil
+    }
+
     private func childID(from zoneName: String) -> UUID {
         let rawValue = zoneName.replacingOccurrences(of: "child-", with: "")
         return UUID(uuidString: rawValue) ?? UUID()
@@ -893,6 +992,22 @@ public final class CloudKitSyncEngine {
 
     private func event(from record: CKRecord) throws -> BabyEvent {
         try CloudKitRecordMapper.event(from: record)
+    }
+
+    private func acceptedShareRootRecordID(from metadata: CKShare.Metadata) throws -> CKRecord.ID {
+        guard let rootRecordID = metadata.hierarchicalRootRecordID else {
+            throw ShareAcceptanceError.missingRootRecord
+        }
+
+        return rootRecordID
+    }
+
+    private func throwIfRefreshFailed(_ summary: SyncStatusSummary) throws {
+        guard summary.state == .failed else {
+            return
+        }
+
+        throw ShareAcceptanceError.refreshFailed(summary.lastErrorDescription)
     }
 
     private func recordType(for event: BabyEvent) -> SyncRecordType {

--- a/docs/CloudKit_Sync_Engine_Guide.md
+++ b/docs/CloudKit_Sync_Engine_Guide.md
@@ -1,0 +1,460 @@
+# CloudKit Sync Engine Guide
+
+## Purpose
+
+This document explains how Baby Tracker's custom CloudKit sync engine works, what we learned during the sharing investigation on March 27, 2026, and what was changed to make owner and caregiver sync behave correctly.
+
+This is the current high-level reference for:
+
+- how data is stored in CloudKit
+- how data moves between devices
+- how sharing works
+- what failure modes we found
+- what fixes are now in place
+
+Relevant Apple documentation:
+
+- [CloudKit overview](https://developer.apple.com/icloud/cloudkit/)
+- [CKDatabase](https://developer.apple.com/documentation/cloudkit/ckdatabase?language=objc)
+- [CKRecord](https://developer.apple.com/documentation/cloudkit/ckrecord)
+- [Sharing CloudKit Data with Other iCloud Users](https://developer.apple.com/documentation/CloudKit/sharing-cloudkit-data-with-other-icloud-users)
+- [CKShare.Participant](https://developer.apple.com/documentation/cloudkit/ckshare/participant)
+- [CKFetchRecordZoneChangesOperation](https://developer.apple.com/documentation/CloudKit/CKFetchRecordZoneChangesOperation)
+- [Remote Records](https://developer.apple.com/documentation/cloudkit/remote-records)
+
+---
+
+## Why We Have a Custom Sync Engine
+
+Baby Tracker does not use `NSPersistentCloudKitContainer` for app data sync. Instead, it uses a custom sync layer in `BabyTrackerSync` so the app can control:
+
+- one CloudKit zone per child
+- explicit owner and caregiver sharing
+- record-level conflict handling
+- local repair logic for incomplete share state
+
+The main type is [`CloudKitSyncEngine.swift`](/Users/brianmurphy/Documents/Development/iOS/Baby%20Tracker/Packages/BabyTrackerSync/Sources/BabyTrackerSync/CloudKitSyncEngine.swift).
+
+The record mapping logic lives in [`CloudKitRecordMapper.swift`](/Users/brianmurphy/Documents/Development/iOS/Baby%20Tracker/Packages/BabyTrackerSync/Sources/BabyTrackerSync/CloudKitRecordMapper.swift).
+
+---
+
+## Core Model
+
+### Container and Zones
+
+The app uses one CloudKit container:
+
+- `iCloud.com.adappt.BabyTracker`
+
+Each child gets its own custom record zone:
+
+- `child-<child UUID>`
+
+That means CloudKit data is partitioned by child, not by user.
+
+### Database Scopes
+
+- Owner devices read and write the child's zone in the `.private` database.
+- Caregiver devices read and write the same shared child through the `.shared` database.
+
+Apple’s [`CKDatabase`](https://developer.apple.com/documentation/cloudkit/ckdatabase?language=objc) documentation is the key reference for this model: each user has separate private and shared databases, and the shared database contains records other users have shared with them.
+
+Locally, each child stores a `CloudKitChildContext`, which tells the engine:
+
+- which zone belongs to the child
+- whether the child currently syncs through `.private` or `.shared`
+- which share record name belongs to that child
+
+---
+
+## What We Store
+
+Each child zone contains:
+
+- `Child`
+- `UserIdentity`
+- `Membership`
+- `BreastFeedEvent`
+- `BottleFeedEvent`
+- `SleepEvent`
+- `NappyEvent`
+- `CKShare` when the child is shared
+
+### Data Shape
+
+```mermaid
+flowchart TD
+    A[CloudKit Container]
+    A --> B[Private Database]
+    A --> C[Shared Database]
+
+    B --> Z[Zone child-UUID]
+    C --> SZ[Accepted shared zone child-UUID]
+
+    Z --> CH[Child]
+    Z --> SH[CKShare]
+    Z --> U1[UserIdentity owner]
+    Z --> U2[UserIdentity caregiver]
+    Z --> M1[Membership owner]
+    Z --> M2[Membership caregiver]
+    Z --> E1[Feed Events]
+    Z --> E2[Sleep Events]
+    Z --> E3[Nappy Events]
+```
+
+### Important CloudKit Sharing Rule
+
+CloudKit sharing does not automatically include every record in a zone just because it lives in the same zone.
+
+The share follows the root record hierarchy.
+
+Apple exposes that relationship on [`CKRecord.parent`](https://developer.apple.com/documentation/cloudkit/ckrecord), which is why the mapper now treats parent references as part of the share model instead of optional metadata.
+
+That is why memberships, user identities, and events now all point back to the child record with `record.parent`.
+
+Without that parent-child hierarchy:
+
+- the recipient can accept the share
+- the child record can appear
+- but the rest of the data can be missing from the shared graph
+
+That behavior is documented directly in [`CloudKitRecordMapper.swift`](/Users/brianmurphy/Documents/Development/iOS/Baby%20Tracker/Packages/BabyTrackerSync/Sources/BabyTrackerSync/CloudKitRecordMapper.swift).
+
+---
+
+## Sync Engine Lifecycle
+
+The engine exposes three main entry points:
+
+- `prepareForLaunch()`
+- `refreshForeground()`
+- `refreshAfterLocalWrite()`
+
+All of them feed into `refresh(reason:)`.
+
+### Normal Refresh Flow
+
+```mermaid
+flowchart TD
+    A[refresh(reason)] --> B[Check iCloud account]
+    B --> C[Resolve current CloudKit user]
+    C --> D[Pull shared database changes]
+    D --> E[Pull known child zones]
+    E --> F[Push pending local changes]
+```
+
+For `.localWrite`, the order changes slightly:
+
+- push first
+- then pull
+
+That is intentional. It helps a local write reach CloudKit before an incremental pull can replace local state with older remote data.
+
+### What `pullSharedDatabaseChanges()` Does
+
+This checks the shared database for:
+
+- newly accepted shared zones
+- updated shared zones
+- removed shared zones
+
+When a shared zone appears, the engine stores a `CloudKitChildContext` with `.shared` scope and immediately pulls that zone.
+
+### What `pullKnownChildZones()` Does
+
+For every child known locally, the engine:
+
+1. loads that child's `CloudKitChildContext`
+2. decides which database scope to use
+3. pulls CloudKit changes for that zone
+4. repairs edge cases if needed
+
+### What `pushPendingChanges()` Does
+
+The engine tracks local sync state. If a child, membership, user, or event is pending, it rebuilds that child's full zone snapshot and writes it to CloudKit.
+
+This is a zone-snapshot style push, not a tiny per-record mutation pipeline.
+
+That design keeps the implementation simpler, but it means stale local state is dangerous if the device has missed remote changes. One of today's fixes was specifically to protect against that.
+
+---
+
+## How Sharing Works
+
+### Owner Creates a Share
+
+When the owner shares a child:
+
+```mermaid
+sequenceDiagram
+    participant OwnerApp
+    participant SyncEngine
+    participant PrivateDB as CloudKit Private DB
+    participant Caregiver
+
+    OwnerApp->>SyncEngine: prepareShare(childID)
+    SyncEngine->>PrivateDB: ensure zone exists
+    SyncEngine->>PrivateDB: push full child zone snapshot
+    SyncEngine->>PrivateDB: create or load CKShare
+    SyncEngine-->>OwnerApp: share presentation
+    OwnerApp-->>Caregiver: send invite/link
+```
+
+Before presenting the share, the engine pushes the full zone snapshot. That is important because the shared graph should already be complete before another user accepts the share.
+
+### Caregiver Accepts a Share
+
+```mermaid
+sequenceDiagram
+    participant iOS
+    participant SceneDelegate
+    participant Bridge
+    participant AcceptanceHandler
+    participant SyncEngine
+    participant SharedDB as CloudKit Shared DB
+
+    iOS->>SceneDelegate: userDidAcceptCloudKitShareWith
+    SceneDelegate->>Bridge: handle(metadata)
+    Bridge->>AcceptanceHandler: accept(metadata)
+    AcceptanceHandler->>SyncEngine: accept(metadata)
+    SyncEngine->>SharedDB: client.accept
+    SyncEngine->>SharedDB: force full pull of accepted zone
+    SyncEngine->>SyncEngine: ensure local caregiver membership
+    SyncEngine->>SharedDB: refresh after local write
+```
+
+Two parts of that flow matter a lot:
+
+- the engine does a forced full pull immediately after `client.accept`
+- the engine explicitly ensures a local caregiver membership exists
+
+Those two steps were both added because "accept share" by itself was not enough to guarantee a fully usable local child.
+
+Apple’s sharing docs support this model from two angles:
+
+- [`CKShare.Participant`](https://developer.apple.com/documentation/cloudkit/ckshare/participant) documents that accepted participants access shared records through the shared database.
+- [`CKShare.Metadata.hierarchicalRootRecordID`](https://developer.apple.com/documentation/cloudkit/ckshare/metadata/hierarchicalrootrecordid?language=objc) is the metadata field we use to identify the accepted root record and zone for the forced pull.
+
+---
+
+## How Data Moves Between Devices
+
+### Owner to Caregiver
+
+```mermaid
+flowchart LR
+    A[Owner writes event locally]
+    A --> B[Event marked pending]
+    B --> C[pushPendingChanges]
+    C --> D[Owner private child zone updated]
+    D --> E[CloudKit share exposes child hierarchy]
+    E --> F[Caregiver shared zone pull]
+    F --> G[Event saved into caregiver local store]
+```
+
+### Caregiver to Owner
+
+```mermaid
+flowchart LR
+    A[Caregiver writes event locally]
+    A --> B[Event marked pending]
+    B --> C[pushPendingChanges in shared scope]
+    C --> D[Shared child zone updated]
+    D --> E[Owner private zone must reconcile]
+    E --> F[Owner full private-zone pull]
+    F --> G[Event saved into owner local store]
+```
+
+The second path was the one that was broken during today's investigation.
+
+---
+
+## What We Found Today
+
+### 1. Share Acceptance Did Not Guarantee Local Data Was Downloaded
+
+Originally, accepting a share relied on a normal foreground refresh and hoped the shared database change feed would surface the accepted zone immediately.
+
+That was not reliable enough.
+
+Result:
+
+- share acceptance could appear successful
+- but the shared child might not be fully downloaded locally yet
+
+### 2. Sharing Initially Included Only the `Child` Record
+
+We confirmed that recipients could sometimes see the child but not events, memberships, or users.
+
+Root cause:
+
+- those records existed in the same zone
+- but they were not attached to the child as descendants in the CloudKit share hierarchy
+
+Result:
+
+- the share root was visible
+- the rest of the child data was not guaranteed to come through
+
+### 3. Caregiver Writes Were Landing, but Owners Were Not Always Seeing Them
+
+The most subtle bug we found was:
+
+- caregiver writes to the shared zone succeeded
+- the owner refreshed
+- the owner's incremental private-zone pull sometimes reported zero changes
+- the owner could then push a stale local snapshot back to CloudKit
+
+This was the key owner-side reconciliation bug.
+
+### 4. Local Context Alone Was Not Enough to Tell Whether a Private Zone Was Truly Shared
+
+The local context can already contain a `shareRecordName` before a real `CKShare` exists.
+
+So the engine cannot assume:
+
+- "private zone with a share record name" means
+- "this zone definitely needs owner shared-zone reconciliation"
+
+It now verifies that a real `CKShare` record exists in the private zone before taking the owner-side reconciliation path.
+
+---
+
+## Fixes Applied
+
+### Fix 1. Force a Full Pull After Share Acceptance
+
+After `client.accept`, the engine now:
+
+1. extracts the accepted share's root record and zone
+2. forces a full pull of that shared zone with a nil anchor
+3. fails the accept flow if the follow-up refresh fails
+
+This prevents the app from treating share acceptance as complete before the shared data has actually been downloaded.
+
+Relevant plan:
+
+- [`019-force-full-shared-zone-pull-on-share-accept.md`](/Users/brianmurphy/Documents/Development/iOS/Baby%20Tracker/docs/plans/019-force-full-shared-zone-pull-on-share-accept.md)
+
+### Fix 2. Make the Child Share Include the Full Record Hierarchy
+
+`Membership`, `UserIdentity`, and all event records now set `record.parent` to the child record.
+
+This makes the full child graph part of the CloudKit share instead of sharing only the child root.
+
+Relevant plan:
+
+- [`020-share-full-child-hierarchy.md`](/Users/brianmurphy/Documents/Development/iOS/Baby%20Tracker/docs/plans/020-share-full-child-hierarchy.md)
+
+### Fix 3. Reconcile Owner Shared Private Zones Before Reading or Pushing
+
+For owner devices, if a child is in a private zone that truly has a `CKShare`, the engine now forces a full zone pull:
+
+- during normal zone refresh
+- immediately before pushing that zone
+
+This prevents the owner from continuing with a stale local snapshot when CloudKit incremental changes have not surfaced caregiver-authored records yet.
+
+Relevant plan:
+
+- [`022-reconcile-owner-shared-private-zones.md`](/Users/brianmurphy/Documents/Development/iOS/Baby%20Tracker/docs/plans/022-reconcile-owner-shared-private-zones.md)
+
+### Fix 4. Trim Diagnostic Noise and Keep the Why in Comments
+
+During debugging, we added very verbose sync logs to compare zone scope, owner names, and exact pushed records across devices.
+
+Those logs were useful temporarily, but they were intentionally removed once the root causes were understood. The long-term explanation now lives in comments in the sync engine and record mapper.
+
+Relevant plan:
+
+- [`023-trim-cloudkit-diagnostics-and-document-why.md`](/Users/brianmurphy/Documents/Development/iOS/Baby%20Tracker/docs/plans/023-trim-cloudkit-diagnostics-and-document-why.md)
+
+---
+
+## Conflict Handling
+
+For events, the engine uses last-write-wins based on event metadata timestamps.
+
+If the engine sees:
+
+- a local event
+- a remote event with the same ID
+
+it compares metadata and keeps whichever side is newer.
+
+This logic is important in both directions:
+
+- during pull, so stale CloudKit data does not overwrite a newer local event
+- during push, so an older local snapshot does not overwrite a newer remote event
+
+Non-event records are simpler and are treated more like authoritative zone state.
+
+---
+
+## Current Operational Notes
+
+### What Is Working Now
+
+- share acceptance forces a real local download
+- shared children now include events, memberships, and users
+- caregiver-authored events are reconciled back to the owner before the owner pushes again
+- event attribution is preserved through `createdBy` and `updatedBy`
+
+### What Still Triggers Sync
+
+Today, sync is primarily driven by:
+
+- app launch
+- app foreground
+- local writes
+
+The app is not yet fully wired for background CloudKit push notifications. That means foregrounding the app is still the normal way to pick up remote changes promptly.
+
+### Background Notifications
+
+The project already has some capability-level setup for remote notifications, but the full CloudKit subscription and silent-push handling flow is not implemented yet.
+
+That work can be added later without changing the core sharing model described here.
+
+When we add that work, the Apple docs to follow are:
+
+- [`Remote Records`](https://developer.apple.com/documentation/cloudkit/remote-records)
+- [`CKFetchRecordZoneChangesOperation`](https://developer.apple.com/documentation/CloudKit/CKFetchRecordZoneChangesOperation)
+
+Those docs describe the pattern CloudKit expects:
+
+- keep change tokens
+- use subscriptions for remote notifications
+- fetch database and zone changes after receiving push notifications
+
+---
+
+## Mental Model to Keep
+
+The simplest accurate model is:
+
+1. A child is the sync boundary.
+2. A child maps to one CloudKit zone.
+3. Sharing shares that child's hierarchy.
+4. The owner sees that zone in `.private`.
+5. The caregiver sees that same child through `.shared`.
+6. Owner devices must sometimes fully reconcile shared private zones before trusting incremental pulls.
+
+If any future sharing bug appears, the first questions to ask are:
+
+1. Is the record in the correct child zone?
+2. Is the record a descendant of the child root?
+3. Is the device reading the correct database scope?
+4. Is the owner reconciling a shared private zone before pushing?
+
+---
+
+## Related Files
+
+- [`CloudKitSyncEngine.swift`](/Users/brianmurphy/Documents/Development/iOS/Baby%20Tracker/Packages/BabyTrackerSync/Sources/BabyTrackerSync/CloudKitSyncEngine.swift)
+- [`CloudKitRecordMapper.swift`](/Users/brianmurphy/Documents/Development/iOS/Baby%20Tracker/Packages/BabyTrackerSync/Sources/BabyTrackerSync/CloudKitRecordMapper.swift)
+- [`LiveCloudKitClient.swift`](/Users/brianmurphy/Documents/Development/iOS/Baby%20Tracker/Packages/BabyTrackerSync/Sources/BabyTrackerSync/LiveCloudKitClient.swift)
+- [`CloudKitShareSceneDelegate.swift`](/Users/brianmurphy/Documents/Development/iOS/Baby%20Tracker/Baby%20Tracker/App/CloudKitShareSceneDelegate.swift)
+- [`CloudKitShareAcceptanceBridge.swift`](/Users/brianmurphy/Documents/Development/iOS/Baby%20Tracker/Baby%20Tracker/App/CloudKitShareAcceptanceBridge.swift)
+- [`ShareAcceptanceHandler.swift`](/Users/brianmurphy/Documents/Development/iOS/Baby%20Tracker/Packages/BabyTrackerSync/Sources/BabyTrackerSync/ShareAcceptanceHandler.swift)

--- a/docs/plans/019-force-full-shared-zone-pull-on-share-accept.md
+++ b/docs/plans/019-force-full-shared-zone-pull-on-share-accept.md
@@ -1,0 +1,19 @@
+## Goal
+
+Ensure that when a user accepts a CloudKit share, the app forces a full pull of the accepted shared zone so the shared child data is downloaded locally immediately.
+
+## Plan
+
+1. Update the share acceptance flow in `CloudKitSyncEngine`.
+   - Accept the share with CloudKit.
+   - Force a full fetch of the accepted shared zone using the zone from the share metadata.
+   - Keep the existing follow-up refreshes so normal sync state stays consistent.
+
+2. Make acceptance fail when the forced pull or follow-up refresh fails.
+   - Do not report share acceptance as complete if the shared data could not be fetched locally.
+
+3. Add focused tests for the forced-pull path.
+   - Verify the accepted shared zone is fetched with a nil token.
+   - Verify the fetched child data is saved locally.
+
+- [x] Complete

--- a/docs/plans/020-share-full-child-hierarchy.md
+++ b/docs/plans/020-share-full-child-hierarchy.md
@@ -1,0 +1,17 @@
+## Goal
+
+Ensure CloudKit sharing includes the full child hierarchy, not just the root child record.
+
+## Approach
+
+CloudKit sharing follows the share root's parent-child record hierarchy. The current mapper saves memberships, user identities, and events in the same zone, but does not attach them to the child record with a `parent` reference. That allows the child record to appear in a share while the rest of the child data remains outside the shared hierarchy.
+
+Update the CloudKit record mapper so:
+
+- membership records point to the child record as their parent
+- user identity records point to the child record as their parent
+- event records point to the child record as their parent
+
+Then add mapper tests that verify those parent references are present.
+
+- [x] Complete

--- a/docs/plans/022-reconcile-owner-shared-private-zones.md
+++ b/docs/plans/022-reconcile-owner-shared-private-zones.md
@@ -1,0 +1,19 @@
+## Goal
+
+Ensure owner devices receive caregiver-authored records from shared child zones and do not overwrite missing remote changes with stale local snapshots.
+
+## Approach
+
+The logs show caregiver writes land in the expected shared zone, but owner devices sometimes see zero incremental changes in the corresponding private zone. The current sync flow can then push a stale local snapshot back to the owner's private zone.
+
+Add an owner-side reconciliation rule for private zones that already have a share:
+
+- detect private child contexts that represent shared zones
+- force a full zone pull for those contexts during normal refreshes
+- force a full reconciliation pull immediately before pushing one of those zones
+
+This keeps the owner's local state aligned with caregiver-authored records before any private-zone push occurs.
+
+Also add a focused sync test that proves a stale owner snapshot is reconciled from the private shared zone before a local-write refresh pushes data.
+
+- [x] Complete

--- a/docs/plans/023-trim-cloudkit-diagnostics-and-document-why.md
+++ b/docs/plans/023-trim-cloudkit-diagnostics-and-document-why.md
@@ -1,0 +1,18 @@
+## Goal
+
+Keep the CloudKit sharing fixes, but remove the temporary diagnostic noise and leave behind comments that explain the non-obvious sync behavior.
+
+## Approach
+
+The recent fixes added detailed push and pull logging so the owner and caregiver sync paths could be compared on real devices. That helped diagnose the issue, but the logs are too noisy to keep as the long-term explanation of the design.
+
+Update the sync code so:
+
+- temporary diagnostic logs are removed
+- the share-accept path explains why it forces a full pull
+- the owner refresh and push paths explain why shared private zones are reconciled before continuing
+- the record mapper explains why shared records need a parent-child hierarchy
+
+Also remove the captured device log from the staged project changes.
+
+- [x] Complete


### PR DESCRIPTION
## Summary

This PR hardens the custom CloudKit sharing flow so shared child data is fully available after acceptance and caregiver-authored records reliably make it back to the owner.

It fixes three related issues:

- accepting a share did not guarantee the shared zone was fully pulled locally
- shared children could expose only the `Child` record because the rest of the data was not part of the share hierarchy
- owner devices could miss caregiver-authored records in shared private zones and then push a stale local snapshot back to CloudKit

## What Changed

- force a full shared-zone pull immediately after `client.accept`
- fail the acceptance path if the follow-up refresh fails
- attach memberships, user identities, and events to the child root record with `record.parent`
- reconcile owner-side shared private zones with a full pull before normal refreshes and before pushing local changes
- add focused regression tests for accepted-share full pulls, share hierarchy parenting, and owner reconciliation
- add a CloudKit sync guide documenting the architecture, flows, and fixes
- trim temporary diagnostic logging and keep the long-term rationale as code comments instead

## Data Shape

```mermaid
flowchart TD
    A[CloudKit Container]
    A --> B[Private Database]
    A --> C[Shared Database]

    B --> Z[Zone child-UUID]
    C --> SZ[Accepted shared zone child-UUID]

    Z --> CH[Child]
    Z --> SH[CKShare]
    Z --> U1[UserIdentity owner]
    Z --> U2[UserIdentity caregiver]
    Z --> M1[Membership owner]
    Z --> M2[Membership caregiver]
    Z --> E1[Feed Events]
    Z --> E2[Sleep Events]
    Z --> E3[Nappy Events]
```

## Share Acceptance Flow

```mermaid
sequenceDiagram
    participant iOS
    participant SceneDelegate
    participant Bridge
    participant AcceptanceHandler
    participant SyncEngine
    participant SharedDB as CloudKit Shared DB

    iOS->>SceneDelegate: userDidAcceptCloudKitShareWith
    SceneDelegate->>Bridge: handle(metadata)
    Bridge->>AcceptanceHandler: accept(metadata)
    AcceptanceHandler->>SyncEngine: accept(metadata)
    SyncEngine->>SharedDB: client.accept
    SyncEngine->>SharedDB: full pull of accepted zone
    SyncEngine->>SyncEngine: ensure local caregiver membership
    SyncEngine->>SharedDB: refresh after local write
```

## Caregiver To Owner Sync Path

```mermaid
flowchart LR
    A[Caregiver writes event locally]
    A --> B[Event marked pending]
    B --> C[pushPendingChanges in shared scope]
    C --> D[Shared child zone updated]
    D --> E[Owner private zone reconciles]
    E --> F[Owner full private-zone pull]
    F --> G[Event saved into owner local store]
```

## Testing

```text
xcodebuild -project 'Baby Tracker.xcodeproj' -scheme 'Baby Tracker' -testPlan 'UnitTests' -only-testing:'Baby TrackerTests/CloudKitSyncEngineTests' -only-testing:'Baby TrackerTests/CloudKitRecordMapperTests' -destination 'platform=iOS Simulator,name=iPhone 17,OS=26.2' -derivedDataPath /tmp/BabyTrackerDerivedData test
```

## Docs

- `docs/CloudKit_Sync_Engine_Guide.md`
- `docs/plans/019-force-full-shared-zone-pull-on-share-accept.md`
- `docs/plans/020-share-full-child-hierarchy.md`
- `docs/plans/022-reconcile-owner-shared-private-zones.md`
- `docs/plans/023-trim-cloudkit-diagnostics-and-document-why.md`
https://github.com/murphb52/BabyTracker/issues/18
