### PR TITLE
Issue #16: Replace first-run name prompt with onboarding flow

### DIFF
--- a/Baby TrackerTests/AppModelTests.swift
+++ b/Baby TrackerTests/AppModelTests.swift
@@ -8,6 +8,29 @@ import Testing
 @MainActor
 struct AppModelTests {
     @Test
+    func loadingWithoutLocalUserRoutesToIdentityOnboarding() throws {
+        let harness = try Harness()
+        defer { harness.cleanUp() }
+
+        harness.model.load(performLaunchSync: false)
+
+        #expect(harness.model.route == .identityOnboarding)
+        #expect(harness.model.localUser == nil)
+    }
+
+    @Test
+    func creatingLocalUserRoutesToNoChildren() throws {
+        let harness = try Harness()
+        defer { harness.cleanUp() }
+
+        harness.model.load(performLaunchSync: false)
+        harness.model.createLocalUser(displayName: "Alex Parent")
+
+        #expect(harness.model.route == .noChildren)
+        #expect(harness.model.localUser?.displayName == "Alex Parent")
+    }
+
+    @Test
     func profileDerivesHomeRecentEventsInNewestFirstOrder() throws {
         let harness = try Harness()
         defer { harness.cleanUp() }

--- a/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/OnboardingIntroPage.swift
+++ b/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/OnboardingIntroPage.swift
@@ -1,0 +1,8 @@
+import Foundation
+
+struct OnboardingIntroPage: Identifiable, Equatable, Sendable {
+    let id = UUID()
+    let title: String
+    let message: String
+    let symbolName: String
+}

--- a/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/IdentityOnboardingNameStepView.swift
+++ b/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/IdentityOnboardingNameStepView.swift
@@ -1,0 +1,68 @@
+import SwiftUI
+
+struct IdentityOnboardingNameStepView: View {
+    @Binding var displayName: String
+    let submitAction: () -> Void
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 24) {
+            Spacer(minLength: 32)
+
+            VStack(alignment: .leading, spacing: 12) {
+                Text("Let’s set up your profile")
+                    .font(.largeTitle.weight(.bold))
+
+                Text("Start with your name. You can add your first child right after this.")
+                    .font(.title3)
+                    .foregroundStyle(.secondary)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+
+            VStack(alignment: .leading, spacing: 8) {
+                Text("Your name")
+                    .font(.caption.weight(.semibold))
+                    .foregroundStyle(.secondary)
+                    .padding(.horizontal, 4)
+
+                TextField("e.g. Sarah", text: $displayName)
+                    .font(.title3)
+                    .textInputAutocapitalization(.words)
+                    .submitLabel(.done)
+                    .padding(16)
+                    .background(
+                        RoundedRectangle(cornerRadius: 18, style: .continuous)
+                            .fill(Color(.secondarySystemGroupedBackground))
+                    )
+                    .accessibilityIdentifier("identity-name-field")
+            }
+
+            RoundedRectangle(cornerRadius: 24, style: .continuous)
+                .fill(.thinMaterial)
+                .overlay(alignment: .leading) {
+                    VStack(alignment: .leading, spacing: 6) {
+                        Text("Next up")
+                            .font(.caption.weight(.semibold))
+                            .foregroundStyle(.secondary)
+
+                        Text("You’ll go straight into creating your first child profile.")
+                            .font(.subheadline)
+                    }
+                    .padding(20)
+                }
+                .frame(height: 96)
+
+            Spacer(minLength: 24)
+        }
+        .padding(.horizontal, 24)
+        .onSubmit {
+            submitAction()
+        }
+    }
+}
+
+#Preview {
+    IdentityOnboardingNameStepView(
+        displayName: .constant("Alex"),
+        submitAction: {}
+    )
+}

--- a/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/IdentityOnboardingView.swift
+++ b/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/IdentityOnboardingView.swift
@@ -1,66 +1,139 @@
+import BabyTrackerDomain
+import BabyTrackerPersistence
+import BabyTrackerSync
 import SwiftUI
 
 public struct IdentityOnboardingView: View {
     let model: AppModel
 
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+    @State private var currentStepIndex = 0
     @State private var displayName = ""
+
+    private static let introPages: [OnboardingIntroPage] = [
+        OnboardingIntroPage(
+            title: "Track every feed, sleep, and nappy",
+            message: "Log the moments that matter without digging through a complicated setup.",
+            symbolName: "drop.circle.fill"
+        ),
+        OnboardingIntroPage(
+            title: "See patterns at a glance",
+            message: "Use the Summary tab to spot daily rhythms and understand how your baby is doing over time.",
+            symbolName: "chart.line.uptrend.xyaxis.circle.fill"
+        ),
+        OnboardingIntroPage(
+            title: "Share with another caregiver",
+            message: "Keep both parents in sync through iCloud so everyone is working from the same timeline.",
+            symbolName: "person.2.circle.fill"
+        ),
+    ]
 
     private var trimmedName: String {
         displayName.trimmingCharacters(in: .whitespaces)
+    }
+
+    private var isShowingNameStep: Bool {
+        currentStepIndex >= Self.introPages.count
     }
 
     public init(model: AppModel) {
         self.model = model
     }
 
+    init(
+        model: AppModel,
+        previewStepIndex: Int,
+        previewDisplayName: String = ""
+    ) {
+        self.model = model
+        _currentStepIndex = State(initialValue: previewStepIndex)
+        _displayName = State(initialValue: previewDisplayName)
+    }
+
     public var body: some View {
         ZStack {
-            Color(.systemGroupedBackground).ignoresSafeArea()
+            LinearGradient(
+                colors: [
+                    Color(.systemGroupedBackground),
+                    Color.accentColor.opacity(0.08),
+                    Color(.systemGroupedBackground),
+                ],
+                startPoint: .topLeading,
+                endPoint: .bottomTrailing
+            )
+            .ignoresSafeArea()
 
             VStack(spacing: 0) {
-                Spacer()
+                topBar
 
-                VStack(spacing: 16) {
-                    Image(systemName: "figure.and.child.holdinghands")
-                        .font(.system(size: 64, weight: .thin))
-                        .foregroundStyle(Color.accentColor)
-                        .accessibilityHidden(true)
-
-                    Text("Baby Tracker")
-                        .font(.largeTitle.weight(.bold))
-
-                    Text("What should we call you?")
-                        .font(.title3)
-                        .foregroundStyle(.secondary)
-                        .multilineTextAlignment(.center)
-                }
-
-                Spacer().frame(height: 40)
-
-                VStack(alignment: .leading, spacing: 8) {
-                    Text("Your name")
-                        .font(.caption.weight(.semibold))
-                        .foregroundStyle(.secondary)
-                        .padding(.horizontal, 4)
-
-                    TextField("e.g. Sarah", text: $displayName)
-                        .font(.title3)
-                        .textInputAutocapitalization(.words)
-                        .submitLabel(.done)
-                        .padding(16)
-                        .background(
-                            RoundedRectangle(cornerRadius: 14, style: .continuous)
-                                .fill(Color(.secondarySystemGroupedBackground))
+                Group {
+                    if isShowingNameStep {
+                        IdentityOnboardingNameStepView(
+                            displayName: $displayName,
+                            submitAction: submitName
                         )
-                        .accessibilityIdentifier("identity-name-field")
+                    } else {
+                        introPager
+                    }
                 }
-                .padding(.horizontal, 32)
+                .animation(reduceMotion ? nil : .easeInOut(duration: 0.25), value: currentStepIndex)
 
-                Spacer().frame(height: 24)
+                Spacer(minLength: 24)
 
-                Button {
-                    model.createLocalUser(displayName: trimmedName)
-                } label: {
+                footer
+                    .padding(.horizontal, 24)
+                    .padding(.bottom, 24)
+            }
+        }
+    }
+
+    private var topBar: some View {
+        HStack {
+            Text("Baby Tracker")
+                .font(.headline)
+                .foregroundStyle(.secondary)
+
+            Spacer()
+
+            if !isShowingNameStep {
+                Button("Skip") {
+                    moveToNameStep()
+                }
+                .font(.subheadline.weight(.semibold))
+                .accessibilityIdentifier("identity-onboarding-skip-button")
+            }
+        }
+        .padding(.horizontal, 24)
+        .padding(.top, 20)
+    }
+
+    private var introPager: some View {
+        VStack(spacing: 24) {
+            TabView(selection: $currentStepIndex) {
+                ForEach(Array(Self.introPages.enumerated()), id: \.offset) { index, page in
+                    OnboardingIntroStepView(page: page)
+                        .tag(index)
+                        .padding(.horizontal, 24)
+                }
+            }
+            .tabViewStyle(.page(indexDisplayMode: .never))
+
+            HStack(spacing: 8) {
+                ForEach(Self.introPages.indices, id: \.self) { index in
+                    Capsule()
+                        .fill(index == currentStepIndex ? Color.accentColor : Color.secondary.opacity(0.18))
+                        .frame(width: index == currentStepIndex ? 28 : 10, height: 10)
+                }
+            }
+            .accessibilityElement(children: .ignore)
+            .accessibilityLabel("Onboarding step \(currentStepIndex + 1) of \(Self.introPages.count)")
+        }
+    }
+
+    private var footer: some View {
+        VStack(spacing: 12) {
+            if isShowingNameStep {
+                Button(action: submitName) {
                     Text("Get Started")
                         .font(.headline)
                         .frame(maxWidth: .infinity)
@@ -68,16 +141,107 @@ public struct IdentityOnboardingView: View {
                 }
                 .buttonStyle(.borderedProminent)
                 .disabled(trimmedName.isEmpty)
-                .padding(.horizontal, 32)
                 .accessibilityIdentifier("identity-save-button")
-
-                Spacer()
-                Spacer()
+            } else {
+                Button {
+                    advance()
+                } label: {
+                    Text(currentStepIndex == Self.introPages.count - 1 ? "Get Started" : "Continue")
+                        .font(.headline)
+                        .frame(maxWidth: .infinity)
+                        .padding(.vertical, 16)
+                }
+                .buttonStyle(.borderedProminent)
+                .accessibilityIdentifier("identity-onboarding-continue-button")
             }
         }
-        .onSubmit {
-            guard !trimmedName.isEmpty else { return }
-            model.createLocalUser(displayName: trimmedName)
+    }
+
+    private func advance() {
+        if currentStepIndex < Self.introPages.count - 1 {
+            move(to: currentStepIndex + 1)
+        } else {
+            moveToNameStep()
         }
+    }
+
+    private func moveToNameStep() {
+        move(to: Self.introPages.count)
+    }
+
+    private func move(to stepIndex: Int) {
+        guard reduceMotion == false else {
+            currentStepIndex = stepIndex
+            return
+        }
+
+        withAnimation(.easeInOut(duration: 0.25)) {
+            currentStepIndex = stepIndex
+        }
+    }
+
+    private func submitName() {
+        guard !trimmedName.isEmpty else {
+            return
+        }
+
+        model.createLocalUser(displayName: trimmedName)
+    }
+}
+
+#Preview("Intro") {
+    IdentityOnboardingView(
+        model: IdentityOnboardingPreviewFactory.makeModel(),
+        previewStepIndex: 0
+    )
+}
+
+#Preview("Name Step") {
+    IdentityOnboardingView(
+        model: IdentityOnboardingPreviewFactory.makeModel(),
+        previewStepIndex: 3,
+        previewDisplayName: "Alex"
+    )
+}
+
+private enum IdentityOnboardingPreviewFactory {
+    @MainActor
+    static func makeModel() -> AppModel {
+        let suiteName = "IdentityOnboardingPreview"
+        let userDefaults = UserDefaults(suiteName: suiteName) ?? .standard
+        userDefaults.removePersistentDomain(forName: suiteName)
+
+        let store = try! BabyTrackerModelStore(isStoredInMemoryOnly: true)
+        let childRepository = SwiftDataChildRepository(store: store)
+        let userIdentityRepository = SwiftDataUserIdentityRepository(store: store, userDefaults: userDefaults)
+        let membershipRepository = SwiftDataMembershipRepository(store: store)
+        let childSelectionStore = UserDefaultsChildSelectionStore(userDefaults: userDefaults)
+        let eventRepository = SwiftDataEventRepository(store: store)
+        let syncStateRepository = SwiftDataSyncStateRepository(store: store)
+        let recordMetadataRepository = SwiftDataCloudKitRecordMetadataRepository(store: store)
+        let syncEngine = CloudKitSyncEngine(
+            childRepository: childRepository,
+            userIdentityRepository: userIdentityRepository,
+            membershipRepository: membershipRepository,
+            eventRepository: eventRepository,
+            syncStateRepository: syncStateRepository,
+            recordMetadataRepository: recordMetadataRepository,
+            client: UnavailableCloudKitClient()
+        )
+        let model = AppModel(
+            childRepository: childRepository,
+            userIdentityRepository: userIdentityRepository,
+            membershipRepository: membershipRepository,
+            childSelectionStore: childSelectionStore,
+            eventRepository: eventRepository,
+            syncEngine: syncEngine,
+            liveActivityManager: NoOpFeedLiveActivityManager(),
+            liveActivityPreferenceStore: InMemoryLiveActivityPreferenceStore(),
+            localNotificationManager: NoOpLocalNotificationManager(),
+            hapticFeedbackProvider: NoOpHapticFeedbackProvider()
+        )
+
+        model.load(performLaunchSync: false)
+        return model
     }
 }

--- a/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/OnboardingIntroStepView.swift
+++ b/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/OnboardingIntroStepView.swift
@@ -1,0 +1,64 @@
+import SwiftUI
+
+struct OnboardingIntroStepView: View {
+    let page: OnboardingIntroPage
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 24) {
+            Spacer(minLength: 24)
+
+            ZStack {
+                RoundedRectangle(cornerRadius: 32, style: .continuous)
+                    .fill(Color.accentColor.opacity(0.14))
+                    .frame(width: 112, height: 112)
+
+                Image(systemName: page.symbolName)
+                    .font(.system(size: 44, weight: .semibold))
+                    .foregroundStyle(Color.accentColor)
+            }
+            .accessibilityHidden(true)
+
+            VStack(alignment: .leading, spacing: 12) {
+                Text(page.title)
+                    .font(.largeTitle.weight(.bold))
+                    .foregroundStyle(.primary)
+
+                Text(page.message)
+                    .font(.title3)
+                    .foregroundStyle(.secondary)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+
+            Spacer(minLength: 24)
+
+            RoundedRectangle(cornerRadius: 28, style: .continuous)
+                .fill(.thinMaterial)
+                .overlay {
+                    HStack(spacing: 16) {
+                        featureBadge(title: "Fast logging", symbolName: "checkmark.circle.fill")
+                        featureBadge(title: "Shared timeline", symbolName: "person.2.fill")
+                    }
+                    .padding(.horizontal, 20)
+                }
+                .frame(height: 84)
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .leading)
+    }
+
+    private func featureBadge(title: String, symbolName: String) -> some View {
+        Label(title, systemImage: symbolName)
+            .font(.subheadline.weight(.semibold))
+            .foregroundStyle(.secondary)
+            .frame(maxWidth: .infinity, alignment: .leading)
+    }
+}
+
+#Preview {
+    OnboardingIntroStepView(
+        page: OnboardingIntroPage(
+            title: "Track every feed, sleep, and nappy",
+            message: "Log the moments that matter without digging through a complicated setup.",
+            symbolName: "drop.circle.fill"
+        )
+    )
+}

--- a/docs/plans/028-onboarding-flow.md
+++ b/docs/plans/028-onboarding-flow.md
@@ -46,4 +46,4 @@ Replace the current single-step identity prompt with a clearer onboarding flow t
 2. Adding network-backed onboarding content or remote configuration.
 3. Building a full tutorial system for every screen in the app.
 
-- [ ] Complete
+- [x] Complete


### PR DESCRIPTION
Closes #16

## Summary
- replace the bare first-run name form with a short onboarding intro flow
- add a dedicated final name step that still uses `AppModel.createLocalUser(displayName:)`
- cover the first-run routing path with AppModel tests and mark the plan complete

## Testing
- xcodebuild -project "Baby Tracker.xcodeproj" -scheme "Baby Tracker" -destination "platform=iOS Simulator,name=iPhone 17" build
- xcodebuild -project "Baby Tracker.xcodeproj" -scheme "Baby Tracker" -destination "platform=iOS Simulator,name=iPhone 17" test

Plan: `docs/plans/028-onboarding-flow.md`