### PR TITLE
Use timestamped filename for log export

### DIFF
--- a/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/LoggingView.swift
+++ b/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/LoggingView.swift
@@ -7,6 +7,7 @@ public struct LoggingView: View {
 
     @State private var searchText = ""
     @State private var selectedLevel: LogLevel?
+    @State private var exportItem: ExportItem?
 
     public init(appLogger: AppLogger) {
         self.appLogger = appLogger
@@ -27,6 +28,9 @@ public struct LoggingView: View {
             ToolbarItem(placement: .navigationBarTrailing) {
                 actionsMenu
             }
+        }
+        .sheet(item: $exportItem) { item in
+            ShareSheet(url: item.url)
         }
         .overlay {
             if appLogger.entries.isEmpty {
@@ -77,7 +81,17 @@ public struct LoggingView: View {
                 Label("Copy Visible", systemImage: "doc.on.doc")
             }
 
-            ShareLink(item: formattedText(for: appLogger.entries)) {
+            Button {
+                let formatter = DateFormatter()
+                formatter.dateFormat = "yyyy-MM-dd-HHmmss"
+                let timestamp = formatter.string(from: Date())
+                let filename = "nest-logs-\(timestamp).txt"
+                let url = FileManager.default.temporaryDirectory.appendingPathComponent(filename)
+                if let data = formattedText(for: appLogger.entries).data(using: .utf8) {
+                    try? data.write(to: url, options: .atomic)
+                    exportItem = ExportItem(url: url)
+                }
+            } label: {
                 Label("Export All as File", systemImage: "square.and.arrow.up")
             }
 
@@ -110,6 +124,21 @@ public struct LoggingView: View {
             "[\(formatter.string(from: entry.timestamp))] [\(entry.level.rawValue.uppercased())] [\(entry.category)] \(entry.message)"
         }.joined(separator: "\n")
     }
+}
+
+private struct ExportItem: Identifiable {
+    let id = UUID()
+    let url: URL
+}
+
+private struct ShareSheet: UIViewControllerRepresentable {
+    let url: URL
+
+    func makeUIViewController(context: Context) -> UIActivityViewController {
+        UIActivityViewController(activityItems: [url], applicationActivities: nil)
+    }
+
+    func updateUIViewController(_ uiViewController: UIActivityViewController, context: Context) {}
 }
 
 private struct LogEntryRow: View {


### PR DESCRIPTION
Closes #104

## Change

The "Export All as File" action in the Logs screen now produces a named file with a timestamp rather than a generic filename.

**Before:** iOS chose a generic name (e.g. `unknown.txt`)
**After:** `nest-logs-2026-04-02-143022.txt`

Replaced the `ShareLink(item: String)` (which gives iOS no filename hint) with a `Button` that writes the log text to a timestamped temp file, then presents a `UIActivityViewController` via a sheet — giving the share sheet a proper filename.

## Plan

No plan document — small focused change to a single view.

🤖 Generated with [Claude Code](https://claude.ai/claude-code)