### PR TITLE
Add local caregiver notifications for remote CloudKit updates

### DIFF
--- a/Baby Tracker/App/AppContainer.swift
+++ b/Baby Tracker/App/AppContainer.swift
@@ -39,6 +39,9 @@ struct AppContainer {
         let liveActivityManager: any FeedLiveActivityManaging = launchConfiguration.usesNoOpLiveActivities ?
             NoOpFeedLiveActivityManager() :
             FeedLiveActivityManager()
+        let localNotificationManager: any LocalNotificationManaging = launchConfiguration.usesUnavailableCloudKitClient ?
+            NoOpLocalNotificationManager() :
+            SystemLocalNotificationManager()
         let syncEngine = CloudKitSyncEngine(
             childRepository: childRepository,
             userIdentityRepository: userIdentityRepository,
@@ -54,7 +57,8 @@ struct AppContainer {
             childSelectionStore: childSelectionStore,
             eventRepository: eventRepository,
             syncEngine: syncEngine,
-            liveActivityManager: liveActivityManager
+            liveActivityManager: liveActivityManager,
+            localNotificationManager: localNotificationManager
         )
         let shareAcceptanceHandler = ShareAcceptanceHandler(syncEngine: syncEngine) {
             appModel.load()
@@ -107,7 +111,8 @@ struct AppContainer {
             childSelectionStore: childSelectionStore,
             eventRepository: eventRepository,
             syncEngine: syncEngine,
-            liveActivityManager: NoOpFeedLiveActivityManager()
+            liveActivityManager: NoOpFeedLiveActivityManager(),
+            localNotificationManager: NoOpLocalNotificationManager()
         )
         let shareAcceptanceHandler = ShareAcceptanceHandler(syncEngine: syncEngine) {
             appModel.load()

--- a/Baby Tracker/App/AppRootView.swift
+++ b/Baby Tracker/App/AppRootView.swift
@@ -54,6 +54,9 @@ struct AppRootView: View {
                 model.refreshSyncStatus()
             }
         }
+        .task {
+            model.requestNotificationAuthorizationIfNeeded()
+        }
         .safeAreaInset(edge: .bottom) {
             if let undoDeleteMessage = model.undoDeleteMessage {
                 UndoBannerView(

--- a/Baby Tracker/App/SystemLocalNotificationManager.swift
+++ b/Baby Tracker/App/SystemLocalNotificationManager.swift
@@ -1,0 +1,42 @@
+import BabyTrackerDomain
+import BabyTrackerFeature
+import Foundation
+import UserNotifications
+
+@MainActor
+final class SystemLocalNotificationManager: LocalNotificationManaging {
+    private let notificationCenter: UNUserNotificationCenter
+
+    init(notificationCenter: UNUserNotificationCenter = .current()) {
+        self.notificationCenter = notificationCenter
+    }
+
+    func requestAuthorizationIfNeeded() async {
+        let settings = await notificationCenter.notificationSettings()
+        guard settings.authorizationStatus == .notDetermined else {
+            return
+        }
+
+        _ = try? await notificationCenter.requestAuthorization(options: [.alert, .sound, .badge])
+    }
+
+    func scheduleRemoteSyncNotification(_ content: RemoteCaregiverNotificationContent) async {
+        let settings = await notificationCenter.notificationSettings()
+        guard settings.authorizationStatus == .authorized || settings.authorizationStatus == .provisional else {
+            return
+        }
+
+        let notificationContent = UNMutableNotificationContent()
+        notificationContent.title = content.title
+        notificationContent.body = content.body
+        notificationContent.sound = .default
+
+        let request = UNNotificationRequest(
+            identifier: UUID().uuidString,
+            content: notificationContent,
+            trigger: nil
+        )
+
+        try? await notificationCenter.add(request)
+    }
+}

--- a/Packages/BabyTrackerDomain/Sources/BabyTrackerDomain/RemoteCaregiverEventChange.swift
+++ b/Packages/BabyTrackerDomain/Sources/BabyTrackerDomain/RemoteCaregiverEventChange.swift
@@ -1,0 +1,11 @@
+import Foundation
+
+public struct RemoteCaregiverEventChange: Equatable, Sendable {
+    public let actorDisplayName: String
+    public let event: BabyEvent
+
+    public init(actorDisplayName: String, event: BabyEvent) {
+        self.actorDisplayName = actorDisplayName
+        self.event = event
+    }
+}

--- a/Packages/BabyTrackerDomain/Sources/BabyTrackerDomain/RemoteCaregiverNotificationContent.swift
+++ b/Packages/BabyTrackerDomain/Sources/BabyTrackerDomain/RemoteCaregiverNotificationContent.swift
@@ -1,0 +1,11 @@
+import Foundation
+
+public struct RemoteCaregiverNotificationContent: Equatable, Sendable {
+    public let title: String
+    public let body: String
+
+    public init(title: String, body: String) {
+        self.title = title
+        self.body = body
+    }
+}

--- a/Packages/BabyTrackerDomain/Sources/BabyTrackerDomain/UseCases/BuildRemoteCaregiverNotificationUseCase.swift
+++ b/Packages/BabyTrackerDomain/Sources/BabyTrackerDomain/UseCases/BuildRemoteCaregiverNotificationUseCase.swift
@@ -1,0 +1,78 @@
+import Foundation
+
+public struct BuildRemoteCaregiverNotificationUseCase: Sendable {
+    public struct Input: Sendable {
+        public let changes: [RemoteCaregiverEventChange]
+
+        public init(changes: [RemoteCaregiverEventChange]) {
+            self.changes = changes
+        }
+    }
+
+    private let formatTime: @Sendable (Date) -> String
+
+    public init(formatTime: @escaping @Sendable (Date) -> String = {
+        let formatter = DateFormatter()
+        formatter.timeStyle = .short
+        formatter.dateStyle = .none
+        return formatter.string(from: $0)
+    }) {
+        self.formatTime = formatTime
+    }
+
+    public func execute(_ input: Input) -> RemoteCaregiverNotificationContent? {
+        guard !input.changes.isEmpty else {
+            return nil
+        }
+
+        if input.changes.count == 1, let change = input.changes.first {
+            return .init(
+                title: "Baby Tracker",
+                body: message(for: change)
+            )
+        }
+
+        let distinctCaregivers = Set(input.changes.map(\.actorDisplayName)).count
+        if distinctCaregivers == 1, let caregiver = input.changes.first?.actorDisplayName {
+            return .init(
+                title: "Baby Tracker",
+                body: "\(caregiver) logged \(input.changes.count) updates."
+            )
+        }
+
+        return .init(
+            title: "Baby Tracker",
+            body: "\(input.changes.count) new updates from caregivers."
+        )
+    }
+
+    private func message(for change: RemoteCaregiverEventChange) -> String {
+        switch change.event {
+        case let .sleep(event):
+            if event.endedAt == nil {
+                return "\(change.actorDisplayName) started a sleep timer."
+            }
+
+            return "\(change.actorDisplayName) logged a sleep at \(formatTime(event.metadata.occurredAt))."
+        case let .nappy(event):
+            return "\(change.actorDisplayName) logged a \(nappyDescriptor(for: event.type)) nappy at \(formatTime(event.metadata.occurredAt))."
+        case let .bottleFeed(event):
+            return "\(change.actorDisplayName) logged a bottle feed at \(formatTime(event.metadata.occurredAt))."
+        case let .breastFeed(event):
+            return "\(change.actorDisplayName) logged a breast feed at \(formatTime(event.metadata.occurredAt))."
+        }
+    }
+
+    private func nappyDescriptor(for type: NappyType) -> String {
+        switch type {
+        case .dry:
+            "dry"
+        case .wee:
+            "wet"
+        case .poo:
+            "dirty"
+        case .mixed:
+            "mixed"
+        }
+    }
+}

--- a/Packages/BabyTrackerDomain/Tests/BabyTrackerDomainTests/BuildRemoteCaregiverNotificationUseCaseTests.swift
+++ b/Packages/BabyTrackerDomain/Tests/BabyTrackerDomainTests/BuildRemoteCaregiverNotificationUseCaseTests.swift
@@ -1,0 +1,67 @@
+import XCTest
+@testable import BabyTrackerDomain
+
+final class BuildRemoteCaregiverNotificationUseCaseTests: XCTestCase {
+    func testSingleSleepStartBuildsSpecificMessage() throws {
+        let caregiver = try UserIdentity(displayName: "Alex")
+        let child = try Child(name: "Robin", birthDate: nil, createdBy: caregiver.id)
+        let sleep = try SleepEvent(
+            metadata: EventMetadata(
+                childID: child.id,
+                occurredAt: Date(timeIntervalSince1970: 100),
+                createdAt: Date(timeIntervalSince1970: 100),
+                createdBy: caregiver.id,
+                updatedAt: Date(timeIntervalSince1970: 100),
+                updatedBy: caregiver.id
+            ),
+            startedAt: Date(timeIntervalSince1970: 100)
+        )
+
+        let useCase = BuildRemoteCaregiverNotificationUseCase(formatTime: { _ in "10:00 AM" })
+        let content = useCase.execute(.init(changes: [
+            .init(actorDisplayName: caregiver.displayName, event: .sleep(sleep)),
+        ]))
+
+        XCTAssertEqual(content?.body, "Alex started a sleep timer.")
+    }
+
+    func testSingleNappyBuildsWetMessage() throws {
+        let caregiver = try UserIdentity(displayName: "Sam")
+        let child = try Child(name: "Robin", birthDate: nil, createdBy: caregiver.id)
+        let nappy = try NappyEvent(
+            metadata: EventMetadata(
+                childID: child.id,
+                occurredAt: Date(timeIntervalSince1970: 100),
+                createdBy: caregiver.id,
+                updatedBy: caregiver.id
+            ),
+            type: .wee
+        )
+
+        let useCase = BuildRemoteCaregiverNotificationUseCase(formatTime: { _ in "11:45 AM" })
+        let content = useCase.execute(.init(changes: [
+            .init(actorDisplayName: caregiver.displayName, event: .nappy(nappy)),
+        ]))
+
+        XCTAssertEqual(content?.body, "Sam logged a wet nappy at 11:45 AM.")
+    }
+
+    func testManyChangesFromMultipleCaregiversBuildsAggregateMessage() throws {
+        let caregiverOne = try UserIdentity(displayName: "Sam")
+        let caregiverTwo = try UserIdentity(displayName: "Alex")
+        let child = try Child(name: "Robin", birthDate: nil, createdBy: caregiverOne.id)
+        let feed = try BottleFeedEvent(
+            metadata: EventMetadata(childID: child.id, occurredAt: .now, createdBy: caregiverOne.id, updatedBy: caregiverOne.id),
+            amountMilliliters: 120,
+            milkType: .formula
+        )
+
+        let useCase = BuildRemoteCaregiverNotificationUseCase()
+        let content = useCase.execute(.init(changes: [
+            .init(actorDisplayName: caregiverOne.displayName, event: .bottleFeed(feed)),
+            .init(actorDisplayName: caregiverTwo.displayName, event: .bottleFeed(feed)),
+        ]))
+
+        XCTAssertEqual(content?.body, "2 new updates from caregivers.")
+    }
+}

--- a/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/AppModel.swift
+++ b/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/AppModel.swift
@@ -28,7 +28,9 @@ public final class AppModel {
     private let eventRepository: EventRepository
     private let syncEngine: CloudKitSyncEngine
     private let liveActivityManager: any FeedLiveActivityManaging
+    private let localNotificationManager: any LocalNotificationManaging
     private let buildTimelineStripDatasetUseCase = BuildTimelineStripDatasetUseCase()
+    private let buildRemoteNotificationUseCase = BuildRemoteCaregiverNotificationUseCase()
     private let calendar = Calendar.autoupdatingCurrent
     private var timelineSelectedDay = Calendar.autoupdatingCurrent.startOfDay(for: .now)
     private var timelineDisplayMode: TimelineScreenState.DisplayMode = .day
@@ -44,7 +46,8 @@ public final class AppModel {
         childSelectionStore: any ChildSelectionStore,
         eventRepository: EventRepository,
         syncEngine: CloudKitSyncEngine,
-        liveActivityManager: any FeedLiveActivityManaging = NoOpFeedLiveActivityManager()
+        liveActivityManager: any FeedLiveActivityManaging = NoOpFeedLiveActivityManager(),
+        localNotificationManager: any LocalNotificationManaging = NoOpLocalNotificationManager()
     ) {
         self.childRepository = childRepository
         self.userIdentityRepository = userIdentityRepository
@@ -53,6 +56,7 @@ public final class AppModel {
         self.eventRepository = eventRepository
         self.syncEngine = syncEngine
         self.liveActivityManager = liveActivityManager
+        self.localNotificationManager = localNotificationManager
     }
 
     public func load(performLaunchSync: Bool = true) {
@@ -92,8 +96,15 @@ public final class AppModel {
 
     public func refreshAfterRemoteNotification() async -> SyncStatusSummary {
         let summary = await syncEngine.refreshAfterRemoteNotification()
+        await scheduleRemoteSyncNotificationIfNeeded()
         refresh(selecting: childSelectionStore.loadSelectedChildID())
         return summary
+    }
+
+    public func requestNotificationAuthorizationIfNeeded() {
+        Task { @MainActor in
+            await localNotificationManager.requestAuthorizationIfNeeded()
+        }
     }
 
     public func hardDeleteAllData() {
@@ -1592,5 +1603,15 @@ public final class AppModel {
 
     public func dismissNestImportResult() {
         nestImportState = .idle
+    }
+
+    private func scheduleRemoteSyncNotificationIfNeeded() async {
+        let changes = syncEngine.consumeRemoteCaregiverEventChanges()
+        let input = BuildRemoteCaregiverNotificationUseCase.Input(changes: changes)
+        guard let content = buildRemoteNotificationUseCase.execute(input) else {
+            return
+        }
+
+        await localNotificationManager.scheduleRemoteSyncNotification(content)
     }
 }

--- a/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/LocalNotificationManaging.swift
+++ b/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/LocalNotificationManaging.swift
@@ -1,0 +1,8 @@
+import BabyTrackerDomain
+import Foundation
+
+@MainActor
+public protocol LocalNotificationManaging: AnyObject {
+    func requestAuthorizationIfNeeded() async
+    func scheduleRemoteSyncNotification(_ content: RemoteCaregiverNotificationContent) async
+}

--- a/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/NoOpLocalNotificationManager.swift
+++ b/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/NoOpLocalNotificationManager.swift
@@ -1,0 +1,13 @@
+import BabyTrackerDomain
+import Foundation
+
+@MainActor
+public final class NoOpLocalNotificationManager: LocalNotificationManaging {
+    public init() {}
+
+    public func requestAuthorizationIfNeeded() async {}
+
+    public func scheduleRemoteSyncNotification(_ content: RemoteCaregiverNotificationContent) async {
+        _ = content
+    }
+}

--- a/Packages/BabyTrackerSync/Sources/BabyTrackerSync/CloudKitSyncEngine.swift
+++ b/Packages/BabyTrackerSync/Sources/BabyTrackerSync/CloudKitSyncEngine.swift
@@ -31,6 +31,10 @@ public final class CloudKitSyncEngine {
 
     private var pendingInvitesByChildID: [UUID: [CloudKitPendingInvite]] = [:]
     private var hasEnsuredDatabaseSubscriptions = false
+    private var remoteCaregiverEventChanges: [RemoteCaregiverEventChange] = []
+    private var shouldCollectRemoteCaregiverEvents = false
+    private var currentLocalUserID: UUID?
+    private var cachedUserDisplayNames: [UUID: String] = [:]
 
     private let logger = Logger(subsystem: "com.adappt.BabyTracker", category: "CloudKitSync")
 
@@ -68,6 +72,12 @@ public final class CloudKitSyncEngine {
 
     public func pendingInvites(for childID: UUID) -> [CloudKitPendingInvite] {
         pendingInvitesByChildID[childID] ?? []
+    }
+
+    public func consumeRemoteCaregiverEventChanges() -> [RemoteCaregiverEventChange] {
+        let changes = remoteCaregiverEventChanges
+        remoteCaregiverEventChanges = []
+        return changes
     }
 
     public func prepareShare(
@@ -276,6 +286,11 @@ public final class CloudKitSyncEngine {
     }
 
     private func refresh(reason: RefreshReason) async -> SyncStatusSummary {
+        shouldCollectRemoteCaregiverEvents = reason == .remoteNotification
+        remoteCaregiverEventChanges = []
+        cachedUserDisplayNames = [:]
+        currentLocalUserID = try? userIdentityRepository.loadLocalUser()?.id
+
         do {
             if reason == .launch {
                 logger.info("Launch sync starting")
@@ -826,9 +841,40 @@ public final class CloudKitSyncEngine {
                 lastSyncedAt: .now,
                 lastSyncErrorCode: nil
             )
+            try trackRemoteCaregiverChange(for: event)
         default:
             return
         }
+    }
+
+    private func trackRemoteCaregiverChange(for event: BabyEvent) throws {
+        guard shouldCollectRemoteCaregiverEvents else {
+            return
+        }
+
+        let actorID = event.metadata.updatedBy
+        guard actorID != currentLocalUserID else {
+            return
+        }
+
+        let actorDisplayName = try displayName(for: actorID)
+        remoteCaregiverEventChanges.append(
+            RemoteCaregiverEventChange(
+                actorDisplayName: actorDisplayName,
+                event: event
+            )
+        )
+    }
+
+    private func displayName(for userID: UUID) throws -> String {
+        if let cached = cachedUserDisplayNames[userID] {
+            return cached
+        }
+
+        let user = try userIdentityRepository.loadUsers(for: [userID]).first
+        let displayName = user?.displayName ?? "Another caregiver"
+        cachedUserDisplayNames[userID] = displayName
+        return displayName
     }
 
     private func applyDeletion(


### PR DESCRIPTION
## Summary
- add new domain models and use case to build user-facing local notification content from caregiver-originated remote sync event changes
- extend `CloudKitSyncEngine` to collect remote event changes during background-push refreshes, filter out local-user writes, and expose consumable change batches
- add `LocalNotificationManaging` abstraction and no-op implementation in Feature layer, wire it into `AppModel`, and schedule notifications after remote-refresh syncs
- implement `SystemLocalNotificationManager` in the app target using `UNUserNotificationCenter`
- request notification permission when the app first opens (`AppRootView.task`)

## Testing
- `swift test --package-path Packages/BabyTrackerDomain`

## Notes
- notification permission prompts are only requested when status is `.notDetermined`
- notification content aggregates multiple changes into a summary message when needed

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c707b162c4832fb053b46efcba462d)