### PR TITLE
Issue #84: Consolidate iCloud unavailable messaging

### DIFF
--- a/Baby TrackerTests/AppModelTests.swift
+++ b/Baby TrackerTests/AppModelTests.swift
@@ -310,11 +310,12 @@ struct AppModelTests {
         let profile = try #require(harness.model.profile)
 
         #expect(profile.cloudKitStatus.state == .failed)
-        #expect(profile.timeline.syncMessage == profile.cloudKitStatus.detailMessage)
+        #expect(profile.cloudKitStatus.isAccountUnavailable)
+        #expect(profile.timeline.syncMessage == nil)
     }
 
     @Test
-    func syncIndicatorShowsTransientUnavailableStateAfterFailedRefresh() async throws {
+    func syncIndicatorSuppressesUnavailableStateAfterFailedRefresh() async throws {
         let syncEngine = TestSyncEngine()
         syncEngine.refreshForegroundSummary = SyncStatusSummary(
             state: .failed,
@@ -330,19 +331,7 @@ struct AppModelTests {
 
         await harness.model.refreshSyncStatus()
 
-        guard let syncBannerState = harness.model.syncBannerState else {
-            Issue.record("Expected sync banner state after refresh")
-            return
-        }
-
-        switch syncBannerState {
-        case let .syncUnavailable(message):
-            #expect(message.localizedCaseInsensitiveContains("sync unavailable"))
-        case let .lastSyncFailed(message):
-            #expect(message.isEmpty == false)
-        case .syncing, .pendingSync:
-            Issue.record("Expected failed sync banner state after refresh completed")
-        }
+        #expect(harness.model.syncBannerState == nil)
     }
 
     @Test
@@ -995,7 +984,17 @@ struct AppModelTests {
 
         await harness.model.refreshSyncStatus()
 
-        #expect(hapticFeedbackProvider.events == [.actionFailed])
+        #expect(hapticFeedbackProvider.events.isEmpty)
+    }
+
+    @Test
+    func shareSheetSaveFailureSuppressesUnavailableErrorBanner() throws {
+        let harness = try Harness()
+        defer { harness.cleanUp() }
+
+        harness.model.handleShareSheetSaveFailure(TestLocalizedError.accountUnavailable)
+
+        #expect(harness.model.errorMessage == nil)
     }
 
     @Test
@@ -1666,5 +1665,16 @@ extension AppModelTests {
 
     private enum TestSyncEngineError: Error {
         case unimplemented
+    }
+
+    private enum TestLocalizedError: LocalizedError {
+        case accountUnavailable
+
+        var errorDescription: String? {
+            switch self {
+            case .accountUnavailable:
+                "Sync unavailable. Sign in to iCloud."
+            }
+        }
     }
 }

--- a/Baby TrackerTests/CloudKitStatusViewStateTests.swift
+++ b/Baby TrackerTests/CloudKitStatusViewStateTests.swift
@@ -52,5 +52,8 @@ struct CloudKitStatusViewStateTests {
         #expect(viewState.statusTitle == "Sync unavailable")
         #expect(viewState.backupTitle == "Last backup available")
         #expect(viewState.detailMessage == "Sync unavailable. Sign in to iCloud.")
+        #expect(viewState.isAccountUnavailable)
+        #expect(viewState.syncSettingsBannerTitle == "iCloud backup is unavailable")
+        #expect(viewState.syncSettingsBannerMessage?.localizedCaseInsensitiveContains("saving data on this device") == true)
     }
 }

--- a/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/AppModel.swift
+++ b/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/AppModel.swift
@@ -1554,6 +1554,10 @@ public final class AppModel {
     private func timelineSyncMessage(
         for cloudKitStatus: CloudKitStatusViewState
     ) -> String? {
+        if cloudKitStatus.isAccountUnavailable {
+            return nil
+        }
+
         switch cloudKitStatus.state {
         case .upToDate:
             return nil
@@ -1856,14 +1860,15 @@ public final class AppModel {
     private func updateSyncIndicator(using summary: SyncStatusSummary) {
         switch summary.state {
         case .failed:
-            let message = summary.lastErrorDescription ?? "Sync failed. Local changes are still saved."
-            let state: SyncBannerState
-            if message.localizedCaseInsensitiveContains("unavailable") ||
-                message.localizedCaseInsensitiveContains("sign in to iCloud") {
-                state = .syncUnavailable(message)
-            } else {
-                state = .lastSyncFailed(message)
+            let cloudKitStatus = CloudKitStatusViewState(summary: summary)
+            guard !cloudKitStatus.isAccountUnavailable else {
+                setSyncIndicator(nil)
+                return
             }
+
+            let message = cloudKitStatus.detailMessage ?? "Sync failed. Local changes are still saved."
+            let state: SyncBannerState
+            state = .lastSyncFailed(message)
             setSyncIndicator(state)
             playHaptic(.actionFailed)
             syncIndicatorDismissTask = Task { @MainActor in
@@ -1886,6 +1891,11 @@ public final class AppModel {
         _ message: String,
         haptic: HapticEvent = .actionFailed
     ) {
+        if CloudKitStatusViewState.isAccountUnavailableMessage(message) {
+            errorMessage = nil
+            return
+        }
+
         errorMessage = message
         playHaptic(haptic)
     }

--- a/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/CloudKitStatusViewState.swift
+++ b/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/CloudKitStatusViewState.swift
@@ -6,12 +6,15 @@ public struct CloudKitStatusViewState: Equatable, Sendable {
     public let pendingRecordCount: Int
     public let lastSyncAt: Date?
     public let detailMessage: String?
+    public let isAccountUnavailable: Bool
 
     public init(summary: SyncStatusSummary) {
         self.state = summary.state
         self.pendingRecordCount = summary.pendingRecordCount
         self.lastSyncAt = summary.lastSyncAt
-        self.detailMessage = Self.detailMessage(for: summary)
+        let detailMessage = Self.detailMessage(for: summary)
+        self.detailMessage = detailMessage
+        self.isAccountUnavailable = Self.isAccountUnavailableMessage(detailMessage)
     }
 
     public var statusTitle: String {
@@ -23,9 +26,7 @@ public struct CloudKitStatusViewState: Equatable, Sendable {
         case .syncing:
             return "Syncing now"
         case .failed:
-            if let detailMessage,
-               detailMessage.localizedCaseInsensitiveContains("sign in to iCloud") ||
-               detailMessage.localizedCaseInsensitiveContains("unavailable") {
+            if isAccountUnavailable {
                 return "Sync unavailable"
             }
 
@@ -49,6 +50,22 @@ public struct CloudKitStatusViewState: Equatable, Sendable {
         return pendingRecordCount == 1 ? "1 change" : "\(pendingRecordCount) changes"
     }
 
+    public var syncSettingsBannerTitle: String? {
+        guard isAccountUnavailable else {
+            return nil
+        }
+
+        return "iCloud backup is unavailable"
+    }
+
+    public var syncSettingsBannerMessage: String? {
+        guard isAccountUnavailable else {
+            return nil
+        }
+
+        return "Baby Tracker is still saving data on this device. Sign in to iCloud in Settings to resume backups and sharing."
+    }
+
     private static func detailMessage(for summary: SyncStatusSummary) -> String? {
         switch summary.state {
         case .upToDate:
@@ -66,5 +83,14 @@ public struct CloudKitStatusViewState: Equatable, Sendable {
         case .failed:
             return summary.lastErrorDescription ?? "Last sync failed. Local data is still available."
         }
+    }
+
+    public static func isAccountUnavailableMessage(_ message: String?) -> Bool {
+        guard let message else {
+            return false
+        }
+
+        return message.localizedCaseInsensitiveContains("unavailable") ||
+            message.localizedCaseInsensitiveContains("sign in to iCloud")
     }
 }

--- a/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/ChildProfileSharingView.swift
+++ b/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/ChildProfileSharingView.swift
@@ -110,6 +110,10 @@ public struct ChildProfileSharingView: View {
             return nil
         }
 
+        if profile.cloudKitStatus.isAccountUnavailable {
+            return "Sharing is unavailable until iCloud backup is available. Check the iCloud Sync screen for details."
+        }
+
         if let detailMessage = profile.cloudKitStatus.detailMessage {
             return "Sharing is unavailable right now. \(detailMessage)"
         }

--- a/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/ChildProfileSyncView.swift
+++ b/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/ChildProfileSyncView.swift
@@ -15,6 +15,22 @@ public struct ChildProfileSyncView: View {
 
     public var body: some View {
         List {
+            if let bannerTitle = profile.cloudKitStatus.syncSettingsBannerTitle,
+               let bannerMessage = profile.cloudKitStatus.syncSettingsBannerMessage {
+                Section {
+                    VStack(alignment: .leading, spacing: 8) {
+                        Label(bannerTitle, systemImage: "icloud.slash")
+                            .font(.headline)
+
+                        Text(bannerMessage)
+                            .font(.subheadline)
+                            .foregroundStyle(.secondary)
+                    }
+                    .padding(.vertical, 4)
+                    .accessibilityIdentifier("icloud-sync-unavailable-banner")
+                }
+            }
+
             Section("Status") {
                 LabeledContent("Sync") {
                     Text(profile.cloudKitStatus.statusTitle)

--- a/docs/plans/031-icloud-sync-unavailable-messaging.md
+++ b/docs/plans/031-icloud-sync-unavailable-messaging.md
@@ -1,0 +1,37 @@
+# 031 iCloud Sync Unavailable Messaging
+
+## Goal
+Reduce repeated iCloud account error messaging so users see one clear explanation on the iCloud Sync screen instead of multiple banners across the app.
+
+## Scope
+1. Detect when sync is unavailable because the user is not signed into iCloud or iCloud is otherwise unavailable.
+2. Keep the detailed explanation on the iCloud Sync screen.
+3. Remove repeated top-level error and sync banners for that specific account state.
+4. Keep other screens concise when sharing or syncing is unavailable.
+
+## Notes
+- The current sync status is shaped by `CloudKitStatusViewState`.
+- Repeated messaging currently appears through `ErrorBannerView`, `SyncIndicatorView`, timeline sync copy, and sharing copy.
+- Local data should still be presented as safe and available on device.
+
+## Plan
+1. Add explicit account-unavailable classification to `CloudKitStatusViewState`.
+2. Add dedicated sync-screen banner copy for the account-unavailable state.
+3. Suppress app-wide error banners for account-unavailable messages in `AppModel`.
+4. Suppress transient sync indicator banners for the same state.
+5. Hide timeline inline sync messaging when the issue is specifically missing iCloud access.
+6. Shorten sharing copy so it points users to the iCloud Sync screen instead of repeating the full account error.
+7. Add tests for the new classification and the suppressed repeated messaging behavior.
+
+## Acceptance Criteria
+1. The iCloud Sync screen shows one clear explanation when iCloud backup is unavailable.
+2. The app no longer repeats the same iCloud account error through top-level banners and transient sync indicators.
+3. Sharing remains unavailable while iCloud backup is unavailable, with concise guidance.
+4. Tests cover the unavailable classification and the suppressed repeated messaging behavior.
+
+## Out of Scope
+1. Changing generic sync failure handling for non-account-related errors.
+2. Adding Settings deep links or account repair flows.
+3. Changing persistence or CloudKit sync logic itself.
+
+- [x] Complete


### PR DESCRIPTION
## Summary
- classify iCloud account-unavailable sync failures explicitly in feature state
- show one clear explanation on the iCloud Sync screen
- suppress repeated top-level banners and duplicate timeline/sharing copy for that account state

## Testing
- xcodebuild build -project "Baby Tracker.xcodeproj" -scheme "Baby Tracker" -destination "platform=iOS Simulator,name=iPhone 17"
- xcodebuild test -project "Baby Tracker.xcodeproj" -scheme "Baby Tracker" -destination "platform=iOS Simulator,name=iPhone 17" -only-testing:"Baby TrackerTests/CloudKitStatusViewStateTests"
- xcodebuild test -project "Baby Tracker.xcodeproj" -scheme "Baby Tracker" -destination "platform=iOS Simulator,name=iPhone 17" -only-testing:"Baby TrackerTests/AppModelTests/testTimelineShowsSyncMessageWhenSyncStatusIsNotUpToDate" -only-testing:"Baby TrackerTests/AppModelTests/testSyncIndicatorSuppressesUnavailableStateAfterFailedRefresh" -only-testing:"Baby TrackerTests/AppModelTests/testFailedSyncRefreshPlaysErrorHaptic" -only-testing:"Baby TrackerTests/AppModelTests/testShareSheetSaveFailureSuppressesUnavailableErrorBanner"

## Links
- Closes #84
- Plan: docs/plans/031-icloud-sync-unavailable-messaging.md