### PR TITLE
Add Resume Sleep action to sleep edit screen

### DIFF
--- a/Baby TrackerTests/AppModelTests.swift
+++ b/Baby TrackerTests/AppModelTests.swift
@@ -721,6 +721,71 @@ struct AppModelTests {
     }
 
     @Test
+    func resumeSleepClearsEndedAtAndMakesSleepActive() throws {
+        let harness = try Harness()
+        defer { harness.cleanUp() }
+
+        let seed = try harness.seedOwnerProfile()
+        let sleep = try harness.saveSleep(
+            childID: seed.child.id,
+            userID: seed.localUser.id,
+            startedAt: Date(timeIntervalSince1970: 9_000),
+            endedAt: Date(timeIntervalSince1970: 9_900)
+        )
+
+        harness.model.load(performLaunchSync: false)
+
+        #expect(harness.model.resumeSleep(id: sleep.id, startedAt: sleep.startedAt))
+
+        let resumedEvent = try #require(try harness.eventRepository.loadEvent(id: sleep.id))
+        switch resumedEvent {
+        case let .sleep(event):
+            #expect(event.id == sleep.id)
+            #expect(event.startedAt == sleep.startedAt)
+            #expect(event.endedAt == nil)
+            #expect(event.metadata.occurredAt == sleep.startedAt)
+        default:
+            Issue.record("Expected a resumed sleep event")
+        }
+
+        let profile = try #require(harness.model.profile)
+        #expect(profile.activeSleepSession?.id == sleep.id)
+    }
+
+    @Test
+    func resumeSleepFailsWhenSleepIsAlreadyActive() throws {
+        let harness = try Harness()
+        defer { harness.cleanUp() }
+
+        let seed = try harness.seedOwnerProfile()
+        let activeSleep = try harness.saveSleep(
+            childID: seed.child.id,
+            userID: seed.localUser.id,
+            startedAt: Date(timeIntervalSince1970: 10_000),
+            endedAt: nil
+        )
+
+        harness.model.load(performLaunchSync: false)
+
+        #expect(harness.model.resumeSleep(id: activeSleep.id, startedAt: activeSleep.startedAt) == false)
+        #expect(harness.model.errorMessage == BabyEventError.sleepAlreadyActive.errorDescription)
+    }
+
+    @Test
+    func resumeSleepFailsForNonExistentEvent() throws {
+        let harness = try Harness()
+        defer { harness.cleanUp() }
+
+        _ = try harness.seedOwnerProfile()
+
+        harness.model.load(performLaunchSync: false)
+
+        let missingID = UUID()
+        #expect(harness.model.resumeSleep(id: missingID, startedAt: Date()) == false)
+        #expect(harness.model.errorMessage == BabyEventError.noActiveSleepInProgress.errorDescription)
+    }
+
+    @Test
     func completedSleepCanBeEditedDeletedAndUndone() throws {
         let harness = try Harness()
         defer { harness.cleanUp() }

--- a/Packages/BabyTrackerDomain/Sources/BabyTrackerDomain/BabyEventError.swift
+++ b/Packages/BabyTrackerDomain/Sources/BabyTrackerDomain/BabyEventError.swift
@@ -5,6 +5,7 @@ public enum BabyEventError: LocalizedError, Equatable, Sendable {
     case invalidBottleAmount
     case activeSleepAlreadyInProgress
     case noActiveSleepInProgress
+    case sleepAlreadyActive
 
     public var errorDescription: String? {
         switch self {
@@ -16,6 +17,8 @@ public enum BabyEventError: LocalizedError, Equatable, Sendable {
             "A sleep session is already in progress."
         case .noActiveSleepInProgress:
             "There is no active sleep session to end."
+        case .sleepAlreadyActive:
+            "This sleep session is already active."
         }
     }
 }

--- a/Packages/BabyTrackerDomain/Sources/BabyTrackerDomain/UseCases/ResumeSleepUseCase.swift
+++ b/Packages/BabyTrackerDomain/Sources/BabyTrackerDomain/UseCases/ResumeSleepUseCase.swift
@@ -1,0 +1,59 @@
+import Foundation
+
+@MainActor
+public struct ResumeSleepUseCase: UseCase {
+    public struct Input {
+        public let eventID: UUID
+        public let localUserID: UUID
+        public let startedAt: Date
+        public let membership: Membership
+
+        public init(
+            eventID: UUID,
+            localUserID: UUID,
+            startedAt: Date,
+            membership: Membership
+        ) {
+            self.eventID = eventID
+            self.localUserID = localUserID
+            self.startedAt = startedAt
+            self.membership = membership
+        }
+    }
+
+    private let eventRepository: any EventRepository
+    private let hapticFeedbackProvider: any HapticFeedbackProviding
+
+    public init(
+        eventRepository: any EventRepository,
+        hapticFeedbackProvider: any HapticFeedbackProviding = NoOpHapticFeedbackProvider()
+    ) {
+        self.eventRepository = eventRepository
+        self.hapticFeedbackProvider = hapticFeedbackProvider
+    }
+
+    public func execute(_ input: Input) throws -> BabyEvent {
+        guard ChildAccessPolicy.canPerform(.editEvent, membership: input.membership) else {
+            throw ChildProfileValidationError.insufficientPermissions
+        }
+        guard let event = try eventRepository.loadEvent(id: input.eventID) else {
+            throw BabyEventError.noActiveSleepInProgress
+        }
+        guard case let .sleep(sleepEvent) = event else {
+            throw BabyEventError.noActiveSleepInProgress
+        }
+        guard sleepEvent.endedAt != nil else {
+            throw BabyEventError.sleepAlreadyActive
+        }
+
+        let resumedSleep = try sleepEvent.updating(
+            startedAt: input.startedAt,
+            endedAt: nil,
+            updatedBy: input.localUserID
+        )
+
+        try eventRepository.saveEvent(.sleep(resumedSleep))
+        hapticFeedbackProvider.play(.sleepStarted)
+        return .sleep(resumedSleep)
+    }
+}

--- a/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/AppModel.swift
+++ b/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/AppModel.swift
@@ -742,6 +742,24 @@ public final class AppModel {
     }
 
     @discardableResult
+    public func resumeSleep(id: UUID, startedAt: Date) -> Bool {
+        perform {
+            guard let profile else { throw ChildProfileValidationError.insufficientPermissions }
+            guard let localUser else { throw ChildProfileValidationError.insufficientPermissions }
+            _ = try ResumeSleepUseCase(
+                eventRepository: eventRepository,
+                hapticFeedbackProvider: hapticFeedbackProvider
+            )
+                .execute(.init(
+                    eventID: id,
+                    localUserID: localUser.id,
+                    startedAt: startedAt,
+                    membership: profile.currentMembership
+                ))
+        }
+    }
+
+    @discardableResult
     public func deleteEvent(id: UUID) -> Bool {
         perform {
             guard let profile else { throw ChildProfileValidationError.insufficientPermissions }

--- a/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/ChildWorkspaceTabView.swift
+++ b/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/ChildWorkspaceTabView.swift
@@ -368,22 +368,29 @@ public struct ChildWorkspaceTabView: View {
                 childName: profile.child.name,
                 initialStartedAt: startedAt,
                 initialEndedAt: endedAt,
-                endTimeInitialPreset: .custom
-            ) { updatedStartedAt, updatedEndedAt in
-                guard let updatedEndedAt else {
-                    return false
-                }
+                endTimeInitialPreset: .custom,
+                saveAction: { updatedStartedAt, updatedEndedAt in
+                    guard let updatedEndedAt else {
+                        return false
+                    }
 
-                let didSave = model.updateSleep(
-                    id: id,
-                    startedAt: updatedStartedAt,
-                    endedAt: updatedEndedAt
-                )
-                if didSave {
-                    activeEventSheet = nil
+                    let didSave = model.updateSleep(
+                        id: id,
+                        startedAt: updatedStartedAt,
+                        endedAt: updatedEndedAt
+                    )
+                    if didSave {
+                        activeEventSheet = nil
+                    }
+                    return didSave
+                },
+                resumeAction: {
+                    let didResume = model.resumeSleep(id: id, startedAt: startedAt)
+                    if didResume {
+                        activeEventSheet = nil
+                    }
                 }
-                return didSave
-            }
+            )
         case let .editNappy(id, type, occurredAt, peeVolume, pooVolume, pooColor):
             NappyEditorSheetView(
                 navigationTitle: "Edit Nappy",

--- a/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/SleepEditorSheetView.swift
+++ b/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/SleepEditorSheetView.swift
@@ -9,6 +9,7 @@ public struct SleepEditorSheetView: View {
     let startSuggestions: [(label: String, date: Date)]
     let saveAction: (_ startedAt: Date, _ endedAt: Date?) -> Bool
     let deleteAction: (() -> Void)?
+    let resumeAction: (() -> Void)?
     private let endTimeInitialPreset: QuickTimeSelectorView.TimePreset
 
     @Environment(\.dismiss) private var dismiss
@@ -24,13 +25,15 @@ public struct SleepEditorSheetView: View {
         startSuggestions: [(label: String, date: Date)] = [],
         endTimeInitialPreset: QuickTimeSelectorView.TimePreset = .now,
         saveAction: @escaping (_ startedAt: Date, _ endedAt: Date?) -> Bool,
-        deleteAction: (() -> Void)? = nil
+        deleteAction: (() -> Void)? = nil,
+        resumeAction: (() -> Void)? = nil
     ) {
         self.mode = mode
         self.childName = childName
         self.startSuggestions = startSuggestions
         self.saveAction = saveAction
         self.deleteAction = deleteAction
+        self.resumeAction = resumeAction
         self.endTimeInitialPreset = endTimeInitialPreset
         _startedAt = State(initialValue: initialStartedAt)
         _endedAt = State(initialValue: initialEndedAt ?? Date())
@@ -54,6 +57,16 @@ public struct SleepEditorSheetView: View {
                     Section {
                         Text(validationMessage)
                             .foregroundStyle(.red)
+                    }
+                }
+
+                if case .edit = mode, let resumeAction {
+                    Section {
+                        Button("Resume Sleep") {
+                            resumeAction()
+                        }
+                        .foregroundStyle(.orange)
+                        .accessibilityIdentifier("resume-sleep-button")
                     }
                 }
 
@@ -317,4 +330,16 @@ extension SleepEditorSheetView {
             }
         }
     }
+}
+
+#Preview("Edit with Resume") {
+    SleepEditorSheetView(
+        mode: .edit,
+        childName: "Isla",
+        initialStartedAt: Date(timeIntervalSinceNow: -3_600),
+        initialEndedAt: Date(timeIntervalSinceNow: -1_800),
+        endTimeInitialPreset: .custom,
+        saveAction: { _, _ in true },
+        resumeAction: {}
+    )
 }

--- a/docs/plans/026-resume-sleep.md
+++ b/docs/plans/026-resume-sleep.md
@@ -1,0 +1,15 @@
+# 026 - Resume Sleep
+
+## Goal
+
+Allow users to resume an accidentally ended sleep session from the sleep edit screen.
+
+## Approach
+
+1. Add `ResumeSleepUseCase` in the domain layer — clears `endedAt`, making the sleep active again.
+2. Add `AppModel.resumeSleep(id:startedAt:)` following the existing sleep method pattern.
+3. Add an optional `resumeAction` callback to `SleepEditorSheetView` shown only in `.edit` mode.
+4. Wire the callback in `ChildWorkspaceTabView` when presenting the edit sheet.
+5. Add tests for `ResumeSleepUseCase`.
+
+- [ ] Complete


### PR DESCRIPTION
Closes #116

## Change

When a user accidentally ends a sleep, they can now open the sleep edit screen and tap **Resume Sleep** to clear the end time and make it active again.

The button appears only on completed (ended) sleeps — it is not shown for active sleeps or the start/end flows.

## What changed

- `ResumeSleepUseCase` — domain use case that validates the sleep is ended, clears `endedAt`, saves, and plays the sleep-started haptic
- `BabyEventError.sleepAlreadyActive` — new error case for attempting to resume an already-active sleep
- `AppModel.resumeSleep(id:startedAt:)` — wires the use case into the feature layer
- `SleepEditorSheetView` — optional `resumeAction` callback; shows an orange "Resume Sleep" button in `.edit` mode when provided
- `ChildWorkspaceTabView` — passes the `resumeAction` closure when presenting the edit sleep sheet
- `AppModelTests` — 3 new tests covering success, already-active, and non-existent event cases

## Plan

`docs/plans/026-resume-sleep.md`

🤖 Generated with [Claude Code](https://claude.ai/claude-code)