### PR TITLE
Sync live activity immediately when app becomes active

### DIFF
--- a/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/AppModel.swift
+++ b/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/AppModel.swift
@@ -174,6 +174,7 @@ public final class AppModel {
     }
 
     public func refreshSyncStatus() async {
+        refresh(selecting: childSelectionStore.loadSelectedChildID())
         await runSyncRefresh { await self.syncEngine.refreshForeground() }
     }
 


### PR DESCRIPTION
refreshSyncStatus() previously only called refresh() after the cloud sync
completed, so the live activity wouldn't update with local data until the
network round-trip finished. Now it refreshes immediately from local data
first (matching the pattern in perform()), then again after the cloud sync.

https://claude.ai/code/session_01RMJuNsP1jaEiTJu468vpdZ