### PR TITLE
Issue #17: Add in-app Help and FAQ screen

### DIFF
--- a/Baby TrackerTests/HelpFAQContentTests.swift
+++ b/Baby TrackerTests/HelpFAQContentTests.swift
@@ -1,0 +1,25 @@
+import BabyTrackerFeature
+import Testing
+
+struct HelpFAQContentTests {
+    @Test
+    func faqContentCoversSummarySharingAndExportTopics() {
+        let titles = HelpFAQContent.sections.map(\.title)
+
+        #expect(titles.contains("Summary and Ranges"))
+        #expect(titles.contains("Sharing and Caregiver Access"))
+        #expect(titles.contains("Exporting and Talking to a Clinician"))
+    }
+
+    @Test
+    func faqItemsUseCurrentSummaryTerminology() {
+        let answers = HelpFAQContent.sections
+            .flatMap(\.items)
+            .map(\.answer)
+            .joined(separator: " ")
+
+        #expect(answers.contains("More Information"))
+        #expect(answers.contains("specific day"))
+        #expect(answers.contains("Export Data"))
+    }
+}

--- a/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/ChildProfilePreviewFactory.swift
+++ b/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/ChildProfilePreviewFactory.swift
@@ -1,0 +1,48 @@
+import BabyTrackerDomain
+import BabyTrackerPersistence
+import BabyTrackerSync
+import Foundation
+
+enum ChildProfilePreviewFactory {
+    @MainActor
+    static func makeModel() -> AppModel {
+        let suiteName = "ChildProfilePreview"
+        let userDefaults = UserDefaults(suiteName: suiteName) ?? .standard
+        userDefaults.removePersistentDomain(forName: suiteName)
+
+        let store = try! BabyTrackerModelStore(isStoredInMemoryOnly: true)
+        let childRepository = SwiftDataChildRepository(store: store)
+        let userIdentityRepository = SwiftDataUserIdentityRepository(store: store, userDefaults: userDefaults)
+        let membershipRepository = SwiftDataMembershipRepository(store: store)
+        let childSelectionStore = UserDefaultsChildSelectionStore(userDefaults: userDefaults)
+        let eventRepository = SwiftDataEventRepository(store: store)
+        let syncStateRepository = SwiftDataSyncStateRepository(store: store)
+        let recordMetadataRepository = SwiftDataCloudKitRecordMetadataRepository(store: store)
+        let syncEngine = CloudKitSyncEngine(
+            childRepository: childRepository,
+            userIdentityRepository: userIdentityRepository,
+            membershipRepository: membershipRepository,
+            eventRepository: eventRepository,
+            syncStateRepository: syncStateRepository,
+            recordMetadataRepository: recordMetadataRepository,
+            client: UnavailableCloudKitClient()
+        )
+        let model = AppModel(
+            childRepository: childRepository,
+            userIdentityRepository: userIdentityRepository,
+            membershipRepository: membershipRepository,
+            childSelectionStore: childSelectionStore,
+            eventRepository: eventRepository,
+            syncEngine: syncEngine,
+            liveActivityManager: NoOpFeedLiveActivityManager(),
+            liveActivityPreferenceStore: InMemoryLiveActivityPreferenceStore(),
+            localNotificationManager: NoOpLocalNotificationManager(),
+            hapticFeedbackProvider: NoOpHapticFeedbackProvider()
+        )
+
+        model.load(performLaunchSync: false)
+        model.createLocalUser(displayName: "Alex Parent")
+        model.createChild(name: "Poppy", birthDate: Date())
+        return model
+    }
+}

