### PR TITLE
Add date filtering, grouped date headers, and long-press actions to Events

### DIFF
--- a/Packages/BabyTrackerDomain/Sources/BabyTrackerDomain/EventFilter.swift
+++ b/Packages/BabyTrackerDomain/Sources/BabyTrackerDomain/EventFilter.swift
@@ -7,6 +7,8 @@ public struct EventFilter: Equatable, Sendable {
     public var breastSides: Set<BreastSide>
     public var sleepMinDurationMinutes: Int?
     public var sleepMaxDurationMinutes: Int?
+    public var occurredOnOrAfter: Date?
+    public var occurredOnOrBefore: Date?
 
     public init(
         eventTypes: Set<BabyEventKind>,
@@ -14,7 +16,9 @@ public struct EventFilter: Equatable, Sendable {
         milkTypes: Set<MilkType>,
         breastSides: Set<BreastSide>,
         sleepMinDurationMinutes: Int?,
-        sleepMaxDurationMinutes: Int?
+        sleepMaxDurationMinutes: Int?,
+        occurredOnOrAfter: Date?,
+        occurredOnOrBefore: Date?
     ) {
         self.eventTypes = eventTypes
         self.nappyTypes = nappyTypes
@@ -22,6 +26,8 @@ public struct EventFilter: Equatable, Sendable {
         self.breastSides = breastSides
         self.sleepMinDurationMinutes = sleepMinDurationMinutes
         self.sleepMaxDurationMinutes = sleepMaxDurationMinutes
+        self.occurredOnOrAfter = occurredOnOrAfter
+        self.occurredOnOrBefore = occurredOnOrBefore
     }
 
     public static let empty = EventFilter(
@@ -30,7 +36,9 @@ public struct EventFilter: Equatable, Sendable {
         milkTypes: [],
         breastSides: [],
         sleepMinDurationMinutes: nil,
-        sleepMaxDurationMinutes: nil
+        sleepMaxDurationMinutes: nil,
+        occurredOnOrAfter: nil,
+        occurredOnOrBefore: nil
     )
 
     public var isEmpty: Bool {
@@ -39,10 +47,20 @@ public struct EventFilter: Equatable, Sendable {
         milkTypes.isEmpty &&
         breastSides.isEmpty &&
         sleepMinDurationMinutes == nil &&
-        sleepMaxDurationMinutes == nil
+        sleepMaxDurationMinutes == nil &&
+        occurredOnOrAfter == nil &&
+        occurredOnOrBefore == nil
     }
 
     public func matches(_ event: BabyEvent) -> Bool {
+        if let occurredOnOrAfter, event.metadata.occurredAt < occurredOnOrAfter {
+            return false
+        }
+
+        if let occurredOnOrBefore, event.metadata.occurredAt > occurredOnOrBefore {
+            return false
+        }
+
         if !eventTypes.isEmpty, !eventTypes.contains(event.kind) {
             return false
         }

--- a/Packages/BabyTrackerDomain/Tests/BabyTrackerDomainTests/EventFilterTests.swift
+++ b/Packages/BabyTrackerDomain/Tests/BabyTrackerDomainTests/EventFilterTests.swift
@@ -39,7 +39,9 @@ struct EventFilterTests {
             milkTypes: [],
             breastSides: [],
             sleepMinDurationMinutes: nil,
-            sleepMaxDurationMinutes: nil
+            sleepMaxDurationMinutes: nil,
+            occurredOnOrAfter: nil,
+            occurredOnOrBefore: nil
         )
         #expect(filter.matches(.sleep(sleep)))
     }
@@ -53,7 +55,9 @@ struct EventFilterTests {
             milkTypes: [],
             breastSides: [],
             sleepMinDurationMinutes: nil,
-            sleepMaxDurationMinutes: nil
+            sleepMaxDurationMinutes: nil,
+            occurredOnOrAfter: nil,
+            occurredOnOrBefore: nil
         )
         #expect(!filter.matches(.bottleFeed(bottle)))
     }
@@ -70,7 +74,9 @@ struct EventFilterTests {
             milkTypes: [],
             breastSides: [],
             sleepMinDurationMinutes: nil,
-            sleepMaxDurationMinutes: nil
+            sleepMaxDurationMinutes: nil,
+            occurredOnOrAfter: nil,
+            occurredOnOrBefore: nil
         )
         #expect(filter.matches(.nappy(poo)))
         #expect(!filter.matches(.nappy(wee)))
@@ -89,7 +95,9 @@ struct EventFilterTests {
             milkTypes: [.formula],
             breastSides: [],
             sleepMinDurationMinutes: nil,
-            sleepMaxDurationMinutes: nil
+            sleepMaxDurationMinutes: nil,
+            occurredOnOrAfter: nil,
+            occurredOnOrBefore: nil
         )
         #expect(filter.matches(.bottleFeed(formula)))
         #expect(!filter.matches(.bottleFeed(breastMilk)))
@@ -109,7 +117,9 @@ struct EventFilterTests {
             milkTypes: [],
             breastSides: [.left],
             sleepMinDurationMinutes: nil,
-            sleepMaxDurationMinutes: nil
+            sleepMaxDurationMinutes: nil,
+            occurredOnOrAfter: nil,
+            occurredOnOrBefore: nil
         )
         #expect(filter.matches(.breastFeed(left)))
         #expect(!filter.matches(.breastFeed(right)))
@@ -128,7 +138,9 @@ struct EventFilterTests {
             milkTypes: [],
             breastSides: [],
             sleepMinDurationMinutes: 30,
-            sleepMaxDurationMinutes: nil
+            sleepMaxDurationMinutes: nil,
+            occurredOnOrAfter: nil,
+            occurredOnOrBefore: nil
         )
         #expect(!filter.matches(.sleep(shortSleep)))
         #expect(filter.matches(.sleep(longSleep)))
@@ -144,7 +156,9 @@ struct EventFilterTests {
             milkTypes: [],
             breastSides: [],
             sleepMinDurationMinutes: nil,
-            sleepMaxDurationMinutes: 60
+            sleepMaxDurationMinutes: 60,
+            occurredOnOrAfter: nil,
+            occurredOnOrBefore: nil
         )
         #expect(filter.matches(.sleep(shortSleep)))
         #expect(!filter.matches(.sleep(longSleep)))
@@ -159,8 +173,74 @@ struct EventFilterTests {
             milkTypes: [],
             breastSides: [],
             sleepMinDurationMinutes: 60,
-            sleepMaxDurationMinutes: 60
+            sleepMaxDurationMinutes: 60,
+            occurredOnOrAfter: nil,
+            occurredOnOrBefore: nil
         )
         #expect(filter.matches(.sleep(ongoingSleep)))
+    }
+
+    // MARK: - Date range filter
+
+    @Test
+    func occurredOnOrAfterExcludesEarlierEvents() throws {
+        let earlyMetadata = EventMetadata(
+            childID: childID,
+            occurredAt: now.addingTimeInterval(-3_600),
+            createdBy: userID
+        )
+        let lateMetadata = EventMetadata(
+            childID: childID,
+            occurredAt: now.addingTimeInterval(3_600),
+            createdBy: userID
+        )
+
+        let earlyEvent = try BottleFeedEvent(metadata: earlyMetadata, amountMilliliters: 120)
+        let lateEvent = try BottleFeedEvent(metadata: lateMetadata, amountMilliliters: 120)
+
+        let filter = EventFilter(
+            eventTypes: [],
+            nappyTypes: [],
+            milkTypes: [],
+            breastSides: [],
+            sleepMinDurationMinutes: nil,
+            sleepMaxDurationMinutes: nil,
+            occurredOnOrAfter: now,
+            occurredOnOrBefore: nil
+        )
+
+        #expect(!filter.matches(.bottleFeed(earlyEvent)))
+        #expect(filter.matches(.bottleFeed(lateEvent)))
+    }
+
+    @Test
+    func occurredOnOrBeforeExcludesLaterEvents() throws {
+        let earlyMetadata = EventMetadata(
+            childID: childID,
+            occurredAt: now.addingTimeInterval(-3_600),
+            createdBy: userID
+        )
+        let lateMetadata = EventMetadata(
+            childID: childID,
+            occurredAt: now.addingTimeInterval(3_600),
+            createdBy: userID
+        )
+
+        let earlyEvent = try BottleFeedEvent(metadata: earlyMetadata, amountMilliliters: 120)
+        let lateEvent = try BottleFeedEvent(metadata: lateMetadata, amountMilliliters: 120)
+
+        let filter = EventFilter(
+            eventTypes: [],
+            nappyTypes: [],
+            milkTypes: [],
+            breastSides: [],
+            sleepMinDurationMinutes: nil,
+            sleepMaxDurationMinutes: nil,
+            occurredOnOrAfter: nil,
+            occurredOnOrBefore: now
+        )
+
+        #expect(filter.matches(.bottleFeed(earlyEvent)))
+        #expect(!filter.matches(.bottleFeed(lateEvent)))
     }
 }

--- a/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/ViewModels/EventHistoryViewModel.swift
+++ b/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/ViewModels/EventHistoryViewModel.swift
@@ -8,6 +8,7 @@ import Observation
 @Observable
 public final class EventHistoryViewModel {
     private let appModel: AppModel
+    private let calendar = Calendar.current
 
     public init(appModel: AppModel) {
         self.appModel = appModel
@@ -16,15 +17,31 @@ public final class EventHistoryViewModel {
     // MARK: - Computed state
 
     public var events: [EventCardViewState] {
+        sections.flatMap(\.events)
+    }
+
+    public var sections: [EventHistorySectionViewState] {
         guard let child = appModel.currentChild else { return [] }
         let filter = appModel.activeEventFilter
         let filtered = filter.isEmpty
             ? appModel.events
             : appModel.events.filter { filter.matches($0) }
-        return BuildEventCardsUseCase.execute(
-            events: filtered,
-            preferredFeedVolumeUnit: child.preferredFeedVolumeUnit
-        )
+
+        let grouped = Dictionary(grouping: filtered) { event in
+            calendar.startOfDay(for: event.metadata.occurredAt)
+        }
+
+        return grouped
+            .map { day, events in
+                EventHistorySectionViewState(
+                    date: day,
+                    events: BuildEventCardsUseCase.execute(
+                        events: events,
+                        preferredFeedVolumeUnit: child.preferredFeedVolumeUnit
+                    )
+                )
+            }
+            .sorted { $0.date > $1.date }
     }
 
     public var activeFilter: EventFilter {
@@ -49,5 +66,17 @@ public final class EventHistoryViewModel {
 
     public func updateFilter(_ filter: EventFilter) {
         appModel.updateEventFilter(filter)
+    }
+}
+
+public struct EventHistorySectionViewState: Identifiable, Equatable, Sendable {
+    public let date: Date
+    public let events: [EventCardViewState]
+
+    public var id: Date { date }
+
+    public init(date: Date, events: [EventCardViewState]) {
+        self.date = date
+        self.events = events
     }
 }

--- a/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/EventFilterView.swift
+++ b/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/EventFilterView.swift
@@ -22,6 +22,7 @@ public struct EventFilterView: View {
             ScrollView {
                 VStack(spacing: 12) {
                     eventTypeSection
+                    dateSection
                     if shouldShowNappySection { nappyTypeSection }
                     if shouldShowMilkSection { milkTypeSection }
                     if shouldShowBreastSection { breastSideSection }
@@ -41,7 +42,7 @@ public struct EventFilterView: View {
                 }
                 ToolbarItem(placement: .topBarTrailing) {
                     Button("Apply") {
-                        onApply(draft)
+                        onApply(normalizedDateRangeFilter(from: draft))
                         dismiss()
                     }
                     .fontWeight(.semibold)
@@ -75,6 +76,32 @@ public struct EventFilterView: View {
                         color: BabyEventStyle.accentColor(for: .nappy)
                     ) { toggleMembership(type, in: \.nappyTypes) }
                 }
+            }
+        }
+    }
+
+    private var dateSection: some View {
+        filterCard("Date") {
+            VStack(spacing: 12) {
+                optionalDateRow(
+                    title: "From",
+                    keyPath: \.occurredOnOrAfter,
+                    date: draft.occurredOnOrAfter,
+                    normalizeDate: { Calendar.current.startOfDay(for: $0) },
+                    setDateToNow: { draft.occurredOnOrAfter = Calendar.current.startOfDay(for: Date()) },
+                    clearDate: { draft.occurredOnOrAfter = nil }
+                )
+
+                Divider()
+
+                optionalDateRow(
+                    title: "To",
+                    keyPath: \.occurredOnOrBefore,
+                    date: draft.occurredOnOrBefore,
+                    normalizeDate: { endOfDay(for: $0) },
+                    setDateToNow: { draft.occurredOnOrBefore = endOfDay(for: Date()) },
+                    clearDate: { draft.occurredOnOrBefore = nil }
+                )
             }
         }
     }
@@ -234,6 +261,49 @@ public struct EventFilterView: View {
     }
 
     @ViewBuilder
+    private func optionalDateRow(
+        title: String,
+        keyPath: WritableKeyPath<EventFilter, Date?>,
+        date: Date?,
+        normalizeDate: @escaping (Date) -> Date,
+        setDateToNow: @escaping () -> Void,
+        clearDate: @escaping () -> Void
+    ) -> some View {
+        VStack(alignment: .leading, spacing: 8) {
+            HStack {
+                Text(title)
+                    .font(.subheadline)
+                Spacer()
+
+                if let date {
+                    Button("Clear", role: .destructive, action: clearDate)
+                        .font(.caption.weight(.semibold))
+                        .buttonStyle(.borderless)
+                } else {
+                    Button("Set", action: setDateToNow)
+                        .font(.caption.weight(.semibold))
+                        .buttonStyle(.bordered)
+                        .controlSize(.small)
+                }
+            }
+
+            if let date {
+                DatePicker(
+                    title,
+                    selection: binding(for: keyPath, fallback: date, normalizeDate: normalizeDate),
+                    displayedComponents: .date
+                )
+                .labelsHidden()
+                .datePickerStyle(.graphical)
+            } else {
+                Text("Any date")
+                    .font(.subheadline)
+                    .foregroundStyle(.secondary)
+            }
+        }
+    }
+
+    @ViewBuilder
     private func filterCard<Content: View>(_ title: String, @ViewBuilder content: () -> Content) -> some View {
         VStack(alignment: .leading, spacing: 12) {
             Text(title)
@@ -280,6 +350,33 @@ public struct EventFilterView: View {
         }
         draft = updated
     }
+
+    private func binding(
+        for keyPath: WritableKeyPath<EventFilter, Date?>,
+        fallback: Date,
+        normalizeDate: @escaping (Date) -> Date
+    ) -> Binding<Date> {
+        Binding<Date>(
+            get: { draft[keyPath: keyPath] ?? fallback },
+            set: { draft[keyPath: keyPath] = normalizeDate($0) }
+        )
+    }
+
+    private func endOfDay(for date: Date) -> Date {
+        let start = Calendar.current.startOfDay(for: date)
+        return Calendar.current.date(byAdding: DateComponents(day: 1, second: -1), to: start) ?? start
+    }
+
+    private func normalizedDateRangeFilter(from filter: EventFilter) -> EventFilter {
+        guard let from = filter.occurredOnOrAfter, let to = filter.occurredOnOrBefore, from > to else {
+            return filter
+        }
+
+        var normalized = filter
+        normalized.occurredOnOrAfter = to
+        normalized.occurredOnOrBefore = from
+        return normalized
+    }
 }
 
 // MARK: - Display names
@@ -314,4 +411,8 @@ extension BreastSide {
         case .both: "Both"
         }
     }
+}
+
+#Preview {
+    EventFilterView(currentFilter: .empty) { _ in }
 }

--- a/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/EventHistoryView.swift
+++ b/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/EventHistoryView.swift
@@ -38,17 +38,23 @@ public struct EventHistoryView: View {
             }
 
             List {
-                if viewModel.events.isEmpty {
+                if viewModel.sections.isEmpty {
                     emptyState
                         .listRowInsets(EdgeInsets(top: 16, leading: 16, bottom: 16, trailing: 16))
                         .listRowSeparator(.hidden)
                         .listRowBackground(Color.clear)
                 } else {
-                    ForEach(viewModel.events) { event in
-                        eventRow(for: event)
-                            .listRowInsets(EdgeInsets(top: 8, leading: 16, bottom: 8, trailing: 16))
-                            .listRowSeparator(.hidden)
-                            .listRowBackground(Color.clear)
+                    ForEach(viewModel.sections) { section in
+                        Section {
+                            ForEach(section.events) { event in
+                                eventRow(for: event)
+                                    .listRowInsets(EdgeInsets(top: 8, leading: 16, bottom: 8, trailing: 16))
+                                    .listRowSeparator(.hidden)
+                                    .listRowBackground(Color.clear)
+                            }
+                        } header: {
+                            sectionHeader(for: section.date)
+                        }
                     }
                 }
             }
@@ -123,6 +129,14 @@ public struct EventHistoryView: View {
                         deleteEvent(event)
                     }
                 }
+                .contextMenu {
+                    Button(primaryActionTitle(for: event)) {
+                        openEvent(event)
+                    }
+                    Button("Delete", role: .destructive) {
+                        deleteEvent(event)
+                    }
+                }
 
                 if isPendingDelete, let pendingDeleteEvent {
                     AnchoredDeletePromptView(
@@ -165,6 +179,13 @@ public struct EventHistoryView: View {
             "Edit"
         }
     }
+
+    private func sectionHeader(for date: Date) -> some View {
+        Text(date.formatted(date: .abbreviated, time: .omitted))
+            .font(.subheadline.weight(.semibold))
+            .foregroundStyle(.secondary)
+            .textCase(.none)
+    }
 }
 
 // MARK: - Active filter pills
@@ -177,6 +198,8 @@ struct ActiveFilterPill: Identifiable {
         case breastSide(BreastSide)
         case sleepMin
         case sleepMax
+        case occurredOnOrAfter
+        case occurredOnOrBefore
     }
 
     let id: String
@@ -193,6 +216,8 @@ struct ActiveFilterPill: Identifiable {
         case .breastSide(let side): updated.breastSides.remove(side)
         case .sleepMin: updated.sleepMinDurationMinutes = nil
         case .sleepMax: updated.sleepMaxDurationMinutes = nil
+        case .occurredOnOrAfter: updated.occurredOnOrAfter = nil
+        case .occurredOnOrBefore: updated.occurredOnOrBefore = nil
         }
         return updated
     }
@@ -255,6 +280,24 @@ struct ActiveFilterPill: Identifiable {
             ))
         }
 
+        if let date = filter.occurredOnOrAfter {
+            pills.append(ActiveFilterPill(
+                id: "occurredOnOrAfter",
+                label: "From \(date.formatted(date: .abbreviated, time: .omitted))",
+                color: .indigo,
+                criterion: .occurredOnOrAfter
+            ))
+        }
+
+        if let date = filter.occurredOnOrBefore {
+            pills.append(ActiveFilterPill(
+                id: "occurredOnOrBefore",
+                label: "To \(date.formatted(date: .abbreviated, time: .omitted))",
+                color: .indigo,
+                criterion: .occurredOnOrBefore
+            ))
+        }
+
         return pills
     }
 }
