### PR TITLE
Add shared child acceptance loading screen

### DIFF
--- a/Baby Tracker/App/AppContainer.swift
+++ b/Baby Tracker/App/AppContainer.swift
@@ -64,9 +64,18 @@ struct AppContainer {
             localNotificationManager: localNotificationManager,
             hapticFeedbackProvider: hapticFeedbackProvider
         )
-        let shareAcceptanceHandler = ShareAcceptanceHandler(syncEngine: syncEngine) {
-            appModel.load()
-        }
+        let shareAcceptanceHandler = ShareAcceptanceHandler(
+            syncEngine: syncEngine,
+            onStartAcceptingShare: {
+                appModel.beginAcceptingSharedChild()
+            },
+            onAcceptedShare: {
+                appModel.completeAcceptingSharedChild()
+            },
+            onFailedToAcceptShare: { error in
+                appModel.failAcceptingSharedChild(error)
+            }
+        )
         appModel.load(performLaunchSync: !launchConfiguration.skipsLaunchSync)
 
         self.appModel = appModel
@@ -121,9 +130,18 @@ struct AppContainer {
             localNotificationManager: NoOpLocalNotificationManager(),
             hapticFeedbackProvider: NoOpHapticFeedbackProvider()
         )
-        let shareAcceptanceHandler = ShareAcceptanceHandler(syncEngine: syncEngine) {
-            appModel.load()
-        }
+        let shareAcceptanceHandler = ShareAcceptanceHandler(
+            syncEngine: syncEngine,
+            onStartAcceptingShare: {
+                appModel.beginAcceptingSharedChild()
+            },
+            onAcceptedShare: {
+                appModel.completeAcceptingSharedChild()
+            },
+            onFailedToAcceptShare: { error in
+                appModel.failAcceptingSharedChild(error)
+            }
+        )
         appModel.load()
 
         _ = processInfo

--- a/Baby Tracker/App/AppRootView.swift
+++ b/Baby Tracker/App/AppRootView.swift
@@ -13,26 +13,31 @@ struct AppRootView: View {
     var body: some View {
         NavigationStack {
             Group {
-                switch model.route {
-                case .loading:
-                    ProgressView("Loading profile…")
-                        .frame(maxWidth: .infinity, maxHeight: .infinity)
+                if let shareAcceptanceLoadingState = model.shareAcceptanceLoadingState {
+                    ShareAcceptanceLoadingView(state: shareAcceptanceLoadingState)
                         .toolbar(.hidden, for: .navigationBar)
-                case .identityOnboarding:
-                    IdentityOnboardingView(model: model)
-                        .toolbar(.hidden, for: .navigationBar)
-                case .noChildren:
-                    NoChildrenView(model: model)
-                        .toolbar(.hidden, for: .navigationBar)
-                case .childPicker:
-                    ChildPickerView(model: model)
-                        .navigationTitle("Baby Tracker")
-                case .childProfile:
-                    if let profile = model.profile {
-                        ChildWorkspaceTabView(model: model, profile: profile)
-                    } else {
+                } else {
+                    switch model.route {
+                    case .loading:
                         ProgressView("Loading profile…")
                             .frame(maxWidth: .infinity, maxHeight: .infinity)
+                            .toolbar(.hidden, for: .navigationBar)
+                    case .identityOnboarding:
+                        IdentityOnboardingView(model: model)
+                            .toolbar(.hidden, for: .navigationBar)
+                    case .noChildren:
+                        NoChildrenView(model: model)
+                            .toolbar(.hidden, for: .navigationBar)
+                    case .childPicker:
+                        ChildPickerView(model: model)
+                            .navigationTitle("Baby Tracker")
+                    case .childProfile:
+                        if let profile = model.profile {
+                            ChildWorkspaceTabView(model: model, profile: profile)
+                        } else {
+                            ProgressView("Loading profile…")
+                                .frame(maxWidth: .infinity, maxHeight: .infinity)
+                        }
                     }
                 }
             }

--- a/Baby TrackerTests/AppModelTests.swift
+++ b/Baby TrackerTests/AppModelTests.swift
@@ -1194,6 +1194,43 @@ struct AppModelTests {
         #expect(remaining.map(\.id) == [secondChild.id])
     }
 
+    @Test
+    func beginAcceptingSharedChildShowsFullScreenLoadingState() throws {
+        let harness = try Harness()
+        defer { harness.cleanUp() }
+
+        harness.model.beginAcceptingSharedChild()
+
+        #expect(harness.model.shareAcceptanceLoadingState == .acceptingSharedChild)
+    }
+
+    @Test
+    func completingSharedChildAcceptanceRefreshesProfileAndClearsLoadingState() throws {
+        let harness = try Harness()
+        defer { harness.cleanUp() }
+
+        _ = try harness.seedOwnerProfile()
+        harness.model.beginAcceptingSharedChild()
+
+        harness.model.completeAcceptingSharedChild()
+
+        #expect(harness.model.shareAcceptanceLoadingState == nil)
+        #expect(harness.model.route == .childProfile)
+        #expect(harness.model.profile?.child.name == "Poppy")
+    }
+
+    @Test
+    func failingSharedChildAcceptanceClearsLoadingStateAndShowsError() throws {
+        let harness = try Harness()
+        defer { harness.cleanUp() }
+
+        harness.model.beginAcceptingSharedChild()
+        harness.model.failAcceptingSharedChild(TestSyncEngineError.unimplemented)
+
+        #expect(harness.model.shareAcceptanceLoadingState == nil)
+        #expect(harness.model.errorMessage == "Couldn't accept the shared child. Something went wrong. Please try again.")
+    }
+
     // MARK: - Nuke All Data
 
     @Test

--- a/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/AppModel.swift
+++ b/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/AppModel.swift
@@ -15,6 +15,7 @@ public final class AppModel {
     public private(set) var profile: ChildProfileScreenState?
     public private(set) var errorMessage: String?
     public private(set) var undoDeleteMessage: String?
+    public private(set) var shareAcceptanceLoadingState: ShareAcceptanceLoadingState?
     public private(set) var sleepSheetRequestToken: Int = 0
     public var shareSheetState: ShareSheetState?
     public private(set) var csvImportState: CSVImportState = .idle
@@ -83,6 +84,21 @@ public final class AppModel {
 
     public func dismissShareSheet() {
         shareSheetState = nil
+    }
+
+    public func beginAcceptingSharedChild() {
+        errorMessage = nil
+        shareAcceptanceLoadingState = .acceptingSharedChild
+    }
+
+    public func completeAcceptingSharedChild() {
+        load(performLaunchSync: false)
+        shareAcceptanceLoadingState = nil
+    }
+
+    public func failAcceptingSharedChild(_ error: Error) {
+        shareAcceptanceLoadingState = nil
+        setErrorMessage("Couldn't accept the shared child. \(resolveErrorMessage(for: error))")
     }
 
     public func requestSleepSheetPresentation() {

--- a/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/ShareAcceptanceLoadingState.swift
+++ b/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/ShareAcceptanceLoadingState.swift
@@ -1,0 +1,16 @@
+import Foundation
+
+public struct ShareAcceptanceLoadingState: Equatable, Sendable {
+    public let title: String
+    public let message: String
+
+    public init(title: String, message: String) {
+        self.title = title
+        self.message = message
+    }
+
+    public static let acceptingSharedChild = ShareAcceptanceLoadingState(
+        title: "Accepting Shared Child...",
+        message: "We're accepting the iCloud share and downloading the child's data now."
+    )
+}

--- a/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/ShareAcceptanceLoadingView.swift
+++ b/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/ShareAcceptanceLoadingView.swift
@@ -1,0 +1,31 @@
+import SwiftUI
+
+public struct ShareAcceptanceLoadingView: View {
+    let state: ShareAcceptanceLoadingState
+
+    public init(state: ShareAcceptanceLoadingState) {
+        self.state = state
+    }
+
+    public var body: some View {
+        VStack(spacing: 24) {
+            ProgressView()
+                .controlSize(.large)
+
+            VStack(spacing: 12) {
+                Text(state.title)
+                    .font(.title2.weight(.semibold))
+                    .multilineTextAlignment(.center)
+
+                Text(state.message)
+                    .font(.body)
+                    .foregroundStyle(.secondary)
+                    .multilineTextAlignment(.center)
+            }
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .padding(32)
+        .background(Color(.systemGroupedBackground))
+        .accessibilityIdentifier("share-acceptance-loading-screen")
+    }
+}

--- a/Packages/BabyTrackerSync/Sources/BabyTrackerSync/ShareAcceptanceHandler.swift
+++ b/Packages/BabyTrackerSync/Sources/BabyTrackerSync/ShareAcceptanceHandler.swift
@@ -6,15 +6,21 @@ import os
 @MainActor
 public final class ShareAcceptanceHandler {
     private let syncEngine: CloudKitSyncEngine
+    private let onStartAcceptingShare: @MainActor () -> Void
     private let onAcceptedShare: @MainActor () -> Void
+    private let onFailedToAcceptShare: @MainActor (Error) -> Void
     private let logger = Logger(subsystem: "com.adappt.BabyTracker", category: "ShareAcceptance")
 
     public init(
         syncEngine: CloudKitSyncEngine,
-        onAcceptedShare: @escaping @MainActor () -> Void
+        onStartAcceptingShare: @escaping @MainActor () -> Void,
+        onAcceptedShare: @escaping @MainActor () -> Void,
+        onFailedToAcceptShare: @escaping @MainActor (Error) -> Void
     ) {
         self.syncEngine = syncEngine
+        self.onStartAcceptingShare = onStartAcceptingShare
         self.onAcceptedShare = onAcceptedShare
+        self.onFailedToAcceptShare = onFailedToAcceptShare
     }
 
     public func accept(metadata: CKShare.Metadata) {
@@ -22,6 +28,7 @@ public final class ShareAcceptanceHandler {
         logger.info("[3/5] ShareAcceptanceHandler queuing accept task")
         AppLogger.shared.log(.info, category: "ShareAcceptance", "[3/5] ShareAcceptanceHandler queuing accept task")
         Task { @MainActor in
+            onStartAcceptingShare()
             print("[BabyTracker][3/5] ShareAcceptanceHandler task running — calling sync engine")
             logger.info("[3/5] ShareAcceptanceHandler task started — calling sync engine")
             AppLogger.shared.log(.info, category: "ShareAcceptance", "[3/5] ShareAcceptanceHandler task started — calling sync engine")
@@ -35,7 +42,7 @@ public final class ShareAcceptanceHandler {
                 print("[BabyTracker][3/5] Sync engine accept FAILED: \(error)")
                 logger.error("[3/5] Sync engine accept failed: \(error.localizedDescription, privacy: .public)")
                 AppLogger.shared.log(.error, category: "ShareAcceptance", "[3/5] Sync engine accept failed: \(error.localizedDescription)")
-                onAcceptedShare()
+                onFailedToAcceptShare(error)
             }
         }
     }

--- a/docs/plans/027-share-accept-loading-screen.md
+++ b/docs/plans/027-share-accept-loading-screen.md
@@ -1,0 +1,13 @@
+# 027 - Share accept loading screen
+
+## Goal
+Show a dedicated full-screen loading state while the app is accepting a CloudKit share and pulling the shared child data locally.
+
+## Plan
+1. Add explicit share-acceptance UI state to the feature layer so the app can route to a loading screen during acceptance.
+2. Update the share acceptance bridge/container wiring so the loading state starts before the async accept flow and ends on success or failure.
+3. Add a focused SwiftUI loading screen in the app root that explains the app is accepting the share and downloading data.
+4. Keep existing success and failure handling intact, but route failures back to a user-visible error after exiting the loading screen.
+5. Add or update tests for the acceptance state transitions.
+
+- [x] Complete


### PR DESCRIPTION
## Summary
- add a dedicated full-screen loading state for accepted CloudKit shares
- wire the share acceptance handler to start, complete, and fail that state explicitly
- add focused AppModel coverage for the new share-acceptance transitions

## Testing
- xcodebuild test -project 'Baby Tracker.xcodeproj' -scheme 'Baby Tracker' -parallel-testing-enabled NO -destination 'platform=iOS Simulator,OS=26.2,name=iPhone 17' -only-testing:'Baby TrackerTests/AppModelTests/beginAcceptingSharedChildShowsFullScreenLoadingState' -only-testing:'Baby TrackerTests/AppModelTests/completingSharedChildAcceptanceRefreshesProfileAndClearsLoadingState' -only-testing:'Baby TrackerTests/AppModelTests/failingSharedChildAcceptanceClearsLoadingStateAndShowsError'

Closes #75
