### PR TITLE
[codex] Add domain haptic feedback support

### DIFF
--- a/Baby Tracker/App/AppContainer.swift
+++ b/Baby Tracker/App/AppContainer.swift
@@ -42,6 +42,7 @@ struct AppContainer {
         let localNotificationManager: any LocalNotificationManaging = launchConfiguration.usesUnavailableCloudKitClient ?
             NoOpLocalNotificationManager() :
             SystemLocalNotificationManager()
+        let hapticFeedbackProvider: any HapticFeedbackProviding = SystemHapticFeedbackProvider()
         let syncEngine = CloudKitSyncEngine(
             childRepository: childRepository,
             userIdentityRepository: userIdentityRepository,
@@ -58,7 +59,8 @@ struct AppContainer {
             eventRepository: eventRepository,
             syncEngine: syncEngine,
             liveActivityManager: liveActivityManager,
-            localNotificationManager: localNotificationManager
+            localNotificationManager: localNotificationManager,
+            hapticFeedbackProvider: hapticFeedbackProvider
         )
         let shareAcceptanceHandler = ShareAcceptanceHandler(syncEngine: syncEngine) {
             appModel.load()
@@ -112,7 +114,8 @@ struct AppContainer {
             eventRepository: eventRepository,
             syncEngine: syncEngine,
             liveActivityManager: NoOpFeedLiveActivityManager(),
-            localNotificationManager: NoOpLocalNotificationManager()
+            localNotificationManager: NoOpLocalNotificationManager(),
+            hapticFeedbackProvider: NoOpHapticFeedbackProvider()
         )
         let shareAcceptanceHandler = ShareAcceptanceHandler(syncEngine: syncEngine) {
             appModel.load()

--- a/Baby Tracker/App/SystemHapticFeedbackProvider.swift
+++ b/Baby Tracker/App/SystemHapticFeedbackProvider.swift
@@ -1,0 +1,39 @@
+import BabyTrackerDomain
+import UIKit
+
+@MainActor
+final class SystemHapticFeedbackProvider: HapticFeedbackProviding {
+    private let notificationGenerator = UINotificationFeedbackGenerator()
+    private let selectionGenerator = UISelectionFeedbackGenerator()
+    private let mediumImpactGenerator = UIImpactFeedbackGenerator(style: .medium)
+
+    init() {
+        prepareGenerators()
+    }
+
+    func play(_ event: HapticEvent) {
+        switch event {
+        case .actionSucceeded:
+            notificationGenerator.notificationOccurred(.success)
+            notificationGenerator.prepare()
+        case .actionFailed:
+            notificationGenerator.notificationOccurred(.error)
+            notificationGenerator.prepare()
+        case .selectionChanged:
+            selectionGenerator.selectionChanged()
+            selectionGenerator.prepare()
+        case .destructiveActionConfirmed:
+            notificationGenerator.notificationOccurred(.warning)
+            notificationGenerator.prepare()
+        case .sleepStarted, .sleepEnded:
+            mediumImpactGenerator.impactOccurred()
+            mediumImpactGenerator.prepare()
+        }
+    }
+
+    private func prepareGenerators() {
+        notificationGenerator.prepare()
+        selectionGenerator.prepare()
+        mediumImpactGenerator.prepare()
+    }
+}

--- a/Baby TrackerTests/AppModelTests.swift
+++ b/Baby TrackerTests/AppModelTests.swift
@@ -883,6 +883,109 @@ struct AppModelTests {
     }
 
     @Test
+    func loggingBottleFeedPlaysSuccessHaptic() throws {
+        let hapticFeedbackProvider = HapticFeedbackProviderSpy()
+        let harness = try Harness(hapticFeedbackProvider: hapticFeedbackProvider)
+        defer { harness.cleanUp() }
+
+        _ = try harness.seedOwnerProfile()
+
+        harness.model.load(performLaunchSync: false)
+
+        #expect(
+            harness.model.logBottleFeed(
+                amountMilliliters: 120,
+                occurredAt: Date(timeIntervalSince1970: 4_000),
+                milkType: .formula
+            )
+        )
+
+        #expect(hapticFeedbackProvider.events == [.actionSucceeded])
+    }
+
+    @Test
+    func failedSleepStartPlaysErrorHaptic() throws {
+        let hapticFeedbackProvider = HapticFeedbackProviderSpy()
+        let harness = try Harness(hapticFeedbackProvider: hapticFeedbackProvider)
+        defer { harness.cleanUp() }
+
+        _ = try harness.seedOwnerProfile()
+        let initialStart = Date(timeIntervalSince1970: 8_500)
+
+        harness.model.load(performLaunchSync: false)
+
+        #expect(harness.model.startSleep(startedAt: initialStart))
+        #expect(harness.model.startSleep(startedAt: initialStart.addingTimeInterval(600)) == false)
+
+        #expect(hapticFeedbackProvider.events == [.sleepStarted, .actionFailed])
+    }
+
+    @Test
+    func hardDeletePlaysDestructiveHaptic() async throws {
+        let hapticFeedbackProvider = HapticFeedbackProviderSpy()
+        let harness = try Harness(hapticFeedbackProvider: hapticFeedbackProvider)
+        defer { harness.cleanUp() }
+
+        _ = try harness.seedOwnerProfile()
+
+        harness.model.load(performLaunchSync: false)
+        harness.model.hardDeleteAllData()
+
+        await Task.yield()
+
+        #expect(hapticFeedbackProvider.events == [.destructiveActionConfirmed])
+    }
+
+    @Test
+    func exportReadyPlaysSuccessHaptic() async throws {
+        let hapticFeedbackProvider = HapticFeedbackProviderSpy()
+        let harness = try Harness(hapticFeedbackProvider: hapticFeedbackProvider)
+        defer { harness.cleanUp() }
+
+        _ = try harness.seedOwnerProfile()
+
+        harness.model.load(performLaunchSync: false)
+        harness.model.exportData()
+
+        while true {
+            switch harness.model.dataExportState {
+            case .ready:
+                #expect(hapticFeedbackProvider.events == [.actionSucceeded])
+                return
+            case .error(let message):
+                Issue.record("Expected export to succeed, got error: \(message)")
+                return
+            case .idle, .exporting:
+                await Task.yield()
+            }
+        }
+    }
+
+    @Test
+    func failedSyncRefreshPlaysErrorHaptic() async throws {
+        let hapticFeedbackProvider = HapticFeedbackProviderSpy()
+        let syncEngine = TestSyncEngine()
+        syncEngine.refreshForegroundSummary = SyncStatusSummary(
+            state: .failed,
+            pendingRecordCount: 0,
+            lastSyncAt: nil,
+            lastErrorDescription: "Sync unavailable. Sign in to iCloud."
+        )
+        let harness = try Harness(
+            syncEngine: syncEngine,
+            hapticFeedbackProvider: hapticFeedbackProvider
+        )
+        defer { harness.cleanUp() }
+
+        _ = try harness.seedOwnerProfile()
+        harness.model.load(performLaunchSync: false)
+
+        await harness.model.refreshSyncStatus()
+
+        #expect(hapticFeedbackProvider.events == [.actionFailed])
+    }
+
+    @Test
     func nappyMutationsDoNotChangeLiveActivityFeedSnapshot() throws {
         let liveActivityManager = LiveActivityManagerSpy()
         let harness = try Harness(liveActivityManager: liveActivityManager)
@@ -999,7 +1102,8 @@ extension AppModelTests {
 
         init(
             syncEngine: any CloudKitSyncControlling = TestSyncEngine(),
-            liveActivityManager: any FeedLiveActivityManaging = NoOpFeedLiveActivityManager()
+            liveActivityManager: any FeedLiveActivityManaging = NoOpFeedLiveActivityManager(),
+            hapticFeedbackProvider: any HapticFeedbackProviding = NoOpHapticFeedbackProvider()
         ) throws {
             let userDefaults = UserDefaults(suiteName: suiteName)!
             userDefaults.removePersistentDomain(forName: suiteName)
@@ -1019,7 +1123,8 @@ extension AppModelTests {
                 childSelectionStore: childSelectionStore,
                 eventRepository: eventRepository,
                 syncEngine: syncEngine,
-                liveActivityManager: liveActivityManager
+                liveActivityManager: liveActivityManager,
+                hapticFeedbackProvider: hapticFeedbackProvider
             )
         }
 
@@ -1207,6 +1312,15 @@ extension AppModelTests {
 
         func synchronize(with snapshot: FeedLiveActivitySnapshot?) {
             snapshots.append(snapshot)
+        }
+    }
+
+    @MainActor
+    private final class HapticFeedbackProviderSpy: HapticFeedbackProviding {
+        private(set) var events: [HapticEvent] = []
+
+        func play(_ event: HapticEvent) {
+            events.append(event)
         }
     }
 }

--- a/Packages/BabyTrackerDomain/Sources/BabyTrackerDomain/HapticEvent.swift
+++ b/Packages/BabyTrackerDomain/Sources/BabyTrackerDomain/HapticEvent.swift
@@ -1,0 +1,8 @@
+public enum HapticEvent: Sendable {
+    case actionSucceeded
+    case actionFailed
+    case selectionChanged
+    case destructiveActionConfirmed
+    case sleepStarted
+    case sleepEnded
+}

--- a/Packages/BabyTrackerDomain/Sources/BabyTrackerDomain/HapticFeedbackProviding.swift
+++ b/Packages/BabyTrackerDomain/Sources/BabyTrackerDomain/HapticFeedbackProviding.swift
@@ -1,0 +1,4 @@
+@MainActor
+public protocol HapticFeedbackProviding {
+    func play(_ event: HapticEvent)
+}

--- a/Packages/BabyTrackerDomain/Sources/BabyTrackerDomain/NoOpHapticFeedbackProvider.swift
+++ b/Packages/BabyTrackerDomain/Sources/BabyTrackerDomain/NoOpHapticFeedbackProvider.swift
@@ -1,0 +1,6 @@
+@MainActor
+public struct NoOpHapticFeedbackProvider: HapticFeedbackProviding {
+    public init() {}
+
+    public func play(_ event: HapticEvent) {}
+}

--- a/Packages/BabyTrackerDomain/Sources/BabyTrackerDomain/UseCases/ArchiveCurrentChildUseCase.swift
+++ b/Packages/BabyTrackerDomain/Sources/BabyTrackerDomain/UseCases/ArchiveCurrentChildUseCase.swift
@@ -16,13 +16,16 @@ public struct ArchiveCurrentChildUseCase: UseCase {
 
     private let childRepository: any ChildRepository
     private let childSelectionStore: any ChildSelectionStore
+    private let hapticFeedbackProvider: any HapticFeedbackProviding
 
     public init(
         childRepository: any ChildRepository,
-        childSelectionStore: any ChildSelectionStore
+        childSelectionStore: any ChildSelectionStore,
+        hapticFeedbackProvider: any HapticFeedbackProviding = NoOpHapticFeedbackProvider()
     ) {
         self.childRepository = childRepository
         self.childSelectionStore = childSelectionStore
+        self.hapticFeedbackProvider = hapticFeedbackProvider
     }
 
     public func execute(_ input: Input) throws -> Void {
@@ -37,5 +40,7 @@ public struct ArchiveCurrentChildUseCase: UseCase {
         if input.currentSelectedChildID == archivedChild.id {
             childSelectionStore.saveSelectedChildID(nil)
         }
+
+        hapticFeedbackProvider.play(.actionSucceeded)
     }
 }

--- a/Packages/BabyTrackerDomain/Sources/BabyTrackerDomain/UseCases/CreateChildUseCase.swift
+++ b/Packages/BabyTrackerDomain/Sources/BabyTrackerDomain/UseCases/CreateChildUseCase.swift
@@ -19,15 +19,18 @@ public struct CreateChildUseCase: UseCase {
     private let childRepository: any ChildRepository
     private let membershipRepository: any MembershipRepository
     private let childSelectionStore: any ChildSelectionStore
+    private let hapticFeedbackProvider: any HapticFeedbackProviding
 
     public init(
         childRepository: any ChildRepository,
         membershipRepository: any MembershipRepository,
-        childSelectionStore: any ChildSelectionStore
+        childSelectionStore: any ChildSelectionStore,
+        hapticFeedbackProvider: any HapticFeedbackProviding = NoOpHapticFeedbackProvider()
     ) {
         self.childRepository = childRepository
         self.membershipRepository = membershipRepository
         self.childSelectionStore = childSelectionStore
+        self.hapticFeedbackProvider = hapticFeedbackProvider
     }
 
     public func execute(_ input: Input) throws -> Child {
@@ -46,6 +49,7 @@ public struct CreateChildUseCase: UseCase {
         try childRepository.saveChild(child)
         try membershipRepository.saveMembership(ownerMembership)
         childSelectionStore.saveSelectedChildID(child.id)
+        hapticFeedbackProvider.play(.actionSucceeded)
         return child
     }
 }

--- a/Packages/BabyTrackerDomain/Sources/BabyTrackerDomain/UseCases/CreateLocalUserUseCase.swift
+++ b/Packages/BabyTrackerDomain/Sources/BabyTrackerDomain/UseCases/CreateLocalUserUseCase.swift
@@ -11,14 +11,20 @@ public struct CreateLocalUserUseCase: UseCase {
     }
 
     private let userIdentityRepository: any UserIdentityRepository
+    private let hapticFeedbackProvider: any HapticFeedbackProviding
 
-    public init(userIdentityRepository: any UserIdentityRepository) {
+    public init(
+        userIdentityRepository: any UserIdentityRepository,
+        hapticFeedbackProvider: any HapticFeedbackProviding = NoOpHapticFeedbackProvider()
+    ) {
         self.userIdentityRepository = userIdentityRepository
+        self.hapticFeedbackProvider = hapticFeedbackProvider
     }
 
     public func execute(_ input: Input) throws -> UserIdentity {
         let user = try UserIdentity(displayName: input.displayName)
         try userIdentityRepository.saveLocalUser(user)
+        hapticFeedbackProvider.play(.actionSucceeded)
         return user
     }
 }

--- a/Packages/BabyTrackerDomain/Sources/BabyTrackerDomain/UseCases/DeleteEventUseCase.swift
+++ b/Packages/BabyTrackerDomain/Sources/BabyTrackerDomain/UseCases/DeleteEventUseCase.swift
@@ -15,9 +15,14 @@ public struct DeleteEventUseCase: UseCase {
     }
 
     private let eventRepository: any EventRepository
+    private let hapticFeedbackProvider: any HapticFeedbackProviding
 
-    public init(eventRepository: any EventRepository) {
+    public init(
+        eventRepository: any EventRepository,
+        hapticFeedbackProvider: any HapticFeedbackProviding = NoOpHapticFeedbackProvider()
+    ) {
         self.eventRepository = eventRepository
+        self.hapticFeedbackProvider = hapticFeedbackProvider
     }
 
     /// Returns the event snapshot before deletion, for use in undo state.
@@ -35,6 +40,7 @@ public struct DeleteEventUseCase: UseCase {
             deletedAt: .now,
             deletedBy: input.localUserID
         )
+        hapticFeedbackProvider.play(.actionSucceeded)
         return event
     }
 }

--- a/Packages/BabyTrackerDomain/Sources/BabyTrackerDomain/UseCases/EndSleepUseCase.swift
+++ b/Packages/BabyTrackerDomain/Sources/BabyTrackerDomain/UseCases/EndSleepUseCase.swift
@@ -25,9 +25,14 @@ public struct EndSleepUseCase: UseCase {
     }
 
     private let eventRepository: any EventRepository
+    private let hapticFeedbackProvider: any HapticFeedbackProviding
 
-    public init(eventRepository: any EventRepository) {
+    public init(
+        eventRepository: any EventRepository,
+        hapticFeedbackProvider: any HapticFeedbackProviding = NoOpHapticFeedbackProvider()
+    ) {
         self.eventRepository = eventRepository
+        self.hapticFeedbackProvider = hapticFeedbackProvider
     }
 
     public func execute(_ input: Input) throws -> BabyEvent {
@@ -48,6 +53,7 @@ public struct EndSleepUseCase: UseCase {
         )
 
         try eventRepository.saveEvent(.sleep(updatedEvent))
+        hapticFeedbackProvider.play(.sleepEnded)
         return .sleep(updatedEvent)
     }
 }

--- a/Packages/BabyTrackerDomain/Sources/BabyTrackerDomain/UseCases/ExportEventsUseCase.swift
+++ b/Packages/BabyTrackerDomain/Sources/BabyTrackerDomain/UseCases/ExportEventsUseCase.swift
@@ -14,9 +14,14 @@ public struct ExportEventsUseCase: UseCase {
     }
 
     private let eventRepository: any EventRepository
+    private let hapticFeedbackProvider: any HapticFeedbackProviding
 
-    public init(eventRepository: any EventRepository) {
+    public init(
+        eventRepository: any EventRepository,
+        hapticFeedbackProvider: any HapticFeedbackProviding = NoOpHapticFeedbackProvider()
+    ) {
         self.eventRepository = eventRepository
+        self.hapticFeedbackProvider = hapticFeedbackProvider
     }
 
     public func execute(_ input: Input) throws -> Data {
@@ -37,7 +42,9 @@ public struct ExportEventsUseCase: UseCase {
         let encoder = JSONEncoder()
         encoder.dateEncodingStrategy = .iso8601
         encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
-        return try encoder.encode(exportData)
+        let data = try encoder.encode(exportData)
+        hapticFeedbackProvider.play(.actionSucceeded)
+        return data
     }
 
     // MARK: - Mapping

--- a/Packages/BabyTrackerDomain/Sources/BabyTrackerDomain/UseCases/ImportEventsUseCase.swift
+++ b/Packages/BabyTrackerDomain/Sources/BabyTrackerDomain/UseCases/ImportEventsUseCase.swift
@@ -24,9 +24,14 @@ public struct ImportEventsUseCase: UseCase {
     }
 
     private let eventRepository: any EventRepository
+    private let hapticFeedbackProvider: any HapticFeedbackProviding
 
-    public init(eventRepository: any EventRepository) {
+    public init(
+        eventRepository: any EventRepository,
+        hapticFeedbackProvider: any HapticFeedbackProviding = NoOpHapticFeedbackProvider()
+    ) {
         self.eventRepository = eventRepository
+        self.hapticFeedbackProvider = hapticFeedbackProvider
     }
 
     public func execute(_ input: Input) throws -> CSVImportResult {
@@ -44,6 +49,10 @@ public struct ImportEventsUseCase: UseCase {
             } catch {
                 skippedReasons.append("\(event.eventKindLabel) at \(event.occurredAt.formatted()): \(error.localizedDescription)")
             }
+        }
+
+        if importedCount > 0 {
+            hapticFeedbackProvider.play(.actionSucceeded)
         }
 
         return CSVImportResult(
@@ -75,7 +84,10 @@ public struct ImportEventsUseCase: UseCase {
         localUserID: UUID,
         membership: Membership
     ) throws {
-        _ = try LogBottleFeedUseCase(eventRepository: eventRepository)
+        _ = try LogBottleFeedUseCase(
+            eventRepository: eventRepository,
+            hapticFeedbackProvider: NoOpHapticFeedbackProvider()
+        )
             .execute(.init(
                 childID: childID,
                 localUserID: localUserID,
@@ -92,7 +104,10 @@ public struct ImportEventsUseCase: UseCase {
         localUserID: UUID,
         membership: Membership
     ) throws {
-        _ = try LogBreastFeedUseCase(eventRepository: eventRepository)
+        _ = try LogBreastFeedUseCase(
+            eventRepository: eventRepository,
+            hapticFeedbackProvider: NoOpHapticFeedbackProvider()
+        )
             .execute(.init(
                 childID: childID,
                 localUserID: localUserID,
@@ -111,7 +126,10 @@ public struct ImportEventsUseCase: UseCase {
         localUserID: UUID,
         membership: Membership
     ) throws {
-        _ = try LogSleepUseCase(eventRepository: eventRepository)
+        _ = try LogSleepUseCase(
+            eventRepository: eventRepository,
+            hapticFeedbackProvider: NoOpHapticFeedbackProvider()
+        )
             .execute(.init(
                 childID: childID,
                 localUserID: localUserID,
@@ -127,7 +145,10 @@ public struct ImportEventsUseCase: UseCase {
         localUserID: UUID,
         membership: Membership
     ) throws {
-        _ = try LogNappyUseCase(eventRepository: eventRepository)
+        _ = try LogNappyUseCase(
+            eventRepository: eventRepository,
+            hapticFeedbackProvider: NoOpHapticFeedbackProvider()
+        )
             .execute(.init(
                 childID: childID,
                 localUserID: localUserID,

--- a/Packages/BabyTrackerDomain/Sources/BabyTrackerDomain/UseCases/LogBottleFeedUseCase.swift
+++ b/Packages/BabyTrackerDomain/Sources/BabyTrackerDomain/UseCases/LogBottleFeedUseCase.swift
@@ -28,9 +28,14 @@ public struct LogBottleFeedUseCase: UseCase {
     }
 
     private let eventRepository: any EventRepository
+    private let hapticFeedbackProvider: any HapticFeedbackProviding
 
-    public init(eventRepository: any EventRepository) {
+    public init(
+        eventRepository: any EventRepository,
+        hapticFeedbackProvider: any HapticFeedbackProviding = NoOpHapticFeedbackProvider()
+    ) {
         self.eventRepository = eventRepository
+        self.hapticFeedbackProvider = hapticFeedbackProvider
     }
 
     public func execute(_ input: Input) throws -> BabyEvent {
@@ -50,6 +55,7 @@ public struct LogBottleFeedUseCase: UseCase {
         )
 
         try eventRepository.saveEvent(.bottleFeed(event))
+        hapticFeedbackProvider.play(.actionSucceeded)
         return .bottleFeed(event)
     }
 }

--- a/Packages/BabyTrackerDomain/Sources/BabyTrackerDomain/UseCases/LogBreastFeedUseCase.swift
+++ b/Packages/BabyTrackerDomain/Sources/BabyTrackerDomain/UseCases/LogBreastFeedUseCase.swift
@@ -34,9 +34,14 @@ public struct LogBreastFeedUseCase: UseCase {
     }
 
     private let eventRepository: any EventRepository
+    private let hapticFeedbackProvider: any HapticFeedbackProviding
 
-    public init(eventRepository: any EventRepository) {
+    public init(
+        eventRepository: any EventRepository,
+        hapticFeedbackProvider: any HapticFeedbackProviding = NoOpHapticFeedbackProvider()
+    ) {
         self.eventRepository = eventRepository
+        self.hapticFeedbackProvider = hapticFeedbackProvider
     }
 
     public func execute(_ input: Input) throws -> BabyEvent {
@@ -60,6 +65,7 @@ public struct LogBreastFeedUseCase: UseCase {
         )
 
         try eventRepository.saveEvent(.breastFeed(event))
+        hapticFeedbackProvider.play(.actionSucceeded)
         return .breastFeed(event)
     }
 }

--- a/Packages/BabyTrackerDomain/Sources/BabyTrackerDomain/UseCases/LogNappyUseCase.swift
+++ b/Packages/BabyTrackerDomain/Sources/BabyTrackerDomain/UseCases/LogNappyUseCase.swift
@@ -34,9 +34,14 @@ public struct LogNappyUseCase: UseCase {
     }
 
     private let eventRepository: any EventRepository
+    private let hapticFeedbackProvider: any HapticFeedbackProviding
 
-    public init(eventRepository: any EventRepository) {
+    public init(
+        eventRepository: any EventRepository,
+        hapticFeedbackProvider: any HapticFeedbackProviding = NoOpHapticFeedbackProvider()
+    ) {
         self.eventRepository = eventRepository
+        self.hapticFeedbackProvider = hapticFeedbackProvider
     }
 
     public func execute(_ input: Input) throws -> BabyEvent {
@@ -58,6 +63,7 @@ public struct LogNappyUseCase: UseCase {
         )
 
         try eventRepository.saveEvent(.nappy(event))
+        hapticFeedbackProvider.play(.actionSucceeded)
         return .nappy(event)
     }
 }

--- a/Packages/BabyTrackerDomain/Sources/BabyTrackerDomain/UseCases/LogSleepUseCase.swift
+++ b/Packages/BabyTrackerDomain/Sources/BabyTrackerDomain/UseCases/LogSleepUseCase.swift
@@ -19,9 +19,14 @@ public struct LogSleepUseCase: UseCase {
     }
 
     private let eventRepository: any EventRepository
+    private let hapticFeedbackProvider: any HapticFeedbackProviding
 
-    public init(eventRepository: any EventRepository) {
+    public init(
+        eventRepository: any EventRepository,
+        hapticFeedbackProvider: any HapticFeedbackProviding = NoOpHapticFeedbackProvider()
+    ) {
         self.eventRepository = eventRepository
+        self.hapticFeedbackProvider = hapticFeedbackProvider
     }
 
     public func execute(_ input: Input) throws -> BabyEvent {
@@ -41,6 +46,7 @@ public struct LogSleepUseCase: UseCase {
         )
 
         try eventRepository.saveEvent(.sleep(event))
+        hapticFeedbackProvider.play(.actionSucceeded)
         return .sleep(event)
     }
 }

--- a/Packages/BabyTrackerDomain/Sources/BabyTrackerDomain/UseCases/RemoveCaregiverUseCase.swift
+++ b/Packages/BabyTrackerDomain/Sources/BabyTrackerDomain/UseCases/RemoveCaregiverUseCase.swift
@@ -15,9 +15,14 @@ public struct RemoveCaregiverUseCase: UseCase {
     }
 
     private let membershipRepository: any MembershipRepository
+    private let hapticFeedbackProvider: any HapticFeedbackProviding
 
-    public init(membershipRepository: any MembershipRepository) {
+    public init(
+        membershipRepository: any MembershipRepository,
+        hapticFeedbackProvider: any HapticFeedbackProviding = NoOpHapticFeedbackProvider()
+    ) {
         self.membershipRepository = membershipRepository
+        self.hapticFeedbackProvider = hapticFeedbackProvider
     }
 
     /// Returns the removed membership so the caller can trigger the async CloudKit participant removal.
@@ -35,6 +40,7 @@ public struct RemoveCaregiverUseCase: UseCase {
         try MembershipValidator.validateRemoval(of: membership, within: allMemberships)
         let removedMembership = try membership.removed()
         try membershipRepository.saveMembership(removedMembership)
+        hapticFeedbackProvider.play(.actionSucceeded)
         return removedMembership
     }
 }

--- a/Packages/BabyTrackerDomain/Sources/BabyTrackerDomain/UseCases/RestoreChildUseCase.swift
+++ b/Packages/BabyTrackerDomain/Sources/BabyTrackerDomain/UseCases/RestoreChildUseCase.swift
@@ -12,13 +12,16 @@ public struct RestoreChildUseCase: UseCase {
 
     private let childRepository: any ChildRepository
     private let childSelectionStore: any ChildSelectionStore
+    private let hapticFeedbackProvider: any HapticFeedbackProviding
 
     public init(
         childRepository: any ChildRepository,
-        childSelectionStore: any ChildSelectionStore
+        childSelectionStore: any ChildSelectionStore,
+        hapticFeedbackProvider: any HapticFeedbackProviding = NoOpHapticFeedbackProvider()
     ) {
         self.childRepository = childRepository
         self.childSelectionStore = childSelectionStore
+        self.hapticFeedbackProvider = hapticFeedbackProvider
     }
 
     public func execute(_ input: Input) throws -> Child {
@@ -29,6 +32,7 @@ public struct RestoreChildUseCase: UseCase {
         restoredChild.isArchived = false
         try childRepository.saveChild(restoredChild)
         childSelectionStore.saveSelectedChildID(input.childID)
+        hapticFeedbackProvider.play(.actionSucceeded)
         return restoredChild
     }
 }

--- a/Packages/BabyTrackerDomain/Sources/BabyTrackerDomain/UseCases/RestoreDeletedEventUseCase.swift
+++ b/Packages/BabyTrackerDomain/Sources/BabyTrackerDomain/UseCases/RestoreDeletedEventUseCase.swift
@@ -13,14 +13,20 @@ public struct RestoreDeletedEventUseCase: UseCase {
     }
 
     private let eventRepository: any EventRepository
+    private let hapticFeedbackProvider: any HapticFeedbackProviding
 
-    public init(eventRepository: any EventRepository) {
+    public init(
+        eventRepository: any EventRepository,
+        hapticFeedbackProvider: any HapticFeedbackProviding = NoOpHapticFeedbackProvider()
+    ) {
         self.eventRepository = eventRepository
+        self.hapticFeedbackProvider = hapticFeedbackProvider
     }
 
     public func execute(_ input: Input) throws -> BabyEvent {
         let restoredEvent = restoreDeleted(input.event, by: input.restoredBy)
         try eventRepository.saveEvent(restoredEvent)
+        hapticFeedbackProvider.play(.actionSucceeded)
         return restoredEvent
     }
 

--- a/Packages/BabyTrackerDomain/Sources/BabyTrackerDomain/UseCases/StartSleepUseCase.swift
+++ b/Packages/BabyTrackerDomain/Sources/BabyTrackerDomain/UseCases/StartSleepUseCase.swift
@@ -17,9 +17,14 @@ public struct StartSleepUseCase: UseCase {
     }
 
     private let eventRepository: any EventRepository
+    private let hapticFeedbackProvider: any HapticFeedbackProviding
 
-    public init(eventRepository: any EventRepository) {
+    public init(
+        eventRepository: any EventRepository,
+        hapticFeedbackProvider: any HapticFeedbackProviding = NoOpHapticFeedbackProvider()
+    ) {
         self.eventRepository = eventRepository
+        self.hapticFeedbackProvider = hapticFeedbackProvider
     }
 
     public func execute(_ input: Input) throws -> BabyEvent {
@@ -42,6 +47,7 @@ public struct StartSleepUseCase: UseCase {
         )
 
         try eventRepository.saveEvent(.sleep(event))
+        hapticFeedbackProvider.play(.sleepStarted)
         return .sleep(event)
     }
 }

--- a/Packages/BabyTrackerDomain/Sources/BabyTrackerDomain/UseCases/UpdateBottleFeedUseCase.swift
+++ b/Packages/BabyTrackerDomain/Sources/BabyTrackerDomain/UseCases/UpdateBottleFeedUseCase.swift
@@ -28,9 +28,14 @@ public struct UpdateBottleFeedUseCase: UseCase {
     }
 
     private let eventRepository: any EventRepository
+    private let hapticFeedbackProvider: any HapticFeedbackProviding
 
-    public init(eventRepository: any EventRepository) {
+    public init(
+        eventRepository: any EventRepository,
+        hapticFeedbackProvider: any HapticFeedbackProviding = NoOpHapticFeedbackProvider()
+    ) {
         self.eventRepository = eventRepository
+        self.hapticFeedbackProvider = hapticFeedbackProvider
     }
 
     public func execute(_ input: Input) throws -> Void {
@@ -49,5 +54,6 @@ public struct UpdateBottleFeedUseCase: UseCase {
             updatedBy: input.localUserID
         )
         try eventRepository.saveEvent(.bottleFeed(updatedEvent))
+        hapticFeedbackProvider.play(.actionSucceeded)
     }
 }

--- a/Packages/BabyTrackerDomain/Sources/BabyTrackerDomain/UseCases/UpdateBreastFeedUseCase.swift
+++ b/Packages/BabyTrackerDomain/Sources/BabyTrackerDomain/UseCases/UpdateBreastFeedUseCase.swift
@@ -34,9 +34,14 @@ public struct UpdateBreastFeedUseCase: UseCase {
     }
 
     private let eventRepository: any EventRepository
+    private let hapticFeedbackProvider: any HapticFeedbackProviding
 
-    public init(eventRepository: any EventRepository) {
+    public init(
+        eventRepository: any EventRepository,
+        hapticFeedbackProvider: any HapticFeedbackProviding = NoOpHapticFeedbackProvider()
+    ) {
         self.eventRepository = eventRepository
+        self.hapticFeedbackProvider = hapticFeedbackProvider
     }
 
     public func execute(_ input: Input) throws -> Void {
@@ -57,5 +62,6 @@ public struct UpdateBreastFeedUseCase: UseCase {
             updatedBy: input.localUserID
         )
         try eventRepository.saveEvent(.breastFeed(updatedEvent))
+        hapticFeedbackProvider.play(.actionSucceeded)
     }
 }

--- a/Packages/BabyTrackerDomain/Sources/BabyTrackerDomain/UseCases/UpdateCurrentChildUseCase.swift
+++ b/Packages/BabyTrackerDomain/Sources/BabyTrackerDomain/UseCases/UpdateCurrentChildUseCase.swift
@@ -28,9 +28,14 @@ public struct UpdateCurrentChildUseCase: UseCase {
     }
 
     private let childRepository: any ChildRepository
+    private let hapticFeedbackProvider: any HapticFeedbackProviding
 
-    public init(childRepository: any ChildRepository) {
+    public init(
+        childRepository: any ChildRepository,
+        hapticFeedbackProvider: any HapticFeedbackProviding = NoOpHapticFeedbackProvider()
+    ) {
         self.childRepository = childRepository
+        self.hapticFeedbackProvider = hapticFeedbackProvider
     }
 
     public func execute(_ input: Input) throws -> Child {
@@ -45,6 +50,7 @@ public struct UpdateCurrentChildUseCase: UseCase {
             preferredFeedVolumeUnit: input.preferredFeedVolumeUnit
         )
         try childRepository.saveChild(updatedChild)
+        hapticFeedbackProvider.play(.actionSucceeded)
         return updatedChild
     }
 }

--- a/Packages/BabyTrackerDomain/Sources/BabyTrackerDomain/UseCases/UpdateNappyUseCase.swift
+++ b/Packages/BabyTrackerDomain/Sources/BabyTrackerDomain/UseCases/UpdateNappyUseCase.swift
@@ -34,9 +34,14 @@ public struct UpdateNappyUseCase: UseCase {
     }
 
     private let eventRepository: any EventRepository
+    private let hapticFeedbackProvider: any HapticFeedbackProviding
 
-    public init(eventRepository: any EventRepository) {
+    public init(
+        eventRepository: any EventRepository,
+        hapticFeedbackProvider: any HapticFeedbackProviding = NoOpHapticFeedbackProvider()
+    ) {
         self.eventRepository = eventRepository
+        self.hapticFeedbackProvider = hapticFeedbackProvider
     }
 
     public func execute(_ input: Input) throws -> Void {
@@ -57,5 +62,6 @@ public struct UpdateNappyUseCase: UseCase {
             updatedBy: input.localUserID
         )
         try eventRepository.saveEvent(.nappy(updatedEvent))
+        hapticFeedbackProvider.play(.actionSucceeded)
     }
 }

--- a/Packages/BabyTrackerDomain/Sources/BabyTrackerDomain/UseCases/UpdateSleepUseCase.swift
+++ b/Packages/BabyTrackerDomain/Sources/BabyTrackerDomain/UseCases/UpdateSleepUseCase.swift
@@ -25,9 +25,14 @@ public struct UpdateSleepUseCase: UseCase {
     }
 
     private let eventRepository: any EventRepository
+    private let hapticFeedbackProvider: any HapticFeedbackProviding
 
-    public init(eventRepository: any EventRepository) {
+    public init(
+        eventRepository: any EventRepository,
+        hapticFeedbackProvider: any HapticFeedbackProviding = NoOpHapticFeedbackProvider()
+    ) {
         self.eventRepository = eventRepository
+        self.hapticFeedbackProvider = hapticFeedbackProvider
     }
 
     public func execute(_ input: Input) throws -> Void {
@@ -46,5 +51,6 @@ public struct UpdateSleepUseCase: UseCase {
             updatedBy: input.localUserID
         )
         try eventRepository.saveEvent(.sleep(updatedEvent))
+        hapticFeedbackProvider.play(.actionSucceeded)
     }
 }

--- a/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/AppModel.swift
+++ b/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/AppModel.swift
@@ -30,6 +30,7 @@ public final class AppModel {
     private let syncEngine: any CloudKitSyncControlling
     private let liveActivityManager: any FeedLiveActivityManaging
     private let localNotificationManager: any LocalNotificationManaging
+    private let hapticFeedbackProvider: any HapticFeedbackProviding
     private let buildTimelineStripDatasetUseCase = BuildTimelineStripDatasetUseCase()
     private let buildRemoteNotificationUseCase = BuildRemoteCaregiverNotificationUseCase()
     private let calendar = Calendar.autoupdatingCurrent
@@ -49,7 +50,8 @@ public final class AppModel {
         eventRepository: EventRepository,
         syncEngine: any CloudKitSyncControlling,
         liveActivityManager: any FeedLiveActivityManaging = NoOpFeedLiveActivityManager(),
-        localNotificationManager: any LocalNotificationManaging = NoOpLocalNotificationManager()
+        localNotificationManager: any LocalNotificationManaging = NoOpLocalNotificationManager(),
+        hapticFeedbackProvider: any HapticFeedbackProviding = NoOpHapticFeedbackProvider()
     ) {
         self.childRepository = childRepository
         self.userIdentityRepository = userIdentityRepository
@@ -59,6 +61,7 @@ public final class AppModel {
         self.syncEngine = syncEngine
         self.liveActivityManager = liveActivityManager
         self.localNotificationManager = localNotificationManager
+        self.hapticFeedbackProvider = hapticFeedbackProvider
     }
 
     public func load(performLaunchSync: Bool = true) {
@@ -120,11 +123,12 @@ public final class AppModel {
                 childSelectionStore.saveSelectedChildID(nil)
                 clearUndoDeleteState()
                 refresh(selecting: nil)
+                playHaptic(.destructiveActionConfirmed)
                 if let cloudDeleteError {
-                    errorMessage = "Local data was cleared, but iCloud cleanup failed: \(cloudDeleteError.localizedDescription)"
+                    setErrorMessage("Local data was cleared, but iCloud cleanup failed: \(cloudDeleteError.localizedDescription)")
                 }
             } catch {
-                errorMessage = resolveErrorMessage(for: error)
+                setErrorMessage(resolveErrorMessage(for: error))
                 refresh(selecting: nil)
             }
         }
@@ -132,7 +136,10 @@ public final class AppModel {
 
     public func createLocalUser(displayName: String) {
         perform {
-            _ = try CreateLocalUserUseCase(userIdentityRepository: userIdentityRepository)
+            _ = try CreateLocalUserUseCase(
+                userIdentityRepository: userIdentityRepository,
+                hapticFeedbackProvider: hapticFeedbackProvider
+            )
                 .execute(.init(displayName: displayName))
         }
     }
@@ -143,7 +150,8 @@ public final class AppModel {
             _ = try CreateChildUseCase(
                 childRepository: childRepository,
                 membershipRepository: membershipRepository,
-                childSelectionStore: childSelectionStore
+                childSelectionStore: childSelectionStore,
+                hapticFeedbackProvider: hapticFeedbackProvider
             ).execute(.init(name: name, birthDate: birthDate, localUser: localUser, imageData: imageData))
         }
     }
@@ -156,7 +164,10 @@ public final class AppModel {
     ) {
         perform {
             guard let profile else { return }
-            _ = try UpdateCurrentChildUseCase(childRepository: childRepository)
+            _ = try UpdateCurrentChildUseCase(
+                childRepository: childRepository,
+                hapticFeedbackProvider: hapticFeedbackProvider
+            )
                 .execute(.init(
                     child: profile.child,
                     name: name,
@@ -173,7 +184,8 @@ public final class AppModel {
             guard let profile else { return }
             try ArchiveCurrentChildUseCase(
                 childRepository: childRepository,
-                childSelectionStore: childSelectionStore
+                childSelectionStore: childSelectionStore,
+                hapticFeedbackProvider: hapticFeedbackProvider
             ).execute(.init(
                 child: profile.child,
                 membership: profile.currentMembership,
@@ -186,7 +198,8 @@ public final class AppModel {
         perform {
             _ = try RestoreChildUseCase(
                 childRepository: childRepository,
-                childSelectionStore: childSelectionStore
+                childSelectionStore: childSelectionStore,
+                hapticFeedbackProvider: hapticFeedbackProvider
             ).execute(.init(childID: id))
         }
     }
@@ -196,6 +209,7 @@ public final class AppModel {
         timelineChildID = id
         timelineSelectedDay = normalizedTimelineDay(for: .now)
         refresh(selecting: id)
+        playHaptic(.selectionChanged)
     }
 
     public func showPreviousTimelineDay() {
@@ -237,6 +251,7 @@ public final class AppModel {
     public func toggleTimelineDisplayMode() {
         timelineDisplayMode = timelineDisplayMode == .day ? .week : .day
         refresh(selecting: childSelectionStore.loadSelectedChildID())
+        playHaptic(.selectionChanged)
     }
 
     public var eventFilter: EventFilter { activeEventFilter }
@@ -244,6 +259,7 @@ public final class AppModel {
     public func updateEventFilter(_ filter: EventFilter) {
         activeEventFilter = filter
         refresh(selecting: childSelectionStore.loadSelectedChildID())
+        playHaptic(.selectionChanged)
     }
 
     public func showChildPicker() {
@@ -266,8 +282,9 @@ public final class AppModel {
                 )
                 shareSheetState = ShareSheetState(presentation: presentation)
                 refresh(selecting: childSelectionStore.loadSelectedChildID())
+                playHaptic(.actionSucceeded)
             } catch {
-                errorMessage = resolveErrorMessage(for: error)
+                setErrorMessage(resolveErrorMessage(for: error))
             }
         }
     }
@@ -278,7 +295,10 @@ public final class AppModel {
         }
 
         perform {
-            let removedMembership = try RemoveCaregiverUseCase(membershipRepository: membershipRepository)
+            let removedMembership = try RemoveCaregiverUseCase(
+                membershipRepository: membershipRepository,
+                hapticFeedbackProvider: hapticFeedbackProvider
+            )
                 .execute(.init(
                     membershipID: membershipID,
                     childID: profile.child.id,
@@ -302,8 +322,9 @@ public final class AppModel {
                 if childSelectionStore.loadSelectedChildID() == childID {
                     childSelectionStore.saveSelectedChildID(nil)
                 }
+                playHaptic(.actionSucceeded)
             } catch {
-                errorMessage = resolveErrorMessage(for: error)
+                setErrorMessage(resolveErrorMessage(for: error))
             }
             refresh(selecting: childSelectionStore.loadSelectedChildID())
         }
@@ -320,7 +341,10 @@ public final class AppModel {
         perform {
             guard let profile else { throw ChildProfileValidationError.insufficientPermissions }
             guard let localUser else { throw ChildProfileValidationError.insufficientPermissions }
-            _ = try LogBreastFeedUseCase(eventRepository: eventRepository)
+            _ = try LogBreastFeedUseCase(
+                eventRepository: eventRepository,
+                hapticFeedbackProvider: hapticFeedbackProvider
+            )
                 .execute(.init(
                     childID: profile.child.id,
                     localUserID: localUser.id,
@@ -343,7 +367,10 @@ public final class AppModel {
         perform {
             guard let profile else { throw ChildProfileValidationError.insufficientPermissions }
             guard let localUser else { throw ChildProfileValidationError.insufficientPermissions }
-            _ = try LogBottleFeedUseCase(eventRepository: eventRepository)
+            _ = try LogBottleFeedUseCase(
+                eventRepository: eventRepository,
+                hapticFeedbackProvider: hapticFeedbackProvider
+            )
                 .execute(.init(
                     childID: profile.child.id,
                     localUserID: localUser.id,
@@ -366,7 +393,10 @@ public final class AppModel {
         perform {
             guard let profile else { throw ChildProfileValidationError.insufficientPermissions }
             guard let localUser else { throw ChildProfileValidationError.insufficientPermissions }
-            _ = try LogNappyUseCase(eventRepository: eventRepository)
+            _ = try LogNappyUseCase(
+                eventRepository: eventRepository,
+                hapticFeedbackProvider: hapticFeedbackProvider
+            )
                 .execute(.init(
                     childID: profile.child.id,
                     localUserID: localUser.id,
@@ -385,7 +415,10 @@ public final class AppModel {
         perform {
             guard let profile else { throw ChildProfileValidationError.insufficientPermissions }
             guard let localUser else { throw ChildProfileValidationError.insufficientPermissions }
-            _ = try StartSleepUseCase(eventRepository: eventRepository)
+            _ = try StartSleepUseCase(
+                eventRepository: eventRepository,
+                hapticFeedbackProvider: hapticFeedbackProvider
+            )
                 .execute(.init(
                     childID: profile.child.id,
                     localUserID: localUser.id,
@@ -400,7 +433,10 @@ public final class AppModel {
         perform {
             guard let profile else { throw ChildProfileValidationError.insufficientPermissions }
             guard let localUser else { throw ChildProfileValidationError.insufficientPermissions }
-            _ = try LogSleepUseCase(eventRepository: eventRepository)
+            _ = try LogSleepUseCase(
+                eventRepository: eventRepository,
+                hapticFeedbackProvider: hapticFeedbackProvider
+            )
                 .execute(.init(
                     childID: profile.child.id,
                     localUserID: localUser.id,
@@ -420,7 +456,10 @@ public final class AppModel {
         perform {
             guard let profile else { throw ChildProfileValidationError.insufficientPermissions }
             guard let localUser else { throw ChildProfileValidationError.insufficientPermissions }
-            _ = try EndSleepUseCase(eventRepository: eventRepository)
+            _ = try EndSleepUseCase(
+                eventRepository: eventRepository,
+                hapticFeedbackProvider: hapticFeedbackProvider
+            )
                 .execute(.init(
                     eventID: id,
                     localUserID: localUser.id,
@@ -443,7 +482,10 @@ public final class AppModel {
         perform {
             guard let profile else { throw ChildProfileValidationError.insufficientPermissions }
             guard let localUser else { throw ChildProfileValidationError.insufficientPermissions }
-            try UpdateBreastFeedUseCase(eventRepository: eventRepository)
+            try UpdateBreastFeedUseCase(
+                eventRepository: eventRepository,
+                hapticFeedbackProvider: hapticFeedbackProvider
+            )
                 .execute(.init(
                     eventID: id,
                     localUserID: localUser.id,
@@ -467,7 +509,10 @@ public final class AppModel {
         perform {
             guard let profile else { throw ChildProfileValidationError.insufficientPermissions }
             guard let localUser else { throw ChildProfileValidationError.insufficientPermissions }
-            try UpdateBottleFeedUseCase(eventRepository: eventRepository)
+            try UpdateBottleFeedUseCase(
+                eventRepository: eventRepository,
+                hapticFeedbackProvider: hapticFeedbackProvider
+            )
                 .execute(.init(
                     eventID: id,
                     localUserID: localUser.id,
@@ -491,7 +536,10 @@ public final class AppModel {
         perform {
             guard let profile else { throw ChildProfileValidationError.insufficientPermissions }
             guard let localUser else { throw ChildProfileValidationError.insufficientPermissions }
-            try UpdateNappyUseCase(eventRepository: eventRepository)
+            try UpdateNappyUseCase(
+                eventRepository: eventRepository,
+                hapticFeedbackProvider: hapticFeedbackProvider
+            )
                 .execute(.init(
                     eventID: id,
                     localUserID: localUser.id,
@@ -536,7 +584,10 @@ public final class AppModel {
         perform {
             guard let profile else { throw ChildProfileValidationError.insufficientPermissions }
             guard let localUser else { throw ChildProfileValidationError.insufficientPermissions }
-            try UpdateSleepUseCase(eventRepository: eventRepository)
+            try UpdateSleepUseCase(
+                eventRepository: eventRepository,
+                hapticFeedbackProvider: hapticFeedbackProvider
+            )
                 .execute(.init(
                     eventID: id,
                     localUserID: localUser.id,
@@ -553,7 +604,10 @@ public final class AppModel {
             guard let profile else { throw ChildProfileValidationError.insufficientPermissions }
             guard let localUser else { throw ChildProfileValidationError.insufficientPermissions }
             clearUndoDeleteState()
-            if let event = try DeleteEventUseCase(eventRepository: eventRepository)
+            if let event = try DeleteEventUseCase(
+                eventRepository: eventRepository,
+                hapticFeedbackProvider: hapticFeedbackProvider
+            )
                 .execute(.init(
                     eventID: id,
                     localUserID: localUser.id,
@@ -570,14 +624,20 @@ public final class AppModel {
         perform {
             guard let localUser else { throw ChildProfileValidationError.insufficientPermissions }
             guard let pendingUndoDeletedEvent else { return }
-            _ = try RestoreDeletedEventUseCase(eventRepository: eventRepository)
+            _ = try RestoreDeletedEventUseCase(
+                eventRepository: eventRepository,
+                hapticFeedbackProvider: hapticFeedbackProvider
+            )
                 .execute(.init(event: pendingUndoDeletedEvent, restoredBy: localUser.id))
             clearUndoDeleteState()
         }
     }
 
     @discardableResult
-    private func perform(_ operation: () throws -> Void) -> Bool {
+    private func perform(
+        failureHaptic: HapticEvent = .actionFailed,
+        _ operation: () throws -> Void
+    ) -> Bool {
         do {
             try operation()
             refresh(selecting: childSelectionStore.loadSelectedChildID())
@@ -586,7 +646,7 @@ public final class AppModel {
             }
             return true
         } catch {
-            errorMessage = resolveErrorMessage(for: error)
+            setErrorMessage(resolveErrorMessage(for: error), haptic: failureHaptic)
             refresh(selecting: childSelectionStore.loadSelectedChildID())
             return false
         }
@@ -664,7 +724,7 @@ public final class AppModel {
                 )
             )
         } catch {
-            errorMessage = resolveErrorMessage(for: error)
+            setErrorMessage(resolveErrorMessage(for: error))
             // Only redirect to identity onboarding when there is genuinely no
             // local user. Data errors (e.g. owner membership not yet synced on a
             // shared child) must not wipe out the user's session.
@@ -1386,7 +1446,7 @@ public final class AppModel {
 
     public func parseCSVForImport(data: Data) {
         guard let profile else {
-            csvImportState = .error("No active child selected")
+            setCSVImportError("No active child selected")
             return
         }
 
@@ -1404,7 +1464,7 @@ public final class AppModel {
     }
 
     public func reportImportFileError(_ message: String) {
-        csvImportState = .error(message)
+        setCSVImportError(message)
     }
 
     public func toggleImportEvent(id: UUID) {
@@ -1428,13 +1488,13 @@ public final class AppModel {
     public func confirmImport() {
         guard case .previewing(let previewState) = csvImportState else { return }
         guard let profile, let localUser else {
-            csvImportState = .error("No active child selected")
+            setCSVImportError("No active child selected")
             return
         }
 
         let eventsToImport = previewState.selectedEvents
         guard !eventsToImport.isEmpty else {
-            csvImportState = .error("No events selected to import")
+            setCSVImportError("No events selected to import")
             return
         }
 
@@ -1442,7 +1502,10 @@ public final class AppModel {
 
         Task { @MainActor in
             do {
-                let saveResult = try ImportEventsUseCase(eventRepository: eventRepository)
+                let saveResult = try ImportEventsUseCase(
+                    eventRepository: eventRepository,
+                    hapticFeedbackProvider: hapticFeedbackProvider
+                )
                     .execute(.init(
                         events: eventsToImport,
                         childID: profile.child.id,
@@ -1460,7 +1523,7 @@ public final class AppModel {
                 refresh(selecting: childSelectionStore.loadSelectedChildID())
                 await runSyncRefresh { await self.syncEngine.refreshAfterLocalWrite() }
             } catch {
-                csvImportState = .error(resolveErrorMessage(for: error))
+                setCSVImportError(resolveErrorMessage(for: error))
             }
         }
     }
@@ -1477,7 +1540,7 @@ public final class AppModel {
 
     public func exportData() {
         guard let profile else {
-            dataExportState = .error("No active child selected")
+            setDataExportError("No active child selected")
             return
         }
 
@@ -1485,7 +1548,10 @@ public final class AppModel {
 
         Task { @MainActor in
             do {
-                let data = try ExportEventsUseCase(eventRepository: eventRepository)
+                let data = try ExportEventsUseCase(
+                    eventRepository: eventRepository,
+                    hapticFeedbackProvider: hapticFeedbackProvider
+                )
                     .execute(.init(child: profile.child, membership: profile.currentMembership))
 
                 let childName = profile.child.name
@@ -1499,7 +1565,7 @@ public final class AppModel {
 
                 dataExportState = .ready(tempURL)
             } catch {
-                dataExportState = .error(resolveErrorMessage(for: error))
+                setDataExportError(resolveErrorMessage(for: error))
             }
         }
     }
@@ -1512,14 +1578,14 @@ public final class AppModel {
 
     public func parseNestFileForImport(data: Data) {
         guard let profile else {
-            nestImportState = .error("No active child selected")
+            setNestImportError("No active child selected")
             return
         }
 
         let parseResult = NestJSONParser().parse(data: data)
 
         guard !parseResult.events.isEmpty || parseResult.skippedCount > 0 else {
-            nestImportState = .error("The selected file contains no recognisable events")
+            setNestImportError("The selected file contains no recognisable events")
             return
         }
 
@@ -1534,7 +1600,7 @@ public final class AppModel {
     }
 
     public func reportNestImportFileError(_ message: String) {
-        nestImportState = .error(message)
+        setNestImportError(message)
     }
 
     public func toggleNestImportEvent(id: UUID) {
@@ -1558,13 +1624,13 @@ public final class AppModel {
     public func confirmNestImport() {
         guard case .previewing(let previewState) = nestImportState else { return }
         guard let profile, let localUser else {
-            nestImportState = .error("No active child selected")
+            setNestImportError("No active child selected")
             return
         }
 
         let eventsToImport = previewState.selectedEvents
         guard !eventsToImport.isEmpty else {
-            nestImportState = .error("No events selected to import")
+            setNestImportError("No events selected to import")
             return
         }
 
@@ -1572,7 +1638,10 @@ public final class AppModel {
 
         Task { @MainActor in
             do {
-                let saveResult = try ImportEventsUseCase(eventRepository: eventRepository)
+                let saveResult = try ImportEventsUseCase(
+                    eventRepository: eventRepository,
+                    hapticFeedbackProvider: hapticFeedbackProvider
+                )
                     .execute(.init(
                         events: eventsToImport,
                         childID: profile.child.id,
@@ -1589,7 +1658,7 @@ public final class AppModel {
                 refresh(selecting: childSelectionStore.loadSelectedChildID())
                 await runSyncRefresh { await self.syncEngine.refreshAfterLocalWrite() }
             } catch {
-                nestImportState = .error(resolveErrorMessage(for: error))
+                setNestImportError(resolveErrorMessage(for: error))
             }
         }
     }
@@ -1633,6 +1702,7 @@ public final class AppModel {
                 state = .lastSyncFailed(message)
             }
             setSyncIndicator(state)
+            playHaptic(.actionFailed)
             syncIndicatorDismissTask = Task { @MainActor in
                 try? await Task.sleep(for: .seconds(4))
                 guard !Task.isCancelled else { return }
@@ -1647,5 +1717,32 @@ public final class AppModel {
         syncIndicatorDismissTask?.cancel()
         syncIndicatorDismissTask = nil
         syncBannerState = state
+    }
+
+    private func setErrorMessage(
+        _ message: String,
+        haptic: HapticEvent = .actionFailed
+    ) {
+        errorMessage = message
+        playHaptic(haptic)
+    }
+
+    private func setCSVImportError(_ message: String) {
+        csvImportState = .error(message)
+        playHaptic(.actionFailed)
+    }
+
+    private func setNestImportError(_ message: String) {
+        nestImportState = .error(message)
+        playHaptic(.actionFailed)
+    }
+
+    private func setDataExportError(_ message: String) {
+        dataExportState = .error(message)
+        playHaptic(.actionFailed)
+    }
+
+    private func playHaptic(_ event: HapticEvent) {
+        hapticFeedbackProvider.play(event)
     }
 }

--- a/docs/plans/025-haptic-feedback.md
+++ b/docs/plans/025-haptic-feedback.md
@@ -1,0 +1,15 @@
+# 025 Haptic Feedback
+
+1. Add a semantic haptics boundary in `BabyTrackerFeature` with a small protocol, a semantic event enum, and a no-op default implementation.
+2. Inject the haptics dependency into `AppModel` so user-visible outcomes can trigger feedback without coupling `BabyTrackerDomain` to UIKit.
+3. Trigger haptics for the main outcomes:
+   - success for create/update/archive/restore child flows
+   - success for event log/edit/delete/undo flows
+   - success for import completion, export readiness, and share-sheet preparation
+   - selection feedback for child switching, timeline mode changes, and filter changes
+   - warning for destructive hard delete completion
+   - error for surfaced operation failures and sync failures shown to the user
+4. Add the concrete `SystemHapticFeedbackProvider` in the app target and wire it through `AppContainer`.
+5. Add focused `AppModel` tests with a spy provider to verify representative success, error, destructive, and sync-failure haptics.
+
+- [x] Complete


### PR DESCRIPTION
## Summary
- add a semantic haptics boundary in `BabyTrackerDomain`
- trigger success haptics from domain use cases while keeping UIKit in the app target
- keep UI-only haptics in `AppModel` and add coverage with a spy haptic provider

## Why
This keeps the domain free of UIKit while still allowing use cases to express user-visible haptic events through a protocol boundary.

## Validation
- `xcodebuild test -project 'Baby Tracker.xcodeproj' -scheme 'Baby Tracker' -destination 'platform=iOS Simulator,name=iPhone 17' -only-testing:'Baby TrackerTests/AppModelTests'`