@@ -291,4 +334,20 @@ private extension BreastSide {
         case .both: "Both sides"
         }
     }
+}
+
+#Preview {
+    let model = ChildProfilePreviewFactory.makeModel()
+    let viewModel = EventHistoryViewModel(appModel: model)
+
+    return EventHistoryView(
+        viewModel: viewModel,
+        canManageEvents: true,
+        openEvent: { _ in },
+        deleteEvent: { _ in },
+        pendingDeleteEvent: nil,
+        confirmDelete: {},
+        cancelDelete: {},
+        onRefresh: { await Task.yield() }
+    )
 }

--- a/docs/plans/042-events-history-date-filter-grouping-context-menu.md
+++ b/docs/plans/042-events-history-date-filter-grouping-context-menu.md
@@ -1,0 +1,22 @@
+# 042 Events History Date Filter, Date Headers, and Long-Press Actions
+
+## Goal
+Add three usability improvements to the Events tab:
+1. Add a date range filter to the existing event filter sheet.
+2. Group events by day with native section headers in the list.
+3. Add long-press actions for editable events (Edit/Delete).
+
+## Approach
+1. Extend `EventFilter` in the Domain package with optional date range boundaries and include those boundaries in `isEmpty` and `matches(_:)`.
+2. Add domain tests for date range filtering behavior.
+3. Update `EventFilterView` to include a date range section with optional start/end dates and clear actions.
+4. Update active filter pill rendering so date filters appear in the pills row and can be removed individually.
+5. Add event-section view state in `EventHistoryViewModel` by grouping filtered events by day.
+6. Update `EventHistoryView` to render `Section` blocks with sticky date headers and to include long-press context menu actions for Edit/Delete.
+7. Add or update SwiftUI previews for touched SwiftUI files.
+8. Build and run relevant tests before commit.
+
+## Notes
+- No GitHub issue was created in this environment; implementation is tracked via this plan document.
+
+- [x] Complete


