### PR TITLE
Show 'deleted' in push notification when caregiver deletes an event

### DIFF
--- a/Packages/BabyTrackerDomain/Sources/BabyTrackerDomain/RemoteCaregiverEventChange.swift
+++ b/Packages/BabyTrackerDomain/Sources/BabyTrackerDomain/RemoteCaregiverEventChange.swift
@@ -3,9 +3,11 @@ import Foundation
 public struct RemoteCaregiverEventChange: Equatable, Sendable {
     public let actorDisplayName: String
     public let event: BabyEvent
+    public let isDeleted: Bool
 
-    public init(actorDisplayName: String, event: BabyEvent) {
+    public init(actorDisplayName: String, event: BabyEvent, isDeleted: Bool) {
         self.actorDisplayName = actorDisplayName
         self.event = event
+        self.isDeleted = isDeleted
     }
 }

--- a/Packages/BabyTrackerDomain/Sources/BabyTrackerDomain/UseCases/BuildRemoteCaregiverNotificationUseCase.swift
+++ b/Packages/BabyTrackerDomain/Sources/BabyTrackerDomain/UseCases/BuildRemoteCaregiverNotificationUseCase.swift
@@ -34,19 +34,33 @@ public struct BuildRemoteCaregiverNotificationUseCase: Sendable {
 
         let distinctCaregivers = Set(input.changes.map(\.actorDisplayName)).count
         if distinctCaregivers == 1, let caregiver = input.changes.first?.actorDisplayName {
+            let allDeleted = input.changes.allSatisfy(\.isDeleted)
+            if allDeleted {
+                return .init(
+                    title: "Baby Tracker",
+                    body: "\(caregiver) deleted \(input.changes.count) events."
+                )
+            }
             return .init(
                 title: "Baby Tracker",
-                body: "\(caregiver) logged \(input.changes.count) updates."
+                body: "\(caregiver) made \(input.changes.count) updates."
             )
         }
 
         return .init(
             title: "Baby Tracker",
-            body: "\(input.changes.count) new updates from caregivers."
+            body: "Caregivers made \(input.changes.count) updates."
         )
     }
 
     private func message(for change: RemoteCaregiverEventChange) -> String {
+        if change.isDeleted {
+            return deletedMessage(for: change)
+        }
+        return addedMessage(for: change)
+    }
+
+    private func addedMessage(for change: RemoteCaregiverEventChange) -> String {
         switch change.event {
         case let .sleep(event):
             if event.endedAt == nil {
@@ -60,6 +74,19 @@ public struct BuildRemoteCaregiverNotificationUseCase: Sendable {
             return "\(change.actorDisplayName) logged a bottle feed at \(formatTime(event.metadata.occurredAt))."
         case let .breastFeed(event):
             return "\(change.actorDisplayName) logged a breast feed at \(formatTime(event.metadata.occurredAt))."
+        }
+    }
+
+    private func deletedMessage(for change: RemoteCaregiverEventChange) -> String {
+        switch change.event {
+        case .sleep:
+            return "\(change.actorDisplayName) deleted a sleep log."
+        case let .nappy(event):
+            return "\(change.actorDisplayName) deleted a \(nappyDescriptor(for: event.type)) nappy log."
+        case .bottleFeed:
+            return "\(change.actorDisplayName) deleted a bottle feed log."
+        case .breastFeed:
+            return "\(change.actorDisplayName) deleted a breast feed log."
         }
     }
 

--- a/Packages/BabyTrackerDomain/Tests/BabyTrackerDomainTests/BuildRemoteCaregiverNotificationUseCaseTests.swift
+++ b/Packages/BabyTrackerDomain/Tests/BabyTrackerDomainTests/BuildRemoteCaregiverNotificationUseCaseTests.swift
@@ -19,7 +19,7 @@ final class BuildRemoteCaregiverNotificationUseCaseTests: XCTestCase {
 
         let useCase = BuildRemoteCaregiverNotificationUseCase(formatTime: { _ in "10:00 AM" })
         let content = useCase.execute(.init(changes: [
-            .init(actorDisplayName: caregiver.displayName, event: .sleep(sleep)),
+            .init(actorDisplayName: caregiver.displayName, event: .sleep(sleep), isDeleted: false),
         ]))
 
         XCTAssertEqual(content?.body, "Alex started a sleep timer.")
@@ -40,7 +40,7 @@ final class BuildRemoteCaregiverNotificationUseCaseTests: XCTestCase {
 
         let useCase = BuildRemoteCaregiverNotificationUseCase(formatTime: { _ in "11:45 AM" })
         let content = useCase.execute(.init(changes: [
-            .init(actorDisplayName: caregiver.displayName, event: .nappy(nappy)),
+            .init(actorDisplayName: caregiver.displayName, event: .nappy(nappy), isDeleted: false),
         ]))
 
         XCTAssertEqual(content?.body, "Sam logged a wet nappy at 11:45 AM.")
@@ -58,10 +58,157 @@ final class BuildRemoteCaregiverNotificationUseCaseTests: XCTestCase {
 
         let useCase = BuildRemoteCaregiverNotificationUseCase()
         let content = useCase.execute(.init(changes: [
-            .init(actorDisplayName: caregiverOne.displayName, event: .bottleFeed(feed)),
-            .init(actorDisplayName: caregiverTwo.displayName, event: .bottleFeed(feed)),
+            .init(actorDisplayName: caregiverOne.displayName, event: .bottleFeed(feed), isDeleted: false),
+            .init(actorDisplayName: caregiverTwo.displayName, event: .bottleFeed(feed), isDeleted: false),
         ]))
 
-        XCTAssertEqual(content?.body, "2 new updates from caregivers.")
+        XCTAssertEqual(content?.body, "Caregivers made 2 updates.")
+    }
+
+    func testSingleDeletedSleepBuildsDeletedMessage() throws {
+        let caregiver = try UserIdentity(displayName: "Alex")
+        let child = try Child(name: "Robin", birthDate: nil, createdBy: caregiver.id)
+        let sleep = try SleepEvent(
+            metadata: EventMetadata(
+                childID: child.id,
+                occurredAt: Date(timeIntervalSince1970: 100),
+                createdAt: Date(timeIntervalSince1970: 100),
+                createdBy: caregiver.id,
+                updatedAt: Date(timeIntervalSince1970: 100),
+                updatedBy: caregiver.id,
+                isDeleted: true
+            ),
+            startedAt: Date(timeIntervalSince1970: 100),
+            endedAt: Date(timeIntervalSince1970: 200)
+        )
+
+        let useCase = BuildRemoteCaregiverNotificationUseCase(formatTime: { _ in "10:00 AM" })
+        let content = useCase.execute(.init(changes: [
+            .init(actorDisplayName: caregiver.displayName, event: .sleep(sleep), isDeleted: true),
+        ]))
+
+        XCTAssertEqual(content?.body, "Alex deleted a sleep log.")
+    }
+
+    func testSingleDeletedNappyBuildsDeletedMessage() throws {
+        let caregiver = try UserIdentity(displayName: "Sam")
+        let child = try Child(name: "Robin", birthDate: nil, createdBy: caregiver.id)
+        let nappy = try NappyEvent(
+            metadata: EventMetadata(
+                childID: child.id,
+                occurredAt: Date(timeIntervalSince1970: 100),
+                createdBy: caregiver.id,
+                updatedBy: caregiver.id,
+                isDeleted: true
+            ),
+            type: .poo
+        )
+
+        let useCase = BuildRemoteCaregiverNotificationUseCase(formatTime: { _ in "11:00 AM" })
+        let content = useCase.execute(.init(changes: [
+            .init(actorDisplayName: caregiver.displayName, event: .nappy(nappy), isDeleted: true),
+        ]))
+
+        XCTAssertEqual(content?.body, "Sam deleted a dirty nappy log.")
+    }
+
+    func testSingleDeletedBottleFeedBuildsDeletedMessage() throws {
+        let caregiver = try UserIdentity(displayName: "Jordan")
+        let child = try Child(name: "Robin", birthDate: nil, createdBy: caregiver.id)
+        let feed = try BottleFeedEvent(
+            metadata: EventMetadata(
+                childID: child.id,
+                occurredAt: Date(timeIntervalSince1970: 100),
+                createdBy: caregiver.id,
+                updatedBy: caregiver.id,
+                isDeleted: true
+            ),
+            amountMilliliters: 100,
+            milkType: .breastMilk
+        )
+
+        let useCase = BuildRemoteCaregiverNotificationUseCase(formatTime: { _ in "9:00 AM" })
+        let content = useCase.execute(.init(changes: [
+            .init(actorDisplayName: caregiver.displayName, event: .bottleFeed(feed), isDeleted: true),
+        ]))
+
+        XCTAssertEqual(content?.body, "Jordan deleted a bottle feed log.")
+    }
+
+    func testSingleDeletedBreastFeedBuildsDeletedMessage() throws {
+        let caregiver = try UserIdentity(displayName: "Morgan")
+        let child = try Child(name: "Robin", birthDate: nil, createdBy: caregiver.id)
+        let feed = try BreastFeedEvent(
+            metadata: EventMetadata(
+                childID: child.id,
+                occurredAt: Date(timeIntervalSince1970: 200),
+                createdBy: caregiver.id,
+                updatedBy: caregiver.id,
+                isDeleted: true
+            ),
+            side: nil,
+            startedAt: Date(timeIntervalSince1970: 100),
+            endedAt: Date(timeIntervalSince1970: 200)
+        )
+
+        let useCase = BuildRemoteCaregiverNotificationUseCase(formatTime: { _ in "8:00 AM" })
+        let content = useCase.execute(.init(changes: [
+            .init(actorDisplayName: caregiver.displayName, event: .breastFeed(feed), isDeleted: true),
+        ]))
+
+        XCTAssertEqual(content?.body, "Morgan deleted a breast feed log.")
+    }
+
+    func testMultipleDeletesFromSameCaregiverBuildsDeletedSummary() throws {
+        let caregiver = try UserIdentity(displayName: "Alex")
+        let child = try Child(name: "Robin", birthDate: nil, createdBy: caregiver.id)
+        let nappy = try NappyEvent(
+            metadata: EventMetadata(childID: child.id, occurredAt: .now, createdBy: caregiver.id, updatedBy: caregiver.id),
+            type: .wee
+        )
+
+        let useCase = BuildRemoteCaregiverNotificationUseCase()
+        let content = useCase.execute(.init(changes: [
+            .init(actorDisplayName: caregiver.displayName, event: .nappy(nappy), isDeleted: true),
+            .init(actorDisplayName: caregiver.displayName, event: .nappy(nappy), isDeleted: true),
+            .init(actorDisplayName: caregiver.displayName, event: .nappy(nappy), isDeleted: true),
+        ]))
+
+        XCTAssertEqual(content?.body, "Alex deleted 3 events.")
+    }
+
+    func testMixedAddAndDeleteFromSameCaregiverBuildsMadeUpdatesMessage() throws {
+        let caregiver = try UserIdentity(displayName: "Sam")
+        let child = try Child(name: "Robin", birthDate: nil, createdBy: caregiver.id)
+        let nappy = try NappyEvent(
+            metadata: EventMetadata(childID: child.id, occurredAt: .now, createdBy: caregiver.id, updatedBy: caregiver.id),
+            type: .dry
+        )
+
+        let useCase = BuildRemoteCaregiverNotificationUseCase()
+        let content = useCase.execute(.init(changes: [
+            .init(actorDisplayName: caregiver.displayName, event: .nappy(nappy), isDeleted: false),
+            .init(actorDisplayName: caregiver.displayName, event: .nappy(nappy), isDeleted: true),
+        ]))
+
+        XCTAssertEqual(content?.body, "Sam made 2 updates.")
+    }
+
+    func testMixedDeletesFromMultipleCaregiversBuildsCaregiversMadeUpdatesMessage() throws {
+        let caregiverOne = try UserIdentity(displayName: "Sam")
+        let caregiverTwo = try UserIdentity(displayName: "Alex")
+        let child = try Child(name: "Robin", birthDate: nil, createdBy: caregiverOne.id)
+        let nappy = try NappyEvent(
+            metadata: EventMetadata(childID: child.id, occurredAt: .now, createdBy: caregiverOne.id, updatedBy: caregiverOne.id),
+            type: .dry
+        )
+
+        let useCase = BuildRemoteCaregiverNotificationUseCase()
+        let content = useCase.execute(.init(changes: [
+            .init(actorDisplayName: caregiverOne.displayName, event: .nappy(nappy), isDeleted: true),
+            .init(actorDisplayName: caregiverTwo.displayName, event: .nappy(nappy), isDeleted: true),
+        ]))
+
+        XCTAssertEqual(content?.body, "Caregivers made 2 updates.")
     }
 }

--- a/Packages/BabyTrackerSync/Sources/BabyTrackerSync/CloudKitSyncEngine.swift
+++ b/Packages/BabyTrackerSync/Sources/BabyTrackerSync/CloudKitSyncEngine.swift
@@ -1056,7 +1056,8 @@ public final class CloudKitSyncEngine {
         remoteCaregiverEventChanges.append(
             RemoteCaregiverEventChange(
                 actorDisplayName: actorDisplayName,
-                event: event
+                event: event,
+                isDeleted: event.metadata.isDeleted
             )
         )
     }


### PR DESCRIPTION
Closes #108

## Change

When a caregiver deletes an event, the push notification now correctly says "deleted" rather than "logged".

**Before:** `"Alex logged a bottle feed at 2:30 PM."` (even for a deletion)
**After:** `"Alex deleted a bottle feed log."`

## Notification messages

| Scenario | Message |
|---|---|
| Single deleted sleep | `"{name} deleted a sleep log."` |
| Single deleted nappy | `"{name} deleted a dirty nappy log."` |
| Single deleted bottle feed | `"{name} deleted a bottle feed log."` |
| Single deleted breast feed | `"{name} deleted a breast feed log."` |
| Multiple deletes, one caregiver | `"{name} deleted {n} events."` |
| Mixed add/delete, one caregiver | `"{name} made {n} updates."` |
| Multiple caregivers | `"Caregivers made {n} updates."` |

## What changed

- `RemoteCaregiverEventChange` — added `isDeleted: Bool`
- `BuildRemoteCaregiverNotificationUseCase` — dispatches to separate added/deleted message builders
- `CloudKitSyncEngine.trackRemoteCaregiverChange` — passes `event.metadata.isDeleted`
- `BuildRemoteCaregiverNotificationUseCaseTests` — 7 new test cases for deleted event scenarios; existing call sites updated

## Plan

No plan document — focused fix across four files with no architectural change.

🤖 Generated with [Claude Code](https://claude.ai/claude-code)