### PR TITLE
Add architecture reference and AppModel gap analysis

### DIFF
--- a/docs/architecture/2026-04-03-appmodel-architecture-gap-analysis.md
+++ b/docs/architecture/2026-04-03-appmodel-architecture-gap-analysis.md
@@ -1,0 +1,96 @@
+# AppModel Architecture Gap Analysis
+
+Date: 2026-04-03
+
+## Scope
+This analysis compares the current repository architecture with the target in `swiftui_architecture_with_diagram.md`.
+
+## Current state summary
+
+1. **Strong package decomposition already exists** (`Domain`, `Feature`, `Persistence`, `Sync`) and the app target acts as composition root through `AppContainer`.
+2. **Feature still depends on infrastructure packages directly** (`BabyTrackerPersistence`, `BabyTrackerSync`) rather than depending only on domain abstractions.
+3. **`AppModel` remains very large and multi-responsibility** (1,542 lines) and combines:
+   - app routing/session state
+   - read-side repository orchestration
+   - sync orchestration
+   - feature-level state shaping for timeline/home/history
+   - import/export orchestration
+   - transient UI banners, undo, and sheet state
+
+## Gap vs target architecture
+
+### 1) Dependency direction gap (high priority)
+**Target:** `Feature -> Domain` only.
+
+**Current:** `Feature -> Domain + Persistence + Sync` in package manifest, and direct infrastructure imports in `AppModel`.
+
+**Impact:** Feature-level types know infrastructure details, making replacement/testing harder and coupling package boundaries.
+
+### 2) AppModel responsibility gap (high priority)
+**Target:** thin app coordinator focused on app/session/navigation state.
+
+**Current:** `AppModel` owns many domains simultaneously (child profile loading, timeline derivation, sync banners, import/export workflows, event write flows), plus infrastructure-triggering logic.
+
+**Impact:** high merge pressure, larger regression blast radius, and slower feature-level iteration.
+
+### 3) Read-side use case extraction gap (high priority)
+**Target:** read assembly happens behind domain use cases, then mapped in feature.
+
+**Current:** `refresh(selecting:)` path and helpers still load and assemble repository data directly inside `AppModel`.
+
+**Impact:** read rules are not easily testable as independent business/application workflows.
+
+### 4) Presentation mapper boundary gap (medium priority)
+**Target:** feature mappers shape view state from use case results.
+
+**Current:** timeline/page/strip assembly and several display derivations live inside `AppModel`.
+
+**Impact:** app coordinator remains responsible for display shaping details.
+
+### 5) Import/export orchestration placement gap (medium priority)
+**Target:** business/data-flow decisions in use cases; UI state transitions in presentation.
+
+**Current:** parsing + duplicate handling flow control + execution state are concentrated in `AppModel`.
+
+**Impact:** hard to evolve import/export flows independently from core app session state.
+
+## High-level refactor areas to reach target
+
+## 1. Fix package dependency direction
+- Remove direct `BabyTrackerPersistence` and `BabyTrackerSync` dependency from `BabyTrackerFeature`.
+- Expose only domain protocols/use-case interfaces to feature.
+- Keep concrete persistence/sync wiring in app composition root.
+
+## 2. Split AppModel into coordinator + focused feature coordinators
+- Keep one app-level coordinator for route/session/navigation/transient app UI.
+- Move feature-specific orchestration into focused observable models (timeline, child workspace, import/export).
+- Avoid creating wrappers without clear state ownership.
+
+## 3. Extract read-side application use cases in Domain
+- Add use cases for loading app session/initial route and loading child workspace snapshots.
+- Move selection fallback and workspace load decisions out of `AppModel`.
+- Unit test these use cases directly in domain tests.
+
+## 4. Introduce explicit feature mappers
+- Map domain workspace snapshots into screen/view states in `BabyTrackerFeature`.
+- Keep timeline strip/page calculations in dedicated mapper/calculator types unless they are true domain rules.
+
+## 5. Isolate sync-facing behavior behind dedicated service seams
+- Keep sync refresh trigger decisions in app coordinator.
+- Push non-UI sync policy/notification derivations into use cases/services that are not tied to app state container size.
+
+## 6. Decompose import/export into separate flows
+- Separate import parsing/tagging/execution orchestration from app-wide state container.
+- Keep `AppModel` owning only presentation state handoff and routing-level transitions.
+
+## Suggested sequence (safe migration)
+1. Dependency direction cleanup (`Feature -> Domain` only at package boundary).
+2. Read-side use case extraction for `refresh(selecting:)`.
+3. Feature mapper extraction for timeline/workspace state.
+4. Import/export flow extraction.
+5. Optional final split of remaining app coordinator concerns if still oversized.
+
+## Progress against target
+- **What is already aligned:** package modularization, composition root pattern, extensive domain use case coverage on write path.
+- **What is furthest from target:** Feature dependency direction and `AppModel` scope/size.
+- **Overall:** foundational architecture exists, but boundary enforcement and orchestration decomposition are only partially complete.