### PR DESCRIPTION
### Motivation
- Provide a date-range filter for the Events history so users can narrow events to a specific time window.
- Improve readability of the events list by grouping events by day using native list section headers.
- Expose quick actions (edit/end and delete) via long-press/context menu on event rows for faster management.

### Description
- Extended `EventFilter` with optional `occurredOnOrAfter` and `occurredOnOrBefore` fields and applied them in `isEmpty` and `matches(_:)` so date-range filtering works alongside existing criteria (file: `Packages/BabyTrackerDomain/Sources/BabyTrackerDomain/EventFilter.swift`).
- Added domain tests covering the new date-range behavior (file: `Packages/BabyTrackerDomain/Tests/BabyTrackerDomainTests/EventFilterTests.swift`).
- Added a `Date` section to the filter sheet with optional From/To controls, graphical `DatePicker`s, normalization (start/end-of-day) and safe apply behavior (file: `Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/EventFilterView.swift`).
- Grouped events by day in the history by introducing `sections` in `EventHistoryViewModel` and rendering `Section` headers in `EventHistoryView` with a compact date header (files: `Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/ViewModels/EventHistoryViewModel.swift` and `Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/EventHistoryView.swift`).
- Added long-press/context-menu actions on event rows to surface the primary action (Edit/End) and a destructive Delete action, and added date-based pills to the active filter pill bar so date filters are visible and removable.
- Added/updated SwiftUI previews for the touched views and created a plan document tracking the change (`docs/plans/042-events-history-date-filter-grouping-context-menu.md`).

### Testing
- Ran unit tests for the domain package with `swift test --package-path Packages/BabyTrackerDomain`, and all tests passed successfully.
- Attempted to run `xcodebuild -list -project "Baby Tracker.xcodeproj"` for the app-level validation but `xcodebuild` is not available in this environment, so UI/integration verification should be run locally in Xcode.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d1310c874c832fa21cbe1f93f3f886)