--- a/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/HelpFAQContent.swift
+++ b/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/HelpFAQContent.swift
@@ -1,0 +1,76 @@
+import Foundation
+
+public enum HelpFAQContent {
+    public static let sections: [HelpFAQSection] = [
+        HelpFAQSection(
+            title: "Summary and Ranges",
+            items: [
+                HelpFAQItem(
+                    id: "summary-range-picker",
+                    title: "What does the Summary range picker change?",
+                    answer: "The range picker filters the events used in the Summary tab. Today shows only today's logs, 7 Days and 30 Days show recent history, and All Time includes everything saved for the selected child."
+                ),
+                HelpFAQItem(
+                    id: "summary-more-information",
+                    title: "What is More Information in Summary?",
+                    answer: "More Information opens the detailed summary screen. It breaks metrics into feeds, sleep, nappies, and activity, and it can also show one specific day's numbers when you switch from Range to Day."
+                ),
+                HelpFAQItem(
+                    id: "summary-streaks-averages",
+                    title: "How are streaks and averages calculated?",
+                    answer: "The logging streak counts consecutive days with at least one saved event. Averages use the events in the current selection only, so they will change when you pick a different range or a specific day."
+                ),
+            ]
+        ),
+        HelpFAQSection(
+            title: "Feed, Sleep, and Nappy Trends",
+            items: [
+                HelpFAQItem(
+                    id: "feeds",
+                    title: "What counts as a feed?",
+                    answer: "Breast feeds and bottle feeds both count as feeds. Bottle volume averages use bottle feeds only, while feed totals include both types."
+                ),
+                HelpFAQItem(
+                    id: "sleep",
+                    title: "How should I read the sleep metrics?",
+                    answer: "Sleep totals, averages, and longest-block values come from completed sleep sessions in the selected period. Active sleep sessions are shown in the app, but they do not affect finished-summary averages until they end."
+                ),
+                HelpFAQItem(
+                    id: "nappies",
+                    title: "How are nappy trends grouped?",
+                    answer: "Nappy trends are grouped by the type you log: wet, dirty, mixed, or dry. The Summary view is meant to help you review what was recorded, not to interpret whether a pattern is normal."
+                ),
+            ]
+        ),
+        HelpFAQSection(
+            title: "Sharing and Caregiver Access",
+            items: [
+                HelpFAQItem(
+                    id: "sharing",
+                    title: "How does caregiver sharing work?",
+                    answer: "Sharing uses iCloud so another caregiver can work from the same child timeline. If sharing is unavailable, local data still stays on the device and you can review sync details from Profile > Sharing or iCloud Sync."
+                ),
+                HelpFAQItem(
+                    id: "switching-children",
+                    title: "What happens when I switch children?",
+                    answer: "When you choose a different child, the app resets back to that child's Profile tab so you can confirm you are looking at the right profile before logging or reviewing events."
+                ),
+            ]
+        ),
+        HelpFAQSection(
+            title: "Exporting and Talking to a Clinician",
+            items: [
+                HelpFAQItem(
+                    id: "export-data",
+                    title: "How do I export data?",
+                    answer: "Open Profile > Settings > Export Data to prepare a file you can share. Export gives you the recorded information for the selected child so you can keep a copy or bring it into another workflow."
+                ),
+                HelpFAQItem(
+                    id: "clinician",
+                    title: "Can I use this data when talking to a clinician?",
+                    answer: "Yes. The app can help you share logged details and trends during a conversation with a clinician, but it does not diagnose conditions or tell you what a pattern means medically."
+                ),
+            ]
+        ),
+    ]
+}

--- a/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/HelpFAQSection.swift
+++ b/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/HelpFAQSection.swift
@@ -1,0 +1,23 @@
+import Foundation
+
+public struct HelpFAQSection: Equatable, Sendable {
+    public let title: String
+    public let items: [HelpFAQItem]
+
+    public init(title: String, items: [HelpFAQItem]) {
+        self.title = title
+        self.items = items
+    }
+}
+
+public struct HelpFAQItem: Equatable, Identifiable, Sendable {
+    public let id: String
+    public let title: String
+    public let answer: String
+
+    public init(id: String, title: String, answer: String) {
+        self.id = id
+        self.title = title
+        self.answer = answer
+    }
+}

--- a/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/ChildProfileView.swift
+++ b/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/ChildProfileView.swift
@@ -1,4 +1,6 @@
 import BabyTrackerDomain
+import BabyTrackerPersistence
+import BabyTrackerSync
 import SwiftUI
 import UIKit
 