--- a/docs/plans/040-architecture-gap-analysis.md
+++ b/docs/plans/040-architecture-gap-analysis.md
@@ -1,0 +1,21 @@
+# 040 Architecture Gap Analysis for AppModel Refactor
+
+## Goal
+Add the requested architecture reference document to the repository and produce a project-wide gap analysis that compares the current implementation with the target SwiftUI architecture.
+
+## Approach
+1. Add `swiftui_architecture_with_diagram.md` to the repository as the canonical architecture target document.
+2. Review package boundaries and composition root wiring to compare dependency directions against the target.
+3. Review `AppModel` ownership and responsibilities to identify boundary, orchestration, and state-shaping gaps.
+4. Produce a high-level refactor roadmap grouped by architectural area with clear sequencing.
+5. Prepare a stacked PR targeting `claude/refactor-appmodel-architecture-G55po`.
+
+## Deliverables
+- Added architecture reference file in-repo.
+- New architecture gap analysis document with:
+  - current state summary
+  - gap summary vs target
+  - prioritized high-level refactor areas
+  - staged migration plan
+
+- [x] Complete

--- a/swiftui_architecture_with_diagram.md
+++ b/swiftui_architecture_with_diagram.md
@@ -1,0 +1,76 @@
+# SwiftUI Architecture (Target)
+
+This document captures the target architecture for BabyTracker using clean boundaries, explicit use cases, and a thin app coordination layer.
+
+## Principles
+- Keep presentation logic in feature/UI modules.
+- Keep business rules and workflows in domain use cases.
+- Keep persistence and sync details in infrastructure modules.
+- Depend inward toward stable abstractions.
+- Use the app target only as the composition root.
+
+## Layered model
+
+```mermaid
+flowchart TD
+    App[App Target / Composition Root]
+    Feature[Feature / Presentation]
+    Domain[Domain]
+    Data[Persistence/Data]
+    Sync[Sync Infrastructure]
+
+    App --> Feature
+    App --> Domain
+    App --> Data
+    App --> Sync
+
+    Feature --> Domain
+    Data --> Domain
+    Sync --> Domain
+
+    Feature -. no direct dependency .-> Data
+
+    Domain:::core
+
+    classDef core fill:#e8f5e9,stroke:#2e7d32,stroke-width:1px;
+```
+
+## Responsibilities
+
+### App target
+- Builds concrete implementations.
+- Wires repositories, use cases, and services.
+- Owns application lifecycle integration.
+
+### Feature (Presentation)
+- SwiftUI views and presentation models.
+- Screen state shaping and event forwarding.
+- No persistence or CloudKit details.
+
+### Domain
+- Entities and value objects.
+- Repository protocols.
+- Business policies and use cases.
+- Framework-light, test-first business logic.
+
+### Data / Persistence
+- SwiftData models and repository implementations.
+- DTO/entity mapping and local storage behavior.
+
+### Sync
+- CloudKit integration, change tracking, and remote reconciliation.
+- Sync orchestration behind protocol seams.
+
+## AppModel target shape
+`AppModel` should be an app coordinator, not a business engine. It should:
+- own route/navigation/session state
+- trigger use cases
+- map use case outputs to presentation inputs
+- avoid direct repository-heavy read assembly
+- avoid embedding sync/persistence business rules
+
+## Refactor intent
+- Extract read-side workflows to domain use cases.
+- Keep view-specific mapping in feature package.
+- Keep package dependencies aligned with boundary rules.
+- Split large orchestrators into focused coordinators only when this improves clarity.


### PR DESCRIPTION
### Motivation
- Provide an in-repo canonical target architecture for the project so future refactors have a clear reference. 
- Capture the current gaps between the running codebase and the target (with emphasis on `AppModel`) to guide a safe, staged refactor. 
- Produce a short plan and deliverables that can be reviewed and used as the first stacked PR for the `AppModel` decomposition work.

### Description
- Adds a target architecture document `swiftui_architecture_with_diagram.md` that describes layered boundaries, responsibilities, and the intended `AppModel` shape. 
- Adds a dated analysis `docs/architecture/2026-04-03-appmodel-architecture-gap-analysis.md` that compares the current implementation to the target and enumerates high-level refactor areas (dependency direction, `AppModel` decomposition, read-side use cases, feature mappers, sync seams, import/export separation) and a suggested migration sequence. 
- Adds a plan file `docs/plans/040-architecture-gap-analysis.md` and marks it complete to record the work and stack the change into the larger `AppModel` refactor effort. 
- This change is documentation + planning only and leaves code behavior untouched; it establishes the baseline and next steps for refactors (stacked PR target: `claude/refactor-appmodel-architecture-G55po`).

### Testing
- Ran `swift test --package-path Packages/BabyTrackerDomain` which built the package and executed the domain test suite successfully (all tests passed). 
- Verified the repository now contains the new files `swiftui_architecture_with_diagram.md`, `docs/architecture/2026-04-03-appmodel-architecture-gap-analysis.md`, and `docs/plans/040-architecture-gap-analysis.md` with no code changes impacting runtime behavior.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cf87cfe1b4832fa5295f09da7cc46e)