### PR TITLE
Issue #86: Reset navigation and surface feedback when switching child

### DIFF
--- a/Baby TrackerTests/AppModelTests.swift
+++ b/Baby TrackerTests/AppModelTests.swift
@@ -313,6 +313,47 @@ struct AppModelTests {
     }
 
     @Test
+    func selectingDifferentChildResetsNavigationAndShowsProfileFeedback() throws {
+        let harness = try Harness()
+        defer { harness.cleanUp() }
+
+        let seed = try harness.seedOwnerProfile()
+        let secondChild = try harness.saveOwnedChild(
+            name: "Juniper",
+            owner: seed.localUser
+        )
+
+        harness.model.load(performLaunchSync: false)
+        harness.model.selectedWorkspaceTab = .timeline
+        let previousResetToken = harness.model.navigationResetToken
+
+        harness.model.selectChild(id: secondChild.id)
+
+        #expect(harness.model.profile?.child.id == secondChild.id)
+        #expect(harness.model.selectedWorkspaceTab == .profile)
+        #expect(harness.model.transientMessage == "Child changed.")
+        #expect(harness.model.navigationResetToken == previousResetToken + 1)
+    }
+
+    @Test
+    func reselectingCurrentChildDoesNotResetNavigationOrShowSwitchMessage() throws {
+        let harness = try Harness()
+        defer { harness.cleanUp() }
+
+        let seed = try harness.seedOwnerProfile()
+
+        harness.model.load(performLaunchSync: false)
+        harness.model.selectedWorkspaceTab = .summary
+        let previousResetToken = harness.model.navigationResetToken
+
+        harness.model.selectChild(id: seed.child.id)
+
+        #expect(harness.model.selectedWorkspaceTab == .summary)
+        #expect(harness.model.transientMessage == nil)
+        #expect(harness.model.navigationResetToken == previousResetToken)
+    }
+
+    @Test
     func timelineShowsSyncMessageWhenSyncStatusIsNotUpToDate() async throws {
         let syncEngine = TestSyncEngine()
         syncEngine.refreshForegroundSummary = SyncStatusSummary(

--- a/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/AppModel.swift
+++ b/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/AppModel.swift
@@ -20,6 +20,7 @@ public final class AppModel {
     public private(set) var navigationResetToken: Int = 0
     public private(set) var shareAcceptanceLoadingState: ShareAcceptanceLoadingState?
     public private(set) var sleepSheetRequestToken: Int = 0
+    public var selectedWorkspaceTab: ChildWorkspaceTab = .home
     public var shareSheetState: ShareSheetState?
     public private(set) var csvImportState: CSVImportState = .idle
     public private(set) var nestImportState: NestImportState = .idle
@@ -328,9 +329,19 @@ public final class AppModel {
     }
 
     public func selectChild(id: UUID) {
+        let currentSelectedChildID = childSelectionStore.loadSelectedChildID()
+        let didChangeChild = currentSelectedChildID != id
+
         childSelectionStore.saveSelectedChildID(id)
         timelineChildID = id
         timelineSelectedDay = normalizedTimelineDay(for: .now)
+        if didChangeChild {
+            timelineDisplayMode = .day
+            activeEventFilter = .empty
+            selectedWorkspaceTab = .profile
+            resetNavigationStack()
+            showTransientMessage("Child changed.")
+        }
         refresh(selecting: id)
         playHaptic(.selectionChanged)
     }

--- a/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/ChildWorkspaceTab.swift
+++ b/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/ChildWorkspaceTab.swift
@@ -1,0 +1,7 @@
+public enum ChildWorkspaceTab: Hashable, Sendable {
+    case home
+    case summary
+    case events
+    case timeline
+    case profile
+}

--- a/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/ChildWorkspaceTabView.swift
+++ b/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/ChildWorkspaceTabView.swift
@@ -5,7 +5,6 @@ public struct ChildWorkspaceTabView: View {
     let model: AppModel
     let profile: ChildProfileScreenState
 
-    @State private var selectedTab: Tab = .home
     @State private var activeEventSheet: ChildEventSheet?
     @State private var deleteCandidate: EventDeleteCandidate?
     @State private var showingEditChildSheet = false
@@ -23,7 +22,7 @@ public struct ChildWorkspaceTabView: View {
     public var body: some View {
         @Bindable var bindableModel = model
 
-        TabView(selection: $selectedTab) {
+        TabView(selection: $bindableModel.selectedWorkspaceTab) {
             ChildHomeView(
                 profile: profile,
                 stopSleep: showSleepSheet,
@@ -34,7 +33,7 @@ public struct ChildWorkspaceTabView: View {
                     activeEventSheet = .quickLogNappy(.wee)
                 }
             )
-            .tag(Tab.home)
+            .tag(ChildWorkspaceTab.home)
             .tabItem {
                 Label("Home", systemImage: "house")
             }
@@ -49,7 +48,7 @@ public struct ChildWorkspaceTabView: View {
                 onFilterUpdate: model.updateEventFilter,
                 onRefresh: model.forceFullSyncRefresh
             )
-            .tag(Tab.events)
+            .tag(ChildWorkspaceTab.events)
             .tabItem {
                 Label("Events", systemImage: "list.bullet.rectangle")
             }
@@ -63,14 +62,13 @@ public struct ChildWorkspaceTabView: View {
                 confirmDelete: performDelete,
                 cancelDelete: cancelDelete
             )
-            .tag(Tab.timeline)
+            .tag(ChildWorkspaceTab.timeline)
             .tabItem {
                 Label("Timeline", systemImage: "calendar")
             }
 
-
             SummaryScreenView(summary: profile.summary)
-            .tag(Tab.summary)
+            .tag(ChildWorkspaceTab.summary)
             .tabItem {
                 Label("Summary", systemImage: "chart.bar.fill")
             }
@@ -83,7 +81,7 @@ public struct ChildWorkspaceTabView: View {
                 archiveAction: { model.archiveCurrentChild() },
                 hardDeleteAction: { model.hardDeleteCurrentChild() }
             )
-            .tag(Tab.profile)
+            .tag(ChildWorkspaceTab.profile)
             .tabItem {
                 Label("Profile", systemImage: "person.crop.circle")
             }
@@ -91,7 +89,7 @@ public struct ChildWorkspaceTabView: View {
         .navigationTitle(profile.child.name)
         .navigationBarTitleDisplayMode(.inline)
         .toolbar {
-            if selectedTab == .events {
+            if model.selectedWorkspaceTab == .events {
                 ToolbarItem(placement: .topBarTrailing) {
                     Button {
                         showingEventFilter = true
@@ -104,7 +102,7 @@ public struct ChildWorkspaceTabView: View {
                     .accessibilityIdentifier("event-history-filter-button")
                 }
             }
-            if selectedTab == .timeline {
+            if model.selectedWorkspaceTab == .timeline {
                 ToolbarItem(placement: .topBarTrailing) {
                     Button(profile.timeline.displayMode == .day ? "Week View" : "Day View") {
                         model.toggleTimelineDisplayMode()
@@ -422,15 +420,5 @@ public struct ChildWorkspaceTabView: View {
         }
 
         return max(now, startedAt.addingTimeInterval(1))
-    }
-}
-
-extension ChildWorkspaceTabView {
-    public enum Tab: Hashable {
-        case home
-        case summary
-        case events
-        case timeline
-        case profile
     }
 }

--- a/docs/plans/032-child-switch-root-reset.md
+++ b/docs/plans/032-child-switch-root-reset.md
@@ -1,0 +1,36 @@
+# 032 Child Switch Root Reset
+
+## Goal
+Make child switching consistently reset the app to the root workspace, open the Profile tab, and show clear feedback that the active child changed.
+
+## Scope
+1. Detect when the selected child actually changes.
+2. Reset the navigation stack for real child switches.
+3. Force the Profile tab to become active after a real child switch.
+4. Show a brief transient message that confirms the child changed.
+
+## Notes
+- Child selection currently happens through `AppModel.selectChild(id:)`.
+- Workspace tab selection currently lives inside `ChildWorkspaceTabView`.
+- The app already has `navigationResetToken` and `transientMessage`, so this work should reuse those mechanisms.
+
+## Plan
+1. Move workspace tab selection into a shared feature-level type owned by `AppModel`.
+2. Bind `ChildWorkspaceTabView` to the app model tab state instead of local `@State`.
+3. Update `selectChild(id:)` to detect whether the incoming child differs from the current selection.
+4. For real switches, reset the navigation stack, reset timeline state, switch to the Profile tab, and show `Child changed.`.
+5. Keep no-op re-selection lightweight so it does not reset navigation or show redundant feedback.
+6. Add tests for the real-switch and no-op paths.
+
+## Acceptance Criteria
+1. Switching to a different child returns the app to the root workspace.
+2. The Profile tab is active after a real child switch.
+3. A transient `Child changed.` message appears after a real child switch.
+4. Re-selecting the already active child does not reset navigation or show the switch message.
+
+## Out of Scope
+1. Changing the child picker UI design.
+2. Changing how child data is loaded or persisted.
+3. Adding new transition animations for the tab switch.
+
+- [x] Complete


### PR DESCRIPTION
## Summary
- move workspace tab ownership into AppModel so child switches can force a consistent destination
- reset the navigation stack and open the Profile tab on real child changes
- show a transient "Child changed." message while leaving no-op reselection untouched

## Testing
- xcodebuild build -project "Baby Tracker.xcodeproj" -scheme "Baby Tracker" -destination "platform=iOS Simulator,name=iPhone 17"
- xcodebuild test -project "Baby Tracker.xcodeproj" -scheme "Baby Tracker" -destination "platform=iOS Simulator,name=iPhone 17" -only-testing:"Baby TrackerTests/AppModelTests/testSelectingDifferentChildResetsTimelineDayToToday" -only-testing:"Baby TrackerTests/AppModelTests/testSelectingDifferentChildResetsNavigationAndShowsProfileFeedback" -only-testing:"Baby TrackerTests/AppModelTests/testReselectingCurrentChildDoesNotResetNavigationOrShowSwitchMessage"

## Links
- Closes #86
- Plan: docs/plans/032-child-switch-root-reset.md