@@ -84,6 +86,16 @@ public struct ChildProfileView: View {
             }
 
             Section {
+                NavigationLink {
+                    HelpFAQView()
+                } label: {
+                    settingsRow(
+                        title: "Help & FAQ",
+                        value: nil,
+                        accessibilityIdentifier: "profile-help-faq-row"
+                    )
+                }
+
                 NavigationLink {
                     ChildProfileSettingsView(
                         model: model,
@@ -210,5 +222,21 @@ public struct ChildProfileView: View {
         }
         .contentShape(Rectangle())
         .accessibilityIdentifier(accessibilityIdentifier)
+    }
+}
+
+#Preview {
+    NavigationStack {
+        let model = ChildProfilePreviewFactory.makeModel()
+        if let profile = model.profile {
+            ChildProfileView(
+                model: model,
+                profile: profile,
+                editChildAction: {},
+                shareChildAction: {},
+                archiveAction: {},
+                hardDeleteAction: {}
+            )
+        }
     }
 }

--- a/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/HelpFAQView.swift
+++ b/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/HelpFAQView.swift
@@ -1,0 +1,74 @@
+import SwiftUI
+
+public struct HelpFAQView: View {
+    @State private var expandedItemIDs: Set<String>
+
+    public init(expandedItemIDs: Set<String> = []) {
+        _expandedItemIDs = State(initialValue: expandedItemIDs)
+    }
+
+    public var body: some View {
+        List {
+            Section {
+                VStack(alignment: .leading, spacing: 8) {
+                    Text("Baby Tracker explains what was logged and how the app calculates its summaries. It does not provide medical advice or diagnosis.")
+                        .font(.subheadline)
+                        .foregroundStyle(.secondary)
+                }
+                .padding(.vertical, 4)
+            }
+
+            ForEach(HelpFAQContent.sections, id: \.title) { section in
+                Section(section.title) {
+                    ForEach(section.items) { item in
+                        DisclosureGroup(
+                            isExpanded: binding(for: item.id),
+                            content: {
+                                Text(item.answer)
+                                    .font(.subheadline)
+                                    .foregroundStyle(.secondary)
+                                    .fixedSize(horizontal: false, vertical: true)
+                                    .padding(.top, 4)
+                                    .padding(.bottom, 2)
+                            },
+                            label: {
+                                Text(item.title)
+                                    .font(.body.weight(.semibold))
+                                    .padding(.vertical, 4)
+                            }
+                        )
+                        .accessibilityIdentifier("help-faq-\(item.id)")
+                    }
+                }
+            }
+        }
+        .listStyle(.insetGrouped)
+        .navigationTitle("Help & FAQ")
+        .navigationBarTitleDisplayMode(.inline)
+    }
+
+    private func binding(for itemID: String) -> Binding<Bool> {
+        Binding(
+            get: { expandedItemIDs.contains(itemID) },
+            set: { isExpanded in
+                if isExpanded {
+                    expandedItemIDs.insert(itemID)
+                } else {
+                    expandedItemIDs.remove(itemID)
+                }
+            }
+        )
+    }
+}
+
+#Preview("Collapsed") {
+    NavigationStack {
+        HelpFAQView()
+    }
+}
+
+#Preview("Expanded") {
+    NavigationStack {
+        HelpFAQView(expandedItemIDs: ["summary-range-picker"])
+    }
+}

--- a/docs/plans/029-faq-help-section.md
+++ b/docs/plans/029-faq-help-section.md
@@ -47,4 +47,4 @@ Add a focused FAQ and Help area that is reachable from Profile and answers the m
 2. Live chat, support tickets, or web-hosted documentation systems.
 3. Medical recommendations or diagnostic guidance.
 
-- [ ] Complete
+- [x] Complete


### PR DESCRIPTION
Closes #17

## Summary
- add a Help & FAQ destination from the Profile tab
- ship grouped expandable FAQ content for Summary, trends, sharing, and export guidance
- add preview coverage and lightweight FAQ content tests, and mark the plan complete

## Testing
- xcodebuild -project "Baby Tracker.xcodeproj" -scheme "Baby Tracker" -destination "platform=iOS Simulator,name=iPhone 17" build
- xcodebuild -project "Baby Tracker.xcodeproj" -scheme "Baby Tracker" -destination "platform=iOS Simulator,name=iPhone 17" test -only-testing:"Baby TrackerTests/HelpFAQContentTests"

Plan: `docs/plans/029-faq-help-section.md`