### PR TITLE
Use timestamped filename for data export

### DIFF
--- a/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/AppModel.swift
+++ b/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/AppModel.swift
@@ -1752,8 +1752,10 @@ public final class AppModel {
                 let childName = profile.child.name
                     .replacingOccurrences(of: " ", with: "-")
                     .filter { $0.isLetter || $0 == "-" }
-                let dateStamp = Date().formatted(.iso8601.year().month().day())
-                let fileName = "Nest-\(childName)-\(dateStamp).json"
+                let formatter = DateFormatter()
+                formatter.dateFormat = "yyyy-MM-dd-HHmmss"
+                let timeStamp = formatter.string(from: Date())
+                let fileName = "nest-export-\(childName)-\(timeStamp).json"
 
                 let tempURL = FileManager.default.temporaryDirectory.appendingPathComponent(fileName)
                 try data.write(to: tempURL, options: .atomic)


### PR DESCRIPTION
Closes #104

## Change

Export filenames now include date and time, producing unique filenames per export.

**Before:** `Nest-Alice-2026-04-02.json`
**After:** `nest-export-Alice-2026-04-02-143022.json`

Exporting twice in the same day previously produced the same filename. The time component (HHmmss) makes each export unique.

## Plan

No plan document — single-line string change, no architectural impact.

🤖 Generated with [Claude Code](https://claude.ai/claude-code)