### PR TITLE
Issue #50: Add advanced summary drill-in and day-level metrics

### DIFF
--- a/Baby TrackerTests/AdvancedSummaryMetricsCalculatorTests.swift
+++ b/Baby TrackerTests/AdvancedSummaryMetricsCalculatorTests.swift
@@ -1,0 +1,189 @@
+import BabyTrackerDomain
+import BabyTrackerFeature
+import Foundation
+import Testing
+
+struct AdvancedSummaryMetricsCalculatorTests {
+    @Test
+    func daySelectionUsesOnlyTheChosenDay() throws {
+        var calendar = Calendar(identifier: .gregorian)
+        calendar.timeZone = TimeZone(secondsFromGMT: 0)!
+
+        let childID = UUID()
+        let userID = UUID()
+        let selectedDay = try #require(calendar.date(from: DateComponents(year: 2026, month: 3, day: 25, hour: 12)))
+        let sameDayBottle = try #require(calendar.date(from: DateComponents(year: 2026, month: 3, day: 25, hour: 8)))
+        let sameDayNappy = try #require(calendar.date(from: DateComponents(year: 2026, month: 3, day: 25, hour: 10)))
+        let nextDayBottle = try #require(calendar.date(from: DateComponents(year: 2026, month: 3, day: 26, hour: 8)))
+
+        let events: [BabyEvent] = [
+            .bottleFeed(
+                try BottleFeedEvent(
+                    metadata: EventMetadata(
+                        childID: childID,
+                        occurredAt: sameDayBottle,
+                        createdAt: sameDayBottle,
+                        createdBy: userID
+                    ),
+                    amountMilliliters: 120
+                )
+            ),
+            .nappy(
+                try NappyEvent(
+                    metadata: EventMetadata(
+                        childID: childID,
+                        occurredAt: sameDayNappy,
+                        createdAt: sameDayNappy,
+                        createdBy: userID
+                    ),
+                    type: .wee,
+                    peeVolume: .medium
+                )
+            ),
+            .bottleFeed(
+                try BottleFeedEvent(
+                    metadata: EventMetadata(
+                        childID: childID,
+                        occurredAt: nextDayBottle,
+                        createdAt: nextDayBottle,
+                        createdBy: userID
+                    ),
+                    amountMilliliters: 180
+                )
+            ),
+        ]
+
+        let viewState = AdvancedSummaryMetricsCalculator.makeViewState(
+            from: events,
+            selection: AdvancedSummarySelection(mode: .day, range: .today, day: selectedDay),
+            now: nextDayBottle,
+            calendar: calendar
+        )
+
+        #expect(viewState.eventCount == 2)
+        #expect(viewState.totalFeeds == 1)
+        #expect(viewState.totalNappies == 1)
+    }
+
+    @Test
+    func averageBottleVolumeUsesOnlyBottleFeedsInSelection() throws {
+        var calendar = Calendar(identifier: .gregorian)
+        calendar.timeZone = TimeZone(secondsFromGMT: 0)!
+
+        let childID = UUID()
+        let userID = UUID()
+        let now = try #require(calendar.date(from: DateComponents(year: 2026, month: 3, day: 26, hour: 12)))
+        let firstBottle = try #require(calendar.date(from: DateComponents(year: 2026, month: 3, day: 26, hour: 7)))
+        let secondBottle = try #require(calendar.date(from: DateComponents(year: 2026, month: 3, day: 26, hour: 10)))
+
+        let events: [BabyEvent] = [
+            .bottleFeed(
+                try BottleFeedEvent(
+                    metadata: EventMetadata(
+                        childID: childID,
+                        occurredAt: firstBottle,
+                        createdAt: firstBottle,
+                        createdBy: userID
+                    ),
+                    amountMilliliters: 120
+                )
+            ),
+            .bottleFeed(
+                try BottleFeedEvent(
+                    metadata: EventMetadata(
+                        childID: childID,
+                        occurredAt: secondBottle,
+                        createdAt: secondBottle,
+                        createdBy: userID
+                    ),
+                    amountMilliliters: 180
+                )
+            ),
+            .breastFeed(
+                try BreastFeedEvent(
+                    metadata: EventMetadata(
+                        childID: childID,
+                        occurredAt: secondBottle.addingTimeInterval(1_800),
+                        createdAt: secondBottle.addingTimeInterval(1_800),
+                        createdBy: userID
+                    ),
+                    side: .right,
+                    startedAt: secondBottle.addingTimeInterval(900),
+                    endedAt: secondBottle.addingTimeInterval(1_800)
+                )
+            ),
+        ]
+
+        let viewState = AdvancedSummaryMetricsCalculator.makeViewState(
+            from: events,
+            selection: .range(.today),
+            now: now,
+            calendar: calendar
+        )
+
+        #expect(viewState.bottleFeedCount == 2)
+        #expect(viewState.averageBottleVolumeMilliliters == 150)
+    }
+
+    @Test
+    func busiestHourUsesAllEventsInFilteredSelection() throws {
+        var calendar = Calendar(identifier: .gregorian)
+        calendar.timeZone = TimeZone(secondsFromGMT: 0)!
+
+        let childID = UUID()
+        let userID = UUID()
+        let now = try #require(calendar.date(from: DateComponents(year: 2026, month: 3, day: 26, hour: 18)))
+        let morning = try #require(calendar.date(from: DateComponents(year: 2026, month: 3, day: 26, hour: 9)))
+        let lateMorning = try #require(calendar.date(from: DateComponents(year: 2026, month: 3, day: 26, hour: 9, minute: 30)))
+        let afternoon = try #require(calendar.date(from: DateComponents(year: 2026, month: 3, day: 26, hour: 15)))
+
+        let events: [BabyEvent] = [
+            .bottleFeed(
+                try BottleFeedEvent(
+                    metadata: EventMetadata(
+                        childID: childID,
+                        occurredAt: morning,
+                        createdAt: morning,
+                        createdBy: userID
+                    ),
+                    amountMilliliters: 100
+                )
+            ),
+            .nappy(
+                try NappyEvent(
+                    metadata: EventMetadata(
+                        childID: childID,
+                        occurredAt: lateMorning,
+                        createdAt: lateMorning,
+                        createdBy: userID
+                    ),
+                    type: .mixed,
+                    pooVolume: .light,
+                    pooColor: .yellow
+                )
+            ),
+            .sleep(
+                try SleepEvent(
+                    metadata: EventMetadata(
+                        childID: childID,
+                        occurredAt: afternoon,
+                        createdAt: afternoon,
+                        createdBy: userID
+                    ),
+                    startedAt: afternoon.addingTimeInterval(-3_600),
+                    endedAt: afternoon
+                )
+            ),
+        ]
+
+        let viewState = AdvancedSummaryMetricsCalculator.makeViewState(
+            from: events,
+            selection: .range(.today),
+            now: now,
+            calendar: calendar
+        )
+
+        #expect(viewState.busiestHourLabel == "9AM")
+        #expect(viewState.busiestHourCount == 2)
+    }
+}

--- a/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/AdvancedSummaryMetricsCalculator.swift
+++ b/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/AdvancedSummaryMetricsCalculator.swift
@@ -1,0 +1,234 @@
+import BabyTrackerDomain
+import Foundation
+
+public enum AdvancedSummaryMetricsCalculator {
+    public static func makeViewState(
+        from events: [BabyEvent],
+        selection: AdvancedSummarySelection,
+        now: Date = .now,
+        calendar: Calendar = .autoupdatingCurrent
+    ) -> AdvancedSummaryViewState {
+        let filteredEvents = filter(
+            events: events.sorted { $0.metadata.occurredAt < $1.metadata.occurredAt },
+            selection: selection,
+            now: now,
+            calendar: calendar
+        )
+
+        let breastFeeds = filteredEvents.compactMap { event -> BreastFeedEvent? in
+            guard case let .breastFeed(feed) = event else { return nil }
+            return feed
+        }
+        let bottleFeeds = filteredEvents.compactMap { event -> BottleFeedEvent? in
+            guard case let .bottleFeed(feed) = event else { return nil }
+            return feed
+        }
+        let completedSleeps = filteredEvents.compactMap { event -> SleepEvent? in
+            guard case let .sleep(sleep) = event, sleep.endedAt != nil else { return nil }
+            return sleep
+        }
+        let nappies = filteredEvents.compactMap { event -> NappyEvent? in
+            guard case let .nappy(nappy) = event else { return nil }
+            return nappy
+        }
+
+        let sleepDurations = completedSleeps.compactMap(sleepDurationMinutes(for:))
+        let hourlyActivityCounts = makeHourlyActivityCounts(events: filteredEvents, calendar: calendar)
+        let busiestHour = hourlyActivityCounts.max { lhs, rhs in
+            if lhs.count == rhs.count {
+                return lhs.hour > rhs.hour
+            }
+
+            return lhs.count < rhs.count
+        }
+
+        return AdvancedSummaryViewState(
+            eventCount: filteredEvents.count,
+            totalFeeds: breastFeeds.count + bottleFeeds.count,
+            breastFeedCount: breastFeeds.count,
+            bottleFeedCount: bottleFeeds.count,
+            averageBottleVolumeMilliliters: average(of: bottleFeeds.map(\.amountMilliliters)),
+            totalSleepMinutes: sleepDurations.reduce(0, +),
+            completedSleepCount: completedSleeps.count,
+            averageSleepBlockMinutes: average(of: sleepDurations),
+            longestSleepBlockMinutes: sleepDurations.max(),
+            totalNappies: nappies.count,
+            wetNappyCount: nappies.filter { $0.type == .wee }.count,
+            dirtyNappyCount: nappies.filter { $0.type == .poo }.count,
+            mixedNappyCount: nappies.filter { $0.type == .mixed }.count,
+            dryNappyCount: nappies.filter { $0.type == .dry }.count,
+            busiestHourLabel: busiestHour.map(\.label),
+            busiestHourCount: busiestHour?.count ?? 0,
+            dailyActivityCounts: makeDailyActivityCounts(
+                events: filteredEvents,
+                selection: selection,
+                now: now,
+                calendar: calendar
+            ),
+            hourlyActivityCounts: hourlyActivityCounts
+        )
+    }
+
+    private static func filter(
+        events: [BabyEvent],
+        selection: AdvancedSummarySelection,
+        now: Date,
+        calendar: Calendar
+    ) -> [BabyEvent] {
+        switch selection.mode {
+        case .range:
+            switch selection.range {
+            case .allTime:
+                return events
+            case .today:
+                return events.filter { calendar.isDate($0.metadata.occurredAt, inSameDayAs: now) }
+            case .sevenDays:
+                return events.filter { isWithinDays($0.metadata.occurredAt, days: 7, now: now, calendar: calendar) }
+            case .thirtyDays:
+                return events.filter { isWithinDays($0.metadata.occurredAt, days: 30, now: now, calendar: calendar) }
+            }
+        case .day:
+            let start = calendar.startOfDay(for: selection.day)
+            guard let end = calendar.date(byAdding: .day, value: 1, to: start) else {
+                return []
+            }
+
+            return events.filter { $0.metadata.occurredAt >= start && $0.metadata.occurredAt < end }
+        }
+    }
+
+    private static func isWithinDays(
+        _ date: Date,
+        days: Int,
+        now: Date,
+        calendar: Calendar
+    ) -> Bool {
+        guard let start = calendar.date(byAdding: .day, value: -(days - 1), to: calendar.startOfDay(for: now)) else {
+            return false
+        }
+
+        return date >= start && date <= now
+    }
+
+    private static func sleepDurationMinutes(for event: SleepEvent) -> Int? {
+        guard let endedAt = event.endedAt else {
+            return nil
+        }
+
+        return max(1, Int(endedAt.timeIntervalSince(event.startedAt) / 60))
+    }
+
+    private static func average(of values: [Int]) -> Int? {
+        guard !values.isEmpty else {
+            return nil
+        }
+
+        return Int((Double(values.reduce(0, +)) / Double(values.count)).rounded())
+    }
+
+    private static func makeDailyActivityCounts(
+        events: [BabyEvent],
+        selection: AdvancedSummarySelection,
+        now: Date,
+        calendar: Calendar
+    ) -> [SummaryDayCount] {
+        let formatter = DateFormatter()
+        formatter.calendar = calendar
+        formatter.locale = .autoupdatingCurrent
+        formatter.setLocalizedDateFormatFromTemplate("EEE")
+
+        let countsByDay = Dictionary(
+            grouping: events,
+            by: { calendar.startOfDay(for: $0.metadata.occurredAt) }
+        ).mapValues(\.count)
+
+        let dates: [Date]
+        switch selection.mode {
+        case .range:
+            switch selection.range {
+            case .today:
+                dates = [calendar.startOfDay(for: now)]
+            case .sevenDays:
+                dates = trailingDates(dayCount: 7, now: now, calendar: calendar)
+            case .thirtyDays:
+                dates = trailingDates(dayCount: 7, now: now, calendar: calendar)
+            case .allTime:
+                if let firstDay = countsByDay.keys.sorted().first {
+                    dates = strideDates(from: firstDay, through: calendar.startOfDay(for: now), calendar: calendar)
+                } else {
+                    dates = []
+                }
+            }
+        case .day:
+            dates = [calendar.startOfDay(for: selection.day)]
+        }
+
+        return dates.map { date in
+            SummaryDayCount(
+                date: date,
+                label: formatter.string(from: date),
+                count: countsByDay[date, default: 0]
+            )
+        }
+    }
+
+    private static func makeHourlyActivityCounts(
+        events: [BabyEvent],
+        calendar: Calendar
+    ) -> [SummaryHourCount] {
+        let countsByHour = Dictionary(
+            grouping: events,
+            by: { calendar.component(.hour, from: $0.metadata.occurredAt) }
+        ).mapValues(\.count)
+
+        return (0..<24).map { hour in
+            return SummaryHourCount(
+                hour: hour,
+                label: hourLabel(for: hour),
+                count: countsByHour[hour, default: 0]
+            )
+        }
+    }
+
+    private static func hourLabel(for hour: Int) -> String {
+        let normalizedHour = hour % 24
+        let meridiem = normalizedHour < 12 ? "AM" : "PM"
+        let displayHour = normalizedHour % 12 == 0 ? 12 : normalizedHour % 12
+        return "\(displayHour)\(meridiem)"
+    }
+
+    private static func trailingDates(
+        dayCount: Int,
+        now: Date,
+        calendar: Calendar
+    ) -> [Date] {
+        let end = calendar.startOfDay(for: now)
+        guard let start = calendar.date(byAdding: .day, value: -(dayCount - 1), to: end) else {
+            return []
+        }
+
+        return strideDates(from: start, through: end, calendar: calendar)
+    }
+
+    private static func strideDates(
+        from start: Date,
+        through end: Date,
+        calendar: Calendar
+    ) -> [Date] {
+        var dates: [Date] = []
+        var current = calendar.startOfDay(for: start)
+        let finalDate = calendar.startOfDay(for: end)
+
+        while current <= finalDate {
+            dates.append(current)
+
+            guard let next = calendar.date(byAdding: .day, value: 1, to: current) else {
+                break
+            }
+
+            current = next
+        }
+
+        return dates
+    }
+}

--- a/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/AdvancedSummarySelection.swift
+++ b/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/AdvancedSummarySelection.swift
@@ -1,0 +1,37 @@
+import Foundation
+
+public enum AdvancedSummarySelectionMode: String, CaseIterable, Identifiable, Sendable {
+    case range
+    case day
+
+    public var id: String { rawValue }
+
+    public var title: String {
+        switch self {
+        case .range:
+            "Range"
+        case .day:
+            "Day"
+        }
+    }
+}
+
+public struct AdvancedSummarySelection: Equatable, Sendable {
+    public var mode: AdvancedSummarySelectionMode
+    public var range: SummaryTimeRange
+    public var day: Date
+
+    public init(
+        mode: AdvancedSummarySelectionMode,
+        range: SummaryTimeRange,
+        day: Date
+    ) {
+        self.mode = mode
+        self.range = range
+        self.day = day
+    }
+
+    public static func range(_ range: SummaryTimeRange, day: Date = .now) -> AdvancedSummarySelection {
+        AdvancedSummarySelection(mode: .range, range: range, day: day)
+    }
+}

--- a/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/AdvancedSummaryViewState.swift
+++ b/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/AdvancedSummaryViewState.swift
@@ -1,0 +1,62 @@
+import Foundation
+
+public struct AdvancedSummaryViewState: Equatable, Sendable {
+    public let eventCount: Int
+    public let totalFeeds: Int
+    public let breastFeedCount: Int
+    public let bottleFeedCount: Int
+    public let averageBottleVolumeMilliliters: Int?
+    public let totalSleepMinutes: Int
+    public let completedSleepCount: Int
+    public let averageSleepBlockMinutes: Int?
+    public let longestSleepBlockMinutes: Int?
+    public let totalNappies: Int
+    public let wetNappyCount: Int
+    public let dirtyNappyCount: Int
+    public let mixedNappyCount: Int
+    public let dryNappyCount: Int
+    public let busiestHourLabel: String?
+    public let busiestHourCount: Int
+    public let dailyActivityCounts: [SummaryDayCount]
+    public let hourlyActivityCounts: [SummaryHourCount]
+
+    public init(
+        eventCount: Int,
+        totalFeeds: Int,
+        breastFeedCount: Int,
+        bottleFeedCount: Int,
+        averageBottleVolumeMilliliters: Int?,
+        totalSleepMinutes: Int,
+        completedSleepCount: Int,
+        averageSleepBlockMinutes: Int?,
+        longestSleepBlockMinutes: Int?,
+        totalNappies: Int,
+        wetNappyCount: Int,
+        dirtyNappyCount: Int,
+        mixedNappyCount: Int,
+        dryNappyCount: Int,
+        busiestHourLabel: String?,
+        busiestHourCount: Int,
+        dailyActivityCounts: [SummaryDayCount],
+        hourlyActivityCounts: [SummaryHourCount]
+    ) {
+        self.eventCount = eventCount
+        self.totalFeeds = totalFeeds
+        self.breastFeedCount = breastFeedCount
+        self.bottleFeedCount = bottleFeedCount
+        self.averageBottleVolumeMilliliters = averageBottleVolumeMilliliters
+        self.totalSleepMinutes = totalSleepMinutes
+        self.completedSleepCount = completedSleepCount
+        self.averageSleepBlockMinutes = averageSleepBlockMinutes
+        self.longestSleepBlockMinutes = longestSleepBlockMinutes
+        self.totalNappies = totalNappies
+        self.wetNappyCount = wetNappyCount
+        self.dirtyNappyCount = dirtyNappyCount
+        self.mixedNappyCount = mixedNappyCount
+        self.dryNappyCount = dryNappyCount
+        self.busiestHourLabel = busiestHourLabel
+        self.busiestHourCount = busiestHourCount
+        self.dailyActivityCounts = dailyActivityCounts
+        self.hourlyActivityCounts = hourlyActivityCounts
+    }
+}

--- a/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/SummaryScreenPreviewFactory.swift
+++ b/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/SummaryScreenPreviewFactory.swift
@@ -1,0 +1,95 @@
+import BabyTrackerDomain
+import Foundation
+
+enum SummaryScreenPreviewFactory {
+    static var summaryState: SummaryScreenState {
+        SummaryScreenState(
+            events: sampleEvents,
+            emptyStateTitle: "No summary data yet",
+            emptyStateMessage: "Log feeds, sleep, and nappies to unlock trends."
+        )
+    }
+
+    private static var sampleEvents: [BabyEvent] {
+        var calendar = Calendar(identifier: .gregorian)
+        calendar.timeZone = .current
+
+        let childID = UUID()
+        let userID = UUID()
+        let now = Date()
+        let today = calendar.startOfDay(for: now)
+
+        let todayFeed = calendar.date(byAdding: .hour, value: 8, to: today) ?? now
+        let todayBottle = calendar.date(byAdding: .hour, value: 11, to: today) ?? now
+        let todayNappy = calendar.date(byAdding: .hour, value: 13, to: today) ?? now
+        let yesterday = calendar.date(byAdding: .day, value: -1, to: today) ?? now
+        let yesterdaySleepEnd = calendar.date(byAdding: .hour, value: 6, to: yesterday) ?? now
+        let twoDaysAgo = calendar.date(byAdding: .day, value: -2, to: today) ?? now
+        let twoDaysAgoNappy = calendar.date(byAdding: .hour, value: 17, to: twoDaysAgo) ?? now
+
+        return [
+            .breastFeed(
+                try! BreastFeedEvent(
+                    metadata: EventMetadata(
+                        childID: childID,
+                        occurredAt: todayFeed,
+                        createdAt: todayFeed,
+                        createdBy: userID
+                    ),
+                    side: .left,
+                    startedAt: todayFeed.addingTimeInterval(-1_200),
+                    endedAt: todayFeed
+                )
+            ),
+            .bottleFeed(
+                try! BottleFeedEvent(
+                    metadata: EventMetadata(
+                        childID: childID,
+                        occurredAt: todayBottle,
+                        createdAt: todayBottle,
+                        createdBy: userID
+                    ),
+                    amountMilliliters: 150,
+                    milkType: .formula
+                )
+            ),
+            .nappy(
+                try! NappyEvent(
+                    metadata: EventMetadata(
+                        childID: childID,
+                        occurredAt: todayNappy,
+                        createdAt: todayNappy,
+                        createdBy: userID
+                    ),
+                    type: .mixed,
+                    pooVolume: .medium,
+                    pooColor: .yellow
+                )
+            ),
+            .sleep(
+                try! SleepEvent(
+                    metadata: EventMetadata(
+                        childID: childID,
+                        occurredAt: yesterdaySleepEnd,
+                        createdAt: yesterdaySleepEnd,
+                        createdBy: userID
+                    ),
+                    startedAt: yesterdaySleepEnd.addingTimeInterval(-7_200),
+                    endedAt: yesterdaySleepEnd
+                )
+            ),
+            .nappy(
+                try! NappyEvent(
+                    metadata: EventMetadata(
+                        childID: childID,
+                        occurredAt: twoDaysAgoNappy,
+                        createdAt: twoDaysAgoNappy,
+                        createdBy: userID
+                    ),
+                    type: .wee,
+                    peeVolume: .light
+                )
+            ),
+        ]
+    }
+}

--- a/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/AdvancedSummaryView.swift
+++ b/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/AdvancedSummaryView.swift
@@ -1,0 +1,255 @@
+import SwiftUI
+
+public struct AdvancedSummaryView: View {
+    let summary: SummaryScreenState
+
+    @State private var selection: AdvancedSummarySelection
+
+    public init(
+        summary: SummaryScreenState,
+        initialSelection: AdvancedSummarySelection = .range(.today)
+    ) {
+        self.summary = summary
+        _selection = State(initialValue: initialSelection)
+    }
+
+    public var body: some View {
+        let viewState = AdvancedSummaryMetricsCalculator.makeViewState(
+            from: summary.events,
+            selection: selection
+        )
+
+        ScrollView {
+            VStack(alignment: .leading, spacing: 18) {
+                selectionCard
+
+                if viewState.eventCount == 0 {
+                    emptyState
+                } else {
+                    feedSection(viewState: viewState)
+                    sleepSection(viewState: viewState)
+                    nappySection(viewState: viewState)
+                    activitySection(viewState: viewState)
+                }
+            }
+            .padding(.horizontal, 16)
+            .padding(.vertical, 12)
+        }
+        .background(Color(.systemGroupedBackground).ignoresSafeArea())
+        .navigationTitle("More Information")
+        .navigationBarTitleDisplayMode(.inline)
+    }
+
+    private var selectionCard: some View {
+        VStack(alignment: .leading, spacing: 14) {
+            Picker("Summary Type", selection: $selection.mode) {
+                ForEach(AdvancedSummarySelectionMode.allCases) { mode in
+                    Text(mode.title).tag(mode)
+                }
+            }
+            .pickerStyle(.segmented)
+
+            if selection.mode == .range {
+                Picker("Range", selection: $selection.range) {
+                    ForEach(SummaryTimeRange.allCases) { range in
+                        Text(range.title).tag(range)
+                    }
+                }
+                .pickerStyle(.segmented)
+            } else {
+                DatePicker(
+                    "Day",
+                    selection: $selection.day,
+                    displayedComponents: .date
+                )
+                .datePickerStyle(.graphical)
+            }
+
+            Text(selectionDescription)
+                .font(.subheadline)
+                .foregroundStyle(.secondary)
+        }
+        .padding(16)
+        .background(cardBackground)
+    }
+
+    private var emptyState: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text("No summary data for this selection")
+                .font(.headline)
+
+            Text("Try a broader range or choose a different day to see detailed feed, sleep, nappy, and activity trends.")
+                .font(.subheadline)
+                .foregroundStyle(.secondary)
+        }
+        .padding(18)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(cardBackground)
+    }
+
+    private func feedSection(viewState: AdvancedSummaryViewState) -> some View {
+        sectionCard(title: "Feeds", tint: .blue, symbol: "drop.fill") {
+            metricRow(title: "Total feeds", value: "\(viewState.totalFeeds)")
+            metricRow(title: "Breast feeds", value: "\(viewState.breastFeedCount)")
+            metricRow(title: "Bottle feeds", value: "\(viewState.bottleFeedCount)")
+            metricRow(
+                title: "Average bottle volume",
+                value: viewState.averageBottleVolumeMilliliters.map { "\($0) mL" } ?? "No bottle feeds"
+            )
+        }
+    }
+
+    private func sleepSection(viewState: AdvancedSummaryViewState) -> some View {
+        sectionCard(title: "Sleep", tint: .indigo, symbol: "moon.zzz.fill") {
+            metricRow(title: "Completed sleeps", value: "\(viewState.completedSleepCount)")
+            metricRow(title: "Total sleep", value: formatMinutes(viewState.totalSleepMinutes))
+            metricRow(
+                title: "Average sleep block",
+                value: viewState.averageSleepBlockMinutes.map { formatMinutes($0) } ?? "No completed sleeps"
+            )
+            metricRow(
+                title: "Longest sleep block",
+                value: viewState.longestSleepBlockMinutes.map { formatMinutes($0) } ?? "No completed sleeps"
+            )
+        }
+    }
+
+    private func nappySection(viewState: AdvancedSummaryViewState) -> some View {
+        sectionCard(title: "Nappies", tint: .green, symbol: "checklist.checked") {
+            metricRow(title: "Total changes", value: "\(viewState.totalNappies)")
+            metricRow(title: "Wet", value: "\(viewState.wetNappyCount)")
+            metricRow(title: "Dirty", value: "\(viewState.dirtyNappyCount)")
+            metricRow(title: "Mixed", value: "\(viewState.mixedNappyCount)")
+            metricRow(title: "Dry", value: "\(viewState.dryNappyCount)")
+        }
+    }
+
+    private func activitySection(viewState: AdvancedSummaryViewState) -> some View {
+        sectionCard(title: "Activity", tint: .orange, symbol: "flame.fill") {
+            metricRow(title: "Total events", value: "\(viewState.eventCount)")
+            metricRow(
+                title: "Busiest hour",
+                value: viewState.busiestHourLabel.map { "\($0) (\(viewState.busiestHourCount))" } ?? "No activity"
+            )
+
+            VStack(alignment: .leading, spacing: 8) {
+                Text(selection.mode == .day ? "Activity by Hour" : "Daily Activity")
+                    .font(.caption.weight(.semibold))
+                    .foregroundStyle(.secondary)
+
+                activityChart(viewState: viewState)
+            }
+            .padding(.top, 6)
+        }
+    }
+
+    private func sectionCard<Content: View>(
+        title: String,
+        tint: Color,
+        symbol: String,
+        @ViewBuilder content: () -> Content
+    ) -> some View {
+        VStack(alignment: .leading, spacing: 12) {
+            Label(title, systemImage: symbol)
+                .font(.headline)
+                .foregroundStyle(tint)
+
+            content()
+        }
+        .padding(16)
+        .background(cardBackground)
+    }
+
+    private func metricRow(title: String, value: String) -> some View {
+        HStack(alignment: .top, spacing: 12) {
+            Text(title)
+                .foregroundStyle(.secondary)
+
+            Spacer()
+
+            Text(value)
+                .fontWeight(.semibold)
+                .multilineTextAlignment(.trailing)
+        }
+        .font(.subheadline)
+    }
+
+    private func activityChart(viewState: AdvancedSummaryViewState) -> some View {
+        let points: [(String, Int)] = selection.mode == .day
+            ? viewState.hourlyActivityCounts
+                .filter { $0.count > 0 }
+                .map { ($0.label, $0.count) }
+            : viewState.dailyActivityCounts.map { ($0.label, $0.count) }
+
+        return barChart(points: points.isEmpty ? [("None", 0)] : points)
+    }
+
+    private func barChart(points: [(String, Int)]) -> some View {
+        let maxValue = max(1, points.map(\.1).max() ?? 0)
+
+        return HStack(alignment: .bottom, spacing: 8) {
+            ForEach(Array(points.enumerated()), id: \.offset) { _, point in
+                VStack(spacing: 6) {
+                    RoundedRectangle(cornerRadius: 6, style: .continuous)
+                        .fill(Color.orange.gradient)
+                        .frame(height: max(6, (CGFloat(point.1) / CGFloat(maxValue)) * 100))
+
+                    Text(point.0)
+                        .font(.caption2)
+                        .foregroundStyle(.secondary)
+                        .lineLimit(1)
+                }
+                .frame(maxWidth: .infinity)
+            }
+        }
+        .frame(maxWidth: .infinity, minHeight: 140, alignment: .bottom)
+    }
+
+    private var selectionDescription: String {
+        switch selection.mode {
+        case .range:
+            switch selection.range {
+            case .today:
+                return "Detailed metrics for today."
+            case .sevenDays:
+                return "Detailed metrics for the last 7 days."
+            case .thirtyDays:
+                return "Detailed metrics for the last 30 days."
+            case .allTime:
+                return "Detailed metrics across all logged events."
+            }
+        case .day:
+            return "Detailed metrics for \(selection.day.formatted(date: .abbreviated, time: .omitted))."
+        }
+    }
+
+    private var cardBackground: some View {
+        RoundedRectangle(cornerRadius: 18, style: .continuous)
+            .fill(.thinMaterial)
+            .overlay(
+                RoundedRectangle(cornerRadius: 18, style: .continuous)
+                    .stroke(Color.white.opacity(0.28), lineWidth: 1)
+            )
+            .shadow(color: Color.black.opacity(0.05), radius: 14, y: 8)
+    }
+
+    private func formatMinutes(_ minutes: Int) -> String {
+        let hours = minutes / 60
+        let remainingMinutes = minutes % 60
+
+        if hours == 0 {
+            return "\(remainingMinutes)m"
+        }
+
+        return "\(hours)h \(remainingMinutes)m"
+    }
+}
+
+#Preview {
+    NavigationStack {
+        AdvancedSummaryView(
+            summary: SummaryScreenPreviewFactory.summaryState,
+            initialSelection: .range(.sevenDays)
+        )
+    }
+}

--- a/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/ChildWorkspaceTabView.swift
+++ b/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/ChildWorkspaceTabView.swift
@@ -69,7 +69,7 @@ public struct ChildWorkspaceTabView: View {
             }
 
 
-            SummaryScreenView(profile: profile)
+            SummaryScreenView(summary: profile.summary)
             .tag(Tab.summary)
             .tabItem {
                 Label("Summary", systemImage: "chart.bar.fill")

--- a/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/SummaryScreenView.swift
+++ b/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/SummaryScreenView.swift
@@ -1,17 +1,17 @@
 import SwiftUI
 
 public struct SummaryScreenView: View {
-    let profile: ChildProfileScreenState
+    let summary: SummaryScreenState
 
     @State private var selectedRange: SummaryTimeRange = .today
 
-    public init(profile: ChildProfileScreenState) {
-        self.profile = profile
+    public init(summary: SummaryScreenState) {
+        self.summary = summary
     }
 
     public var body: some View {
         let snapshot = SummaryMetricsCalculator.makeSnapshot(
-            from: profile.summary.events,
+            from: summary.events,
             range: selectedRange
         )
 
@@ -23,8 +23,8 @@ public struct SummaryScreenView: View {
                     emptyState
                 } else {
                     topMetrics(snapshot: snapshot)
-                    inDepthMetrics(snapshot: snapshot)
                     chartSection(snapshot: snapshot)
+                    advancedSummaryLink
                 }
             }
             .padding(.horizontal, 16)
@@ -49,10 +49,10 @@ public struct SummaryScreenView: View {
 
     private var emptyState: some View {
         VStack(alignment: .leading, spacing: 8) {
-            Text(profile.summary.emptyStateTitle)
+            Text(summary.emptyStateTitle)
                 .font(.headline)
 
-            Text(profile.summary.emptyStateMessage)
+            Text(summary.emptyStateMessage)
                 .font(.subheadline)
                 .foregroundStyle(.secondary)
         }
@@ -78,71 +78,34 @@ public struct SummaryScreenView: View {
                     title: "Feeds",
                     value: "\(snapshot.totalFeeds)",
                     subtitle: subtitleForFeedAverage(snapshot),
-                    symbol: "drop.fill"
+                    symbol: "drop.fill",
+                    tint: .blue
                 )
 
                 metricCard(
                     title: "Nappy Changes",
                     value: "\(snapshot.totalNappies)",
                     subtitle: "Wet: \(snapshot.wetNappyCount) • Dirty: \(snapshot.dirtyNappyCount)",
-                    symbol: "checklist.checked"
+                    symbol: "checklist.checked",
+                    tint: .green
                 )
 
                 metricCard(
                     title: "Sleep",
                     value: formatMinutes(snapshot.totalSleepMinutes),
                     subtitle: sleepRangeSubtitle(snapshot),
-                    symbol: "moon.zzz.fill"
+                    symbol: "moon.zzz.fill",
+                    tint: .indigo
                 )
 
                 metricCard(
                     title: "Logging Streak",
                     value: "\(snapshot.loggingStreakDays) day\(snapshot.loggingStreakDays == 1 ? "" : "s")",
                     subtitle: "Consecutive days with logs",
-                    symbol: "flame.fill"
+                    symbol: "flame.fill",
+                    tint: .orange
                 )
             }
-        }
-    }
-
-    private func inDepthMetrics(snapshot: SummarySnapshot) -> some View {
-        VStack(alignment: .leading, spacing: 12) {
-            Text("In-Depth")
-                .font(.headline)
-
-            VStack(spacing: 10) {
-                detailRow(
-                    title: "Average feed interval",
-                    value: snapshot.averageFeedIntervalMinutes.map { "\($0) min" } ?? "Not enough feeds"
-                )
-
-                detailRow(
-                    title: "Average sleep block",
-                    value: snapshot.averageSleepBlockMinutes.map { "\($0) min" } ?? "No completed sleeps"
-                )
-
-                detailRow(
-                    title: "Shortest sleep block",
-                    value: snapshot.shortestSleepBlockMinutes.map { "\($0) min" } ?? "No completed sleeps"
-                )
-
-                detailRow(
-                    title: "Longest sleep block",
-                    value: snapshot.longestSleepBlockMinutes.map { "\($0) min" } ?? "No completed sleeps"
-                )
-
-                detailRow(
-                    title: "Wet vs dirty ratio",
-                    value: nappyRatioText(snapshot)
-                )
-
-                detailRow(
-                    title: "Mixed/Dry nappies",
-                    value: "Mixed: \(snapshot.mixedNappyCount) • Dry: \(snapshot.dryNappyCount)"
-                )
-            }
-            .padding(14)
-            .background(cardBackground)
         }
     }
 
@@ -157,7 +120,7 @@ public struct SummaryScreenView: View {
             ) {
                 miniBarChart(
                     points: snapshot.dailyEventCounts.map { ($0.label, $0.count) },
-                    tint: .accentColor
+                    tint: .orange
                 )
             }
 
@@ -177,13 +140,14 @@ public struct SummaryScreenView: View {
         title: String,
         value: String,
         subtitle: String,
-        symbol: String
+        symbol: String,
+        tint: Color
     ) -> some View {
         VStack(alignment: .leading, spacing: 10) {
             HStack {
                 Label(title, systemImage: symbol)
                     .font(.caption.weight(.semibold))
-                    .foregroundStyle(.secondary)
+                    .foregroundStyle(tint)
                 Spacer()
             }
 
@@ -200,16 +164,34 @@ public struct SummaryScreenView: View {
         .background(cardBackground)
     }
 
-    private func detailRow(title: String, value: String) -> some View {
-        HStack(alignment: .top, spacing: 10) {
-            Text(title)
-                .foregroundStyle(.secondary)
-            Spacer()
-            Text(value)
-                .multilineTextAlignment(.trailing)
-                .fontWeight(.semibold)
+    private var advancedSummaryLink: some View {
+        NavigationLink {
+            AdvancedSummaryView(
+                summary: summary,
+                initialSelection: .range(selectedRange)
+            )
+        } label: {
+            HStack(alignment: .center, spacing: 12) {
+                VStack(alignment: .leading, spacing: 4) {
+                    Text("More Information")
+                        .font(.headline)
+                        .foregroundStyle(.primary)
+
+                    Text("Open feeds, sleep, nappies, and activity details for a range or a specific day.")
+                        .font(.subheadline)
+                        .foregroundStyle(.secondary)
+                }
+
+                Spacer()
+
+                Image(systemName: "chevron.right.circle.fill")
+                    .font(.title3)
+                    .foregroundStyle(.orange)
+            }
+            .padding(16)
+            .background(cardBackground)
         }
-        .font(.subheadline)
+        .buttonStyle(.plain)
     }
 
     private func chartCard<Content: View>(
@@ -287,16 +269,6 @@ public struct SummaryScreenView: View {
         return "Shortest: \(shortest)m • Longest: \(longest)m"
     }
 
-    private func nappyRatioText(_ snapshot: SummarySnapshot) -> String {
-        let dirtyIncludingMixed = snapshot.dirtyNappyCount + snapshot.mixedNappyCount
-
-        if snapshot.wetNappyCount == 0 && dirtyIncludingMixed == 0 {
-            return "No nappy data"
-        }
-
-        return "\(snapshot.wetNappyCount):\(dirtyIncludingMixed)"
-    }
-
     private func formatMinutes(_ minutes: Int) -> String {
         let hours = minutes / 60
         let remainingMinutes = minutes % 60
@@ -306,5 +278,23 @@ public struct SummaryScreenView: View {
         }
 
         return "\(hours)h \(remainingMinutes)m"
+    }
+}
+
+#Preview("With Data") {
+    NavigationStack {
+        SummaryScreenView(summary: SummaryScreenPreviewFactory.summaryState)
+    }
+}
+
+#Preview("Empty") {
+    NavigationStack {
+        SummaryScreenView(
+            summary: SummaryScreenState(
+                events: [],
+                emptyStateTitle: "No summary data yet",
+                emptyStateMessage: "Log feeds, sleep, and nappies to unlock trends."
+            )
+        )
     }
 }

--- a/docs/plans/030-advanced-summary-charts.md
+++ b/docs/plans/030-advanced-summary-charts.md
@@ -48,4 +48,4 @@ Expand the Summary experience so users can drill into richer feed, sleep, and na
 2. Clinician-specific report generation.
 3. Overly dense analytics or highly custom charting infrastructure.
 
-- [ ] Complete
+- [x] Complete


### PR DESCRIPTION
Closes #50

## Summary
- keep the Summary overview lightweight and add a new More Information drill-in screen
- support range-based and single-day advanced metrics for feeds, sleep, nappies, and activity
- add advanced summary calculator coverage plus Summary previews and mark the plan complete

## Testing
- xcodebuild -project "Baby Tracker.xcodeproj" -scheme "Baby Tracker" -destination "platform=iOS Simulator,name=iPhone 17" build
- xcodebuild -project "Baby Tracker.xcodeproj" -scheme "Baby Tracker" -destination "platform=iOS Simulator,name=iPhone 17" test -only-testing:"Baby TrackerTests/AdvancedSummaryMetricsCalculatorTests" -only-testing:"Baby TrackerTests/SummaryMetricsCalculatorTests"
- xcodebuild -project "Baby Tracker.xcodeproj" -scheme "Baby Tracker" -destination "platform=iOS Simulator,name=iPhone 17" test

Plan: `docs/plans/030-advanced-summary-charts.md`