### PR TITLE
Pop navigation to root when adding or removing a child

### DIFF
--- a/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/AppModel.swift
+++ b/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/AppModel.swift
@@ -266,7 +266,7 @@ public final class AppModel {
     }
 
     public func createChild(name: String, birthDate: Date?, imageData: Data? = nil) {
-        perform {
+        let succeeded = perform {
             guard let localUser else { return }
             _ = try CreateChildUseCase(
                 childRepository: childRepository,
@@ -275,6 +275,7 @@ public final class AppModel {
                 hapticFeedbackProvider: hapticFeedbackProvider
             ).execute(.init(name: name, birthDate: birthDate, localUser: localUser, imageData: imageData))
         }
+        if succeeded { resetNavigationStack() }
     }
 
     public func updateCurrentChild(
@@ -301,7 +302,7 @@ public final class AppModel {
     }
 
     public func archiveCurrentChild() {
-        perform {
+        let succeeded = perform {
             guard let profile else { return }
             let revokedCaregivers = try ArchiveChildUseCase(
                 childRepository: childRepository,
@@ -319,6 +320,7 @@ public final class AppModel {
                 }
             }
         }
+        if succeeded { resetNavigationStack() }
     }
 
     public func restoreChild(id: UUID) {
@@ -465,6 +467,7 @@ public final class AppModel {
                     childSelectionStore.saveSelectedChildID(nil)
                 }
                 playHaptic(.actionSucceeded)
+                resetNavigationStack()
             } catch {
                 AppLogger.shared.log(.error, category: "CloudKitShare", "leaveChildShare failed for child \(childID): \(error)")
                 setErrorMessage(resolveErrorMessage(for: error))


### PR DESCRIPTION
Closes #97

## Problem

After adding a new child or archiving/leaving a child, the user was left at whatever depth they were in the settings hierarchy. Only hard delete already popped to root.

## Fix

Added `resetNavigationStack()` to three methods in `AppModel` that were missing it, matching the pattern already used by `hardDeleteCurrentChild()`:

- `createChild()` — resets after successful child creation
- `archiveCurrentChild()` — resets after successful archive
- `leaveChildShare()` — resets after successfully leaving a shared child

The token-based reset causes the root `NavigationStack` to recreate itself, clearing all nested screens and returning the user to the profile root.

## Plan

No plan document — three-line fix in one file, matching an existing pattern.

🤖 Generated with [Claude Code](https://claude.ai/claude-code)