### PR TITLE
Clean up child delete transitions

### DIFF
--- a/Baby Tracker/App/AppRootView.swift
+++ b/Baby Tracker/App/AppRootView.swift
@@ -44,7 +44,7 @@ struct AppRootView: View {
         }
         // Reset the stack when the app moves between top-level flows so stale
         // detail screens do not remain visible above a new root route.
-        .id(model.route)
+        .id("\(String(describing: model.route))-\(model.navigationResetToken)")
         .overlay(alignment: .top) {
             ZStack(alignment: .topTrailing) {
                 if let errorMessage = model.errorMessage {
@@ -80,14 +80,21 @@ struct AppRootView: View {
             model.requestSleepSheetPresentation()
         }
         .safeAreaInset(edge: .bottom) {
-            if let undoDeleteMessage = model.undoDeleteMessage {
-                UndoBannerView(
-                    message: undoDeleteMessage,
-                    undoAction: model.undoLastDeletedEvent
-                )
-                .padding(.horizontal, 16)
-                .padding(.bottom, 8)
+            VStack(spacing: 8) {
+                if let transientMessage = model.transientMessage {
+                    TransientMessageBannerView(message: transientMessage)
+                        .padding(.horizontal, 16)
+                }
+
+                if let undoDeleteMessage = model.undoDeleteMessage {
+                    UndoBannerView(
+                        message: undoDeleteMessage,
+                        undoAction: model.undoLastDeletedEvent
+                    )
+                    .padding(.horizontal, 16)
+                }
             }
+            .padding(.bottom, 8)
         }
     }
 }

--- a/Baby TrackerTests/AppModelTests.swift
+++ b/Baby TrackerTests/AppModelTests.swift
@@ -1262,6 +1262,29 @@ struct AppModelTests {
     }
 
     @Test
+    func hardDeleteCurrentChildSelectsRemainingChildAndShowsSuccessMessage() async throws {
+        let harness = try Harness()
+        defer { harness.cleanUp() }
+
+        let seed = try harness.seedOwnerProfile()
+        let secondChild = try harness.saveOwnedChild(name: "Juniper", owner: seed.localUser)
+
+        harness.model.load(performLaunchSync: false)
+        let previousResetToken = harness.model.navigationResetToken
+
+        harness.model.selectChild(id: seed.child.id)
+        harness.model.hardDeleteCurrentChild()
+        await Task.yield()
+        await Task.yield()
+
+        #expect(harness.childSelectionStore.loadSelectedChildID() == secondChild.id)
+        #expect(harness.model.profile?.child.id == secondChild.id)
+        #expect(harness.model.route == .childProfile)
+        #expect(harness.model.transientMessage == "Poppy deleted")
+        #expect(harness.model.navigationResetToken == previousResetToken + 1)
+    }
+
+    @Test
     func beginAcceptingSharedChildShowsFullScreenLoadingState() throws {
         let harness = try Harness()
         defer { harness.cleanUp() }

--- a/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/AppModel.swift
+++ b/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/AppModel.swift
@@ -16,6 +16,8 @@ public final class AppModel {
     public private(set) var errorMessage: String?
     public private(set) var undoDeleteMessage: String?
     public private(set) var isLiveActivityEnabled: Bool
+    public private(set) var transientMessage: String?
+    public private(set) var navigationResetToken: Int = 0
     public private(set) var shareAcceptanceLoadingState: ShareAcceptanceLoadingState?
     public private(set) var sleepSheetRequestToken: Int = 0
     public var shareSheetState: ShareSheetState?
@@ -45,6 +47,7 @@ public final class AppModel {
     private var pendingUndoDeletedEvent: BabyEvent?
     private var undoDeleteTask: Task<Void, Never>?
     private var syncIndicatorDismissTask: Task<Void, Never>?
+    private var transientMessageDismissTask: Task<Void, Never>?
 
     public init(
         childRepository: any ChildRepository,
@@ -190,11 +193,12 @@ public final class AppModel {
 
             do {
                 try childRepository.purgeChildData(id: childID)
-                if childSelectionStore.loadSelectedChildID() == childID {
-                    childSelectionStore.saveSelectedChildID(nil)
-                }
+                let nextSelectedChildID = try nextSelectedChildID(afterDeleting: childID)
+                childSelectionStore.saveSelectedChildID(nextSelectedChildID)
                 clearUndoDeleteState()
-                refresh(selecting: nil)
+                showTransientMessage("\(profile.child.name) deleted")
+                resetNavigationStack()
+                refresh(selecting: nextSelectedChildID)
                 if let cloudDeleteError {
                     errorMessage = "Local data was cleared, but iCloud cleanup failed: \(cloudDeleteError.localizedDescription)"
                 }
@@ -1179,6 +1183,17 @@ public final class AppModel {
         undoDeleteMessage = nil
     }
 
+    private func nextSelectedChildID(afterDeleting deletedChildID: UUID) throws -> UUID? {
+        guard let localUser else {
+            return nil
+        }
+
+        return try childRepository
+            .loadActiveChildren(for: localUser.id)
+            .first(where: { $0.id != deletedChildID })?
+            .id
+    }
+
     private func resolveErrorMessage(for error: Error) -> String {
         if let localizedError = error as? LocalizedError,
            let description = localizedError.errorDescription {
@@ -1888,6 +1903,24 @@ public final class AppModel {
     private func setDataExportError(_ message: String) {
         dataExportState = .error(message)
         playHaptic(.actionFailed)
+    }
+
+    private func showTransientMessage(_ message: String) {
+        transientMessageDismissTask?.cancel()
+        transientMessage = message
+        transientMessageDismissTask = Task { @MainActor in
+            try? await Task.sleep(for: .seconds(4))
+
+            guard !Task.isCancelled else {
+                return
+            }
+
+            transientMessage = nil
+        }
+    }
+
+    private func resetNavigationStack() {
+        navigationResetToken &+= 1
     }
 
     private func playHaptic(_ event: HapticEvent) {

--- a/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/TransientMessageBannerView.swift
+++ b/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/TransientMessageBannerView.swift
@@ -1,0 +1,27 @@
+import SwiftUI
+
+public struct TransientMessageBannerView: View {
+    let message: String
+
+    public init(message: String) {
+        self.message = message
+    }
+
+    public var body: some View {
+        HStack(spacing: 12) {
+            Image(systemName: "checkmark.circle.fill")
+                .foregroundStyle(.green)
+
+            Text(message)
+                .font(.subheadline.weight(.medium))
+                .foregroundStyle(.primary)
+
+            Spacer()
+        }
+        .padding(.horizontal, 16)
+        .padding(.vertical, 12)
+        .background(.thinMaterial, in: Capsule())
+        .shadow(radius: 4, y: 2)
+        .accessibilityIdentifier("transient-message-banner")
+    }
+}

--- a/docs/plans/028-child-delete-transition-cleanup.md
+++ b/docs/plans/028-child-delete-transition-cleanup.md
@@ -1,0 +1,12 @@
+# 028 - Child delete transition cleanup
+
+## Goal
+Make child deletion transitions clearer by showing a success banner, switching to a valid remaining child, and avoiding stale navigation on deleted-child screens.
+
+## Plan
+1. Review the current hard-delete flow and identify the minimum state needed for a post-delete success banner and deterministic navigation reset.
+2. Extend the feature state so a successful delete can trigger a transient success message without affecting unrelated banners.
+3. Update the root/profile navigation flow so deleting the current child returns the user to a sensible top-level state.
+4. Add or update tests covering remaining-child selection and empty-state routing after delete.
+
+- [x] Complete


### PR DESCRIPTION
## Summary
- add a transient success banner for completed child deletion
- reset the navigation stack after hard delete so stale deleted-child screens are dismissed
- automatically select a valid remaining child after delete and cover the flow with tests

## Testing
- xcodebuild test -project 'Baby Tracker.xcodeproj' -scheme 'Baby Tracker' -parallel-testing-enabled NO -destination 'platform=iOS Simulator,OS=26.2,name=iPhone 17' -only-testing:'Baby TrackerTests/AppModelTests/hardDeleteCurrentChildSelectsRemainingChildAndShowsSuccessMessage'

Closes #76
