### PR TITLE
Always push current content to live activity on every synchronize call

### DIFF
--- a/Baby Tracker/App/FeedLiveActivityManager.swift
+++ b/Baby Tracker/App/FeedLiveActivityManager.swift
@@ -6,7 +6,6 @@ import Foundation
 @MainActor
 final class FeedLiveActivityManager: FeedLiveActivityManaging {
     private var activeActivityID: String?
-    private var lastSnapshot: FeedLiveActivitySnapshot?
     private var synchronizationTask: Task<Void, Never>?
 
     func synchronize(with snapshot: FeedLiveActivitySnapshot?) {
@@ -22,7 +21,6 @@ final class FeedLiveActivityManager: FeedLiveActivityManaging {
         guard let snapshot else {
             await Self.endAllActivities()
             activeActivityID = nil
-            lastSnapshot = nil
             return
         }
 
@@ -37,10 +35,6 @@ final class FeedLiveActivityManager: FeedLiveActivityManaging {
             activeActivityID = nil
         }
 
-        guard lastSnapshot != snapshot || activeActivityID == nil else {
-            return
-        }
-
         if let activeActivityID {
             let didUpdate = await Self.updateActivity(
                 withID: activeActivityID,
@@ -48,7 +42,6 @@ final class FeedLiveActivityManager: FeedLiveActivityManaging {
             )
 
             if didUpdate {
-                lastSnapshot = snapshot
                 return
             }
 
@@ -62,10 +55,8 @@ final class FeedLiveActivityManager: FeedLiveActivityManaging {
                 pushType: nil
             )
             activeActivityID = activity.id
-            lastSnapshot = snapshot
         } catch {
             activeActivityID = nil
-            lastSnapshot = nil
         }
     }
 


### PR DESCRIPTION
Closes #111

## Problem

The live activity would sometimes show stale data. Toggling the live activity off and on forced a refresh, which pointed to the `lastSnapshot` optimisation in `FeedLiveActivityManager` as the culprit.

`reconcile()` had a guard that skipped the ActivityKit `update()` call when the snapshot appeared unchanged and an activity was already running:

```swift
guard lastSnapshot != snapshot || activeActivityID == nil else {
    return
}
```

If the live activity's displayed content fell out of sync with app state for any reason (iOS rehydrating the widget from disk, a silently throttled prior update), this guard prevented the corrective update from ever being sent.

Toggling off/on worked because it reset `lastSnapshot = nil`, causing the guard to pass on the next call and forcing a fresh activity to be requested.

## Fix

Removed `lastSnapshot` entirely. Every `synchronize()` call now results in an actual ActivityKit `update()` call when an activity is running. ActivityKit handles duplicate or identical updates gracefully, so the guard was not providing correctness — only a small, unnecessary optimisation.

## What changed

Only `Baby Tracker/App/FeedLiveActivityManager.swift` — 9 lines deleted, no new code.

## Plan

No plan document — single-file deletion of a flawed optimisation.

🤖 Generated with [Claude Code](https://claude.ai/claude-code)