### PR TITLE
Track child updates for shared image sync

### DIFF
--- a/Baby TrackerTests/AppModelTests.swift
+++ b/Baby TrackerTests/AppModelTests.swift
@@ -1096,6 +1096,27 @@ struct AppModelTests {
         #expect(liveActivityManager.latestSnapshot?.lastFeedKind == .breastFeed)
     }
 
+    @Test
+    func updatingCurrentChildAdvancesUpdatedAt() throws {
+        let harness = try Harness()
+        defer { harness.cleanUp() }
+
+        let seed = try harness.seedOwnerProfile()
+        harness.model.load(performLaunchSync: false)
+        let originalChild = try #require(try harness.childRepository.loadChild(id: seed.child.id))
+
+        harness.model.updateCurrentChild(
+            name: "Poppy Updated",
+            birthDate: nil,
+            imageData: Data([0x01, 0x02])
+        )
+
+        let updatedChild = try #require(try harness.childRepository.loadChild(id: seed.child.id))
+        #expect(updatedChild.name == "Poppy Updated")
+        #expect(updatedChild.imageData == Data([0x01, 0x02]))
+        #expect(updatedChild.updatedAt >= originalChild.updatedAt)
+    }
+
     // MARK: - Archive
 
     @Test

--- a/Baby TrackerTests/ChildProfilePersistenceTests.swift
+++ b/Baby TrackerTests/ChildProfilePersistenceTests.swift
@@ -104,6 +104,27 @@ struct ChildProfilePersistenceTests {
     }
 
     @Test
+    func savesChildUpdatedAt() throws {
+        let harness = try RepositoryHarness()
+        defer { harness.cleanUp() }
+
+        let owner = try UserIdentity(displayName: "Owner")
+        let updatedAt = Date(timeIntervalSince1970: 20_000)
+        let child = try Child(
+            name: "Robin",
+            createdAt: Date(timeIntervalSince1970: 10_000),
+            updatedAt: updatedAt,
+            createdBy: owner.id
+        )
+
+        try harness.userIdentityRepository.saveLocalUser(owner)
+        try harness.childRepository.saveChild(child)
+
+        let loadedChild = try #require(try harness.childRepository.loadChild(id: child.id))
+        #expect(loadedChild.updatedAt == updatedAt)
+    }
+
+    @Test
     func savesSelectedChildIdentifier() throws {
         let harness = try RepositoryHarness()
         defer { harness.cleanUp() }

--- a/Baby TrackerTests/CloudKitRecordMapperTests.swift
+++ b/Baby TrackerTests/CloudKitRecordMapperTests.swift
@@ -220,4 +220,25 @@ struct CloudKitRecordMapperTests {
 
         #expect(mappedChild.preferredFeedVolumeUnit == .ounces)
     }
+
+    @Test
+    func childMapperRoundTripsImageAndUpdatedAt() throws {
+        let updatedAt = Date(timeIntervalSince1970: 12_345)
+        let imageData = Data([0x01, 0x02, 0x03])
+        let child = try Child(
+            name: "Robin",
+            createdAt: Date(timeIntervalSince1970: 10_000),
+            updatedAt: updatedAt,
+            createdBy: UUID(),
+            imageData: imageData
+        )
+        let zoneID = CloudKitRecordNames.zoneID(for: child.id, ownerName: "owner")
+
+        let record = CloudKitRecordMapper.childRecord(from: child, zoneID: zoneID)
+        let mappedChild = try CloudKitRecordMapper.child(from: record)
+
+        #expect(record["updatedAt"] as? Date == updatedAt)
+        #expect(mappedChild.updatedAt == updatedAt)
+        #expect(mappedChild.imageData == imageData)
+    }
 }

--- a/Packages/BabyTrackerDomain/Sources/BabyTrackerDomain/Child.swift
+++ b/Packages/BabyTrackerDomain/Sources/BabyTrackerDomain/Child.swift
@@ -5,6 +5,7 @@ public struct Child: Equatable, Identifiable, Sendable {
     public var name: String
     public var birthDate: Date?
     public let createdAt: Date
+    public var updatedAt: Date
     public let createdBy: UUID
     public var isArchived: Bool
     public var imageData: Data?
@@ -15,6 +16,7 @@ public struct Child: Equatable, Identifiable, Sendable {
         name: String,
         birthDate: Date? = nil,
         createdAt: Date = Date(),
+        updatedAt: Date? = nil,
         createdBy: UUID,
         isArchived: Bool = false,
         imageData: Data? = nil,
@@ -29,6 +31,7 @@ public struct Child: Equatable, Identifiable, Sendable {
         self.name = normalizedName
         self.birthDate = birthDate
         self.createdAt = createdAt
+        self.updatedAt = updatedAt ?? createdAt
         self.createdBy = createdBy
         self.isArchived = isArchived
         self.imageData = imageData
@@ -39,13 +42,15 @@ public struct Child: Equatable, Identifiable, Sendable {
         name: String,
         birthDate: Date?,
         imageData: Data? = nil,
-        preferredFeedVolumeUnit: FeedVolumeUnit
+        preferredFeedVolumeUnit: FeedVolumeUnit,
+        updatedAt: Date = Date()
     ) throws -> Child {
         try Child(
             id: id,
             name: name,
             birthDate: birthDate,
             createdAt: createdAt,
+            updatedAt: updatedAt,
             createdBy: createdBy,
             isArchived: isArchived,
             imageData: imageData,

--- a/Packages/BabyTrackerDomain/Sources/BabyTrackerDomain/UseCases/ArchiveCurrentChildUseCase.swift
+++ b/Packages/BabyTrackerDomain/Sources/BabyTrackerDomain/UseCases/ArchiveCurrentChildUseCase.swift
@@ -41,6 +41,7 @@ public struct ArchiveChildUseCase: UseCase {
 
         var archivedChild = input.child
         archivedChild.isArchived = true
+        archivedChild.updatedAt = .now
         try childRepository.saveChild(archivedChild)
 
         if input.currentSelectedChildID == archivedChild.id {

--- a/Packages/BabyTrackerDomain/Sources/BabyTrackerDomain/UseCases/RestoreChildUseCase.swift
+++ b/Packages/BabyTrackerDomain/Sources/BabyTrackerDomain/UseCases/RestoreChildUseCase.swift
@@ -30,6 +30,7 @@ public struct RestoreChildUseCase: UseCase {
         }
 
         restoredChild.isArchived = false
+        restoredChild.updatedAt = .now
         try childRepository.saveChild(restoredChild)
         childSelectionStore.saveSelectedChildID(input.childID)
         hapticFeedbackProvider.play(.actionSucceeded)

--- a/Packages/BabyTrackerPersistence/Sources/BabyTrackerPersistence/Models/StoredChild.swift
+++ b/Packages/BabyTrackerPersistence/Sources/BabyTrackerPersistence/Models/StoredChild.swift
@@ -8,6 +8,7 @@ final class StoredChild {
     var name: String = ""
     var birthDate: Date?
     var createdAt: Date = Date()
+    var updatedAt: Date = Date()
     var createdBy: UUID = UUID()
     var isArchived: Bool = false
     var imageData: Data?
@@ -25,6 +26,7 @@ final class StoredChild {
         name: String,
         birthDate: Date?,
         createdAt: Date,
+        updatedAt: Date,
         createdBy: UUID,
         isArchived: Bool,
         imageData: Data? = nil,
@@ -41,6 +43,7 @@ final class StoredChild {
         self.name = name
         self.birthDate = birthDate
         self.createdAt = createdAt
+        self.updatedAt = updatedAt
         self.createdBy = createdBy
         self.isArchived = isArchived
         self.imageData = imageData

--- a/Packages/BabyTrackerPersistence/Sources/BabyTrackerPersistence/SwiftDataChildRepository.swift
+++ b/Packages/BabyTrackerPersistence/Sources/BabyTrackerPersistence/SwiftDataChildRepository.swift
@@ -40,6 +40,7 @@ public final class SwiftDataChildRepository: CloudKitChildRepository {
             name: child.name,
             birthDate: child.birthDate,
             createdAt: child.createdAt,
+            updatedAt: child.updatedAt,
             createdBy: child.createdBy,
             isArchived: child.isArchived
         )
@@ -47,6 +48,7 @@ public final class SwiftDataChildRepository: CloudKitChildRepository {
         storedChild.name = child.name
         storedChild.birthDate = child.birthDate
         storedChild.createdAt = child.createdAt
+        storedChild.updatedAt = child.updatedAt
         storedChild.createdBy = child.createdBy
         storedChild.isArchived = child.isArchived
         storedChild.imageData = child.imageData
@@ -151,6 +153,7 @@ public final class SwiftDataChildRepository: CloudKitChildRepository {
             name: storedChild.name,
             birthDate: storedChild.birthDate,
             createdAt: storedChild.createdAt,
+            updatedAt: storedChild.updatedAt,
             createdBy: storedChild.createdBy,
             isArchived: storedChild.isArchived,
             imageData: storedChild.imageData,

--- a/Packages/BabyTrackerSync/Sources/BabyTrackerSync/CloudKitRecordMapper.swift
+++ b/Packages/BabyTrackerSync/Sources/BabyTrackerSync/CloudKitRecordMapper.swift
@@ -38,6 +38,7 @@ public enum CloudKitRecordMapper {
         record["name"] = child.name
         record["birthDate"] = child.birthDate
         record["createdAt"] = child.createdAt
+        record["updatedAt"] = child.updatedAt
         record["createdBy"] = child.createdBy.uuidString
         record["isArchived"] = child.isArchived
         record["preferredFeedVolumeUnit"] = child.preferredFeedVolumeUnit.rawValue
@@ -123,6 +124,7 @@ public enum CloudKitRecordMapper {
             name: record["name"] as? String ?? "",
             birthDate: record["birthDate"] as? Date,
             createdAt: record["createdAt"] as? Date ?? .now,
+            updatedAt: record["updatedAt"] as? Date ?? (record["createdAt"] as? Date ?? .now),
             createdBy: UUID(uuidString: record["createdBy"] as? String ?? "") ?? UUID(),
             isArchived: record["isArchived"] as? Bool ?? false,
             imageData: imageData,

--- a/Packages/BabyTrackerSync/Sources/BabyTrackerSync/CloudKitSyncEngine.swift
+++ b/Packages/BabyTrackerSync/Sources/BabyTrackerSync/CloudKitSyncEngine.swift
@@ -1284,7 +1284,7 @@ public final class CloudKitSyncEngine {
         switch record.recordType {
         case CloudKitConfiguration.childRecordType,
              CloudKitConfiguration.userRecordType:
-            return record["createdAt"] as? Date
+            return record["updatedAt"] as? Date ?? record["createdAt"] as? Date
         case CloudKitConfiguration.membershipRecordType:
             // acceptedAt is set when the caregiver accepts the share, making it
             // the most recent mutation timestamp for a membership record.

--- a/docs/plans/029-shared-child-image-sync.md
+++ b/docs/plans/029-shared-child-image-sync.md
@@ -1,0 +1,12 @@
+# 029 - Shared child image sync
+
+## Goal
+Ensure child profile images sync reliably across CloudKit sharing, including initial share acceptance, later updates, and image removal.
+
+## Plan
+1. Review the current child image save, CloudKit mapping, and accepted-share refresh path to find the missing behavior.
+2. Fix the sync path with the smallest change that keeps image handling at the child-record boundary.
+3. Add focused tests for image upload, update, and removal behavior in the CloudKit mapping/sync flow.
+4. Validate that the shared child image remains visible in existing presentation code without UI-specific workarounds.
+
+- [x] Complete


### PR DESCRIPTION
## Summary
- add `updatedAt` tracking to child records so later profile edits can sync reliably
- persist and map the new timestamp through SwiftData and CloudKit child records
- add focused tests for child image/timestamp mapping and update behavior

## Testing
- xcodebuild test -project 'Baby Tracker.xcodeproj' -scheme 'Baby Tracker' -parallel-testing-enabled NO -destination 'platform=iOS Simulator,OS=26.2,name=iPhone 17' -only-testing:'Baby TrackerTests/CloudKitRecordMapperTests/childMapperRoundTripsImageAndUpdatedAt' -only-testing:'Baby TrackerTests/ChildProfilePersistenceTests/savesChildUpdatedAt' -only-testing:'Baby TrackerTests/AppModelTests/updatingCurrentChildAdvancesUpdatedAt'

Closes #77
