### PR TITLE
Redesign Summary tab with Today/Trends two-tab layout

### DIFF
--- a/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/TodaySummaryCalculator.swift
+++ b/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/TodaySummaryCalculator.swift
@@ -1,0 +1,177 @@
+import BabyTrackerDomain
+import Foundation
+
+public enum TodaySummaryCalculator {
+    public static func makeData(
+        from allEvents: [BabyEvent],
+        now: Date = .now,
+        calendar: Calendar = .autoupdatingCurrent
+    ) -> TodaySummaryData {
+        let todayEvents = allEvents.filter {
+            calendar.isDate($0.metadata.occurredAt, inSameDayAs: now)
+        }
+
+        // Bottle feeds
+        let bottleFeeds = todayEvents.compactMap { event -> BottleFeedEvent? in
+            guard case let .bottleFeed(feed) = event else { return nil }
+            return feed
+        }
+        let bottleTotalMilliliters = bottleFeeds.reduce(0) { $0 + $1.amountMilliliters }
+
+        // Breast feeds
+        let breastFeeds = todayEvents.compactMap { event -> BreastFeedEvent? in
+            guard case let .breastFeed(feed) = event else { return nil }
+            return feed
+        }
+        let breastFeedTotalMinutes = breastFeeds.reduce(0) { total, feed in
+            total + max(1, Int(feed.endedAt.timeIntervalSince(feed.startedAt) / 60))
+        }
+
+        // Average feed interval (all feeds combined, by occurredAt time)
+        let allFeedEvents = todayEvents.filter {
+            switch $0 {
+            case .breastFeed, .bottleFeed: true
+            case .sleep, .nappy: false
+            }
+        }
+        let averageFeedInterval = averageFeedIntervalMinutes(for: allFeedEvents)
+
+        // Time since last feed
+        let lastFeedDate = allFeedEvents.map(\.metadata.occurredAt).max()
+        let minutesSinceLastFeed = lastFeedDate.map {
+            max(0, Int(now.timeIntervalSince($0) / 60))
+        }
+
+        // Sleep
+        let completedSleeps = todayEvents.compactMap { event -> SleepEvent? in
+            guard case let .sleep(sleep) = event, sleep.endedAt != nil else { return nil }
+            return sleep
+        }
+        let sleepDurations = completedSleeps.compactMap { sleepDurationMinutes(for: $0) }
+        let totalSleepMinutes = sleepDurations.reduce(0, +)
+        let longestSleepBlock = sleepDurations.max()
+
+        var daytimeSleepMinutes = 0
+        var nighttimeSleepMinutes = 0
+        for sleep in completedSleeps {
+            let (daytime, nighttime) = splitSleepDuration(sleep, calendar: calendar)
+            daytimeSleepMinutes += daytime
+            nighttimeSleepMinutes += nighttime
+        }
+
+        // Nappies
+        let nappies = todayEvents.compactMap { event -> NappyEvent? in
+            guard case let .nappy(nappy) = event else { return nil }
+            return nappy
+        }
+        let wetCount = nappies.filter { $0.type == .wee }.count
+        let dirtyCount = nappies.filter { $0.type == .poo }.count
+        let mixedCount = nappies.filter { $0.type == .mixed }.count
+
+        // Logging streak (uses all events, not just today)
+        let streak = loggingStreakDays(from: allEvents, now: now, calendar: calendar)
+
+        return TodaySummaryData(
+            bottleTotalMilliliters: bottleTotalMilliliters,
+            bottleCount: bottleFeeds.count,
+            breastFeedTotalMinutes: breastFeedTotalMinutes,
+            breastFeedCount: breastFeeds.count,
+            averageFeedIntervalMinutes: averageFeedInterval,
+            minutesSinceLastFeed: minutesSinceLastFeed,
+            totalSleepMinutes: totalSleepMinutes,
+            daytimeSleepMinutes: daytimeSleepMinutes,
+            nighttimeSleepMinutes: nighttimeSleepMinutes,
+            longestSleepBlockMinutes: longestSleepBlock,
+            totalNappies: nappies.count,
+            wetNappyCount: wetCount,
+            dirtyNappyCount: dirtyCount,
+            mixedNappyCount: mixedCount,
+            wetInclusiveCount: wetCount + mixedCount,
+            dirtyInclusiveCount: dirtyCount + mixedCount,
+            loggingStreakDays: streak
+        )
+    }
+
+    // MARK: - Private helpers
+
+    private static func sleepDurationMinutes(for event: SleepEvent) -> Int? {
+        guard let endedAt = event.endedAt else { return nil }
+        return max(1, Int(endedAt.timeIntervalSince(event.startedAt) / 60))
+    }
+
+    /// Splits a completed sleep block into daytime (6am–10pm) and nighttime (10pm–6am) minutes.
+    private static func splitSleepDuration(
+        _ sleep: SleepEvent,
+        calendar: Calendar
+    ) -> (daytime: Int, nighttime: Int) {
+        guard let endedAt = sleep.endedAt else { return (0, 0) }
+
+        let totalMinutes = max(0, Int(endedAt.timeIntervalSince(sleep.startedAt) / 60))
+        guard totalMinutes > 0 else { return (0, 0) }
+
+        // Build the 10pm and 6am boundaries for the day the sleep started.
+        let startDay = calendar.startOfDay(for: sleep.startedAt)
+        guard
+            let tenPm = calendar.date(bySettingHour: 22, minute: 0, second: 0, of: startDay),
+            let sixAm = calendar.date(bySettingHour: 6, minute: 0, second: 0, of: startDay),
+            let nextSixAm = calendar.date(byAdding: .day, value: 1, to: sixAm)
+        else {
+            return (totalMinutes, 0)
+        }
+
+        // Collect nighttime intervals: [midnight–6am] and [10pm–midnight]
+        var nighttimeMinutes = 0
+
+        let intervals: [(Date, Date)] = [
+            (startDay, sixAm),       // midnight–6am
+            (tenPm, nextSixAm)       // 10pm–next 6am
+        ]
+
+        for (nightStart, nightEnd) in intervals {
+            let overlapStart = max(sleep.startedAt, nightStart)
+            let overlapEnd = min(endedAt, nightEnd)
+            if overlapEnd > overlapStart {
+                nighttimeMinutes += Int(overlapEnd.timeIntervalSince(overlapStart) / 60)
+            }
+        }
+
+        let daytimeMinutes = max(0, totalMinutes - nighttimeMinutes)
+        return (daytimeMinutes, nighttimeMinutes)
+    }
+
+    private static func averageFeedIntervalMinutes(for feedEvents: [BabyEvent]) -> Int? {
+        let sortedTimes = feedEvents.map(\.metadata.occurredAt).sorted()
+        guard sortedTimes.count > 1 else { return nil }
+
+        var intervals: [Int] = []
+        for index in 1..<sortedTimes.count {
+            let interval = sortedTimes[index].timeIntervalSince(sortedTimes[index - 1])
+            intervals.append(max(1, Int(interval / 60)))
+        }
+
+        guard !intervals.isEmpty else { return nil }
+        return Int((Double(intervals.reduce(0, +)) / Double(intervals.count)).rounded())
+    }
+
+    private static func loggingStreakDays(
+        from events: [BabyEvent],
+        now: Date,
+        calendar: Calendar
+    ) -> Int {
+        let daySet = Set(events.map { calendar.startOfDay(for: $0.metadata.occurredAt) })
+        guard !daySet.isEmpty else { return 0 }
+
+        var streak = 0
+        var currentDay = calendar.startOfDay(for: now)
+
+        while daySet.contains(currentDay) {
+            streak += 1
+            guard let previousDay = calendar.date(byAdding: .day, value: -1, to: currentDay) else {
+                break
+            }
+            currentDay = previousDay
+        }
+
+        return streak
+    }
+}

--- a/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/TodaySummaryData.swift
+++ b/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/TodaySummaryData.swift
@@ -1,0 +1,70 @@
+import Foundation
+
+public struct TodaySummaryData: Equatable, Sendable {
+    // Bottle feeds
+    public let bottleTotalMilliliters: Int
+    public let bottleCount: Int
+
+    // Breast feeds
+    public let breastFeedTotalMinutes: Int
+    public let breastFeedCount: Int
+    public let averageFeedIntervalMinutes: Int?
+
+    // Combined
+    public let minutesSinceLastFeed: Int?
+
+    // Sleep
+    public let totalSleepMinutes: Int
+    public let daytimeSleepMinutes: Int
+    public let nighttimeSleepMinutes: Int
+    public let longestSleepBlockMinutes: Int?
+
+    // Nappies
+    public let totalNappies: Int
+    public let wetNappyCount: Int       // wee only
+    public let dirtyNappyCount: Int     // poo only
+    public let mixedNappyCount: Int
+    public let wetInclusiveCount: Int   // wee + mixed
+    public let dirtyInclusiveCount: Int // poo + mixed
+
+    // Streak (across all events)
+    public let loggingStreakDays: Int
+
+    public init(
+        bottleTotalMilliliters: Int,
+        bottleCount: Int,
+        breastFeedTotalMinutes: Int,
+        breastFeedCount: Int,
+        averageFeedIntervalMinutes: Int?,
+        minutesSinceLastFeed: Int?,
+        totalSleepMinutes: Int,
+        daytimeSleepMinutes: Int,
+        nighttimeSleepMinutes: Int,
+        longestSleepBlockMinutes: Int?,
+        totalNappies: Int,
+        wetNappyCount: Int,
+        dirtyNappyCount: Int,
+        mixedNappyCount: Int,
+        wetInclusiveCount: Int,
+        dirtyInclusiveCount: Int,
+        loggingStreakDays: Int
+    ) {
+        self.bottleTotalMilliliters = bottleTotalMilliliters
+        self.bottleCount = bottleCount
+        self.breastFeedTotalMinutes = breastFeedTotalMinutes
+        self.breastFeedCount = breastFeedCount
+        self.averageFeedIntervalMinutes = averageFeedIntervalMinutes
+        self.minutesSinceLastFeed = minutesSinceLastFeed
+        self.totalSleepMinutes = totalSleepMinutes
+        self.daytimeSleepMinutes = daytimeSleepMinutes
+        self.nighttimeSleepMinutes = nighttimeSleepMinutes
+        self.longestSleepBlockMinutes = longestSleepBlockMinutes
+        self.totalNappies = totalNappies
+        self.wetNappyCount = wetNappyCount
+        self.dirtyNappyCount = dirtyNappyCount
+        self.mixedNappyCount = mixedNappyCount
+        self.wetInclusiveCount = wetInclusiveCount
+        self.dirtyInclusiveCount = dirtyInclusiveCount
+        self.loggingStreakDays = loggingStreakDays
+    }
+}

--- a/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/TrendsSummaryCalculator.swift
+++ b/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/TrendsSummaryCalculator.swift
@@ -1,0 +1,190 @@
+import BabyTrackerDomain
+import Foundation
+
+public enum TrendsSummaryCalculator {
+    public static func makeData(
+        from events: [BabyEvent],
+        range: TrendsTimeRange,
+        now: Date = .now,
+        calendar: Calendar = .autoupdatingCurrent
+    ) -> TrendsSummaryData {
+        let sortedEvents = events.sorted { $0.metadata.occurredAt < $1.metadata.occurredAt }
+        let rangeEvents = filter(events: sortedEvents, range: range, now: now, calendar: calendar)
+        let dates = makeDates(range: range, events: rangeEvents, now: now, calendar: calendar)
+
+        // Group events by day
+        let eventsByDay = Dictionary(
+            grouping: rangeEvents,
+            by: { calendar.startOfDay(for: $0.metadata.occurredAt) }
+        )
+
+        let formatter = makeDayFormatter(calendar: calendar, totalDays: dates.count)
+
+        let dailyBottle = dates.map { date -> DailyBottleData in
+            let dayEvents = eventsByDay[date] ?? []
+            let bottles = dayEvents.compactMap { event -> BottleFeedEvent? in
+                guard case let .bottleFeed(feed) = event else { return nil }
+                return feed
+            }
+            return DailyBottleData(
+                date: date,
+                label: formatter(date),
+                totalMilliliters: bottles.reduce(0) { $0 + $1.amountMilliliters },
+                count: bottles.count
+            )
+        }
+
+        let dailyBreastFeed = dates.map { date -> DailyBreastFeedData in
+            let dayEvents = eventsByDay[date] ?? []
+            let feeds = dayEvents.compactMap { event -> BreastFeedEvent? in
+                guard case let .breastFeed(feed) = event else { return nil }
+                return feed
+            }
+            let totalMinutes = feeds.reduce(0) { total, feed in
+                total + max(1, Int(feed.endedAt.timeIntervalSince(feed.startedAt) / 60))
+            }
+            return DailyBreastFeedData(
+                date: date,
+                label: formatter(date),
+                sessionCount: feeds.count,
+                totalMinutes: totalMinutes
+            )
+        }
+
+        let dailySleep = dates.map { date -> DailySleepData in
+            let dayEvents = eventsByDay[date] ?? []
+            let sleepMinutes = dayEvents.compactMap { event -> Int? in
+                guard case let .sleep(sleep) = event, let endedAt = sleep.endedAt else { return nil }
+                return max(1, Int(endedAt.timeIntervalSince(sleep.startedAt) / 60))
+            }.reduce(0, +)
+            return DailySleepData(
+                date: date,
+                label: formatter(date),
+                totalMinutes: sleepMinutes
+            )
+        }
+
+        let dailyNappy = dates.map { date -> DailyNappyData in
+            let dayEvents = eventsByDay[date] ?? []
+            let nappies = dayEvents.compactMap { event -> NappyEvent? in
+                guard case let .nappy(nappy) = event else { return nil }
+                return nappy
+            }
+            return DailyNappyData(
+                date: date,
+                label: formatter(date),
+                wetCount: nappies.filter { $0.type == .wee }.count,
+                dirtyCount: nappies.filter { $0.type == .poo }.count,
+                mixedCount: nappies.filter { $0.type == .mixed }.count,
+                dryCount: nappies.filter { $0.type == .dry }.count
+            )
+        }
+
+        return TrendsSummaryData(
+            dailyBottle: dailyBottle,
+            dailyBreastFeed: dailyBreastFeed,
+            dailySleep: dailySleep,
+            dailyNappy: dailyNappy,
+            avgDailyBottleMilliliters: average(of: dailyBottle.filter { $0.count > 0 }.map(\.totalMilliliters)),
+            avgDailyBreastFeedSessions: average(of: dailyBreastFeed.filter { $0.sessionCount > 0 }.map(\.sessionCount)),
+            avgDailySleepMinutes: average(of: dailySleep.filter { $0.totalMinutes > 0 }.map(\.totalMinutes)),
+            avgDailyNappies: average(of: dailyNappy.filter { $0.totalCount > 0 }.map(\.totalCount))
+        )
+    }
+
+    // MARK: - Private helpers
+
+    private static func filter(
+        events: [BabyEvent],
+        range: TrendsTimeRange,
+        now: Date,
+        calendar: Calendar
+    ) -> [BabyEvent] {
+        switch range {
+        case .allTime:
+            return events
+        case .sevenDays:
+            return events.filter { isWithinDays($0.metadata.occurredAt, days: 7, now: now, calendar: calendar) }
+        case .thirtyDays:
+            return events.filter { isWithinDays($0.metadata.occurredAt, days: 30, now: now, calendar: calendar) }
+        }
+    }
+
+    private static func isWithinDays(_ date: Date, days: Int, now: Date, calendar: Calendar) -> Bool {
+        guard let start = calendar.date(byAdding: .day, value: -(days - 1), to: calendar.startOfDay(for: now)) else {
+            return false
+        }
+        return date >= start && date <= now
+    }
+
+    private static func makeDates(
+        range: TrendsTimeRange,
+        events: [BabyEvent],
+        now: Date,
+        calendar: Calendar
+    ) -> [Date] {
+        switch range {
+        case .sevenDays:
+            return trailingDates(dayCount: 7, now: now, calendar: calendar)
+        case .thirtyDays:
+            return trailingDates(dayCount: 30, now: now, calendar: calendar)
+        case .allTime:
+            let days = Set(events.map { calendar.startOfDay(for: $0.metadata.occurredAt) }).sorted()
+            guard let first = days.first else { return [] }
+            return strideDates(from: first, through: calendar.startOfDay(for: now), calendar: calendar)
+        }
+    }
+
+    private static func trailingDates(dayCount: Int, now: Date, calendar: Calendar) -> [Date] {
+        let end = calendar.startOfDay(for: now)
+        guard let start = calendar.date(byAdding: .day, value: -(dayCount - 1), to: end) else {
+            return []
+        }
+        return strideDates(from: start, through: end, calendar: calendar)
+    }
+
+    private static func strideDates(from start: Date, through end: Date, calendar: Calendar) -> [Date] {
+        var dates: [Date] = []
+        var current = calendar.startOfDay(for: start)
+        let finalDate = calendar.startOfDay(for: end)
+
+        while current <= finalDate {
+            dates.append(current)
+            guard let next = calendar.date(byAdding: .day, value: 1, to: current) else { break }
+            current = next
+        }
+
+        return dates
+    }
+
+    /// Returns a label formatter appropriate for the number of days being shown.
+    /// Fewer days → day-of-week labels; more days → short date labels.
+    private static func makeDayFormatter(
+        calendar: Calendar,
+        totalDays: Int
+    ) -> (Date) -> String {
+        if totalDays <= 14 {
+            // Narrow weekday: M, T, W …
+            return { date in date.formatted(.dateTime.weekday(.narrow)) }
+        } else if totalDays <= 60 {
+            // Short date: Jan 5
+            let fmt = DateFormatter()
+            fmt.calendar = calendar
+            fmt.locale = .autoupdatingCurrent
+            fmt.setLocalizedDateFormatFromTemplate("MMMd")
+            return { date in fmt.string(from: date) }
+        } else {
+            // Month/year: Jan, Feb …
+            let fmt = DateFormatter()
+            fmt.calendar = calendar
+            fmt.locale = .autoupdatingCurrent
+            fmt.setLocalizedDateFormatFromTemplate("MMM")
+            return { date in fmt.string(from: date) }
+        }
+    }
+
+    private static func average(of values: [Int]) -> Int? {
+        guard !values.isEmpty else { return nil }
+        return Int((Double(values.reduce(0, +)) / Double(values.count)).rounded())
+    }
+}

--- a/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/TrendsSummaryData.swift
+++ b/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/TrendsSummaryData.swift
@@ -1,0 +1,99 @@
+import Foundation
+
+public enum TrendsTimeRange: String, CaseIterable, Identifiable, Sendable {
+    case sevenDays = "7 Days"
+    case thirtyDays = "30 Days"
+    case allTime = "All Time"
+
+    public var id: String { rawValue }
+}
+
+public struct DailyBottleData: Equatable, Sendable {
+    public let date: Date
+    public let label: String
+    public let totalMilliliters: Int
+    public let count: Int
+
+    public init(date: Date, label: String, totalMilliliters: Int, count: Int) {
+        self.date = date
+        self.label = label
+        self.totalMilliliters = totalMilliliters
+        self.count = count
+    }
+}
+
+public struct DailyBreastFeedData: Equatable, Sendable {
+    public let date: Date
+    public let label: String
+    public let sessionCount: Int
+    public let totalMinutes: Int
+
+    public init(date: Date, label: String, sessionCount: Int, totalMinutes: Int) {
+        self.date = date
+        self.label = label
+        self.sessionCount = sessionCount
+        self.totalMinutes = totalMinutes
+    }
+}
+
+public struct DailySleepData: Equatable, Sendable {
+    public let date: Date
+    public let label: String
+    public let totalMinutes: Int
+
+    public init(date: Date, label: String, totalMinutes: Int) {
+        self.date = date
+        self.label = label
+        self.totalMinutes = totalMinutes
+    }
+}
+
+public struct DailyNappyData: Equatable, Sendable {
+    public let date: Date
+    public let label: String
+    public let wetCount: Int   // wee only
+    public let dirtyCount: Int // poo only
+    public let mixedCount: Int
+    public let dryCount: Int
+    public var totalCount: Int { wetCount + dirtyCount + mixedCount + dryCount }
+
+    public init(date: Date, label: String, wetCount: Int, dirtyCount: Int, mixedCount: Int, dryCount: Int) {
+        self.date = date
+        self.label = label
+        self.wetCount = wetCount
+        self.dirtyCount = dirtyCount
+        self.mixedCount = mixedCount
+        self.dryCount = dryCount
+    }
+}
+
+public struct TrendsSummaryData: Equatable, Sendable {
+    public let dailyBottle: [DailyBottleData]
+    public let dailyBreastFeed: [DailyBreastFeedData]
+    public let dailySleep: [DailySleepData]
+    public let dailyNappy: [DailyNappyData]
+    public let avgDailyBottleMilliliters: Int?
+    public let avgDailyBreastFeedSessions: Int?
+    public let avgDailySleepMinutes: Int?
+    public let avgDailyNappies: Int?
+
+    public init(
+        dailyBottle: [DailyBottleData],
+        dailyBreastFeed: [DailyBreastFeedData],
+        dailySleep: [DailySleepData],
+        dailyNappy: [DailyNappyData],
+        avgDailyBottleMilliliters: Int?,
+        avgDailyBreastFeedSessions: Int?,
+        avgDailySleepMinutes: Int?,
+        avgDailyNappies: Int?
+    ) {
+        self.dailyBottle = dailyBottle
+        self.dailyBreastFeed = dailyBreastFeed
+        self.dailySleep = dailySleep
+        self.dailyNappy = dailyNappy
+        self.avgDailyBottleMilliliters = avgDailyBottleMilliliters
+        self.avgDailyBreastFeedSessions = avgDailyBreastFeedSessions
+        self.avgDailySleepMinutes = avgDailySleepMinutes
+        self.avgDailyNappies = avgDailyNappies
+    }
+}

--- a/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/SummaryScreenView.swift
+++ b/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/SummaryScreenView.swift
@@ -1,30 +1,30 @@
 import SwiftUI
 
+private enum SummaryTab: String, CaseIterable {
+    case today = "Today"
+    case trends = "Trends"
+}
+
 public struct SummaryScreenView: View {
     let viewModel: SummaryViewModel
 
-    @State private var selectedRange: SummaryTimeRange = .today
+    @State private var selectedTab: SummaryTab = .today
+    @State private var selectedTrendsRange: TrendsTimeRange = .sevenDays
 
     public init(viewModel: SummaryViewModel) {
         self.viewModel = viewModel
     }
 
     public var body: some View {
-        let snapshot = SummaryMetricsCalculator.makeSnapshot(
-            from: viewModel.events,
-            range: selectedRange
-        )
-
         ScrollView {
             VStack(alignment: .leading, spacing: 18) {
-                rangePicker
+                tabPicker
 
-                if snapshot.eventCount == 0 {
-                    emptyState
-                } else {
-                    topMetrics(snapshot: snapshot)
-                    chartSection(snapshot: snapshot)
-                    advancedSummaryLink
+                switch selectedTab {
+                case .today:
+                    todayTabContent
+                case .trends:
+                    trendsTabContent
                 }
             }
             .padding(.horizontal, 16)
@@ -33,10 +33,12 @@ public struct SummaryScreenView: View {
         .background(Color(.systemGroupedBackground).ignoresSafeArea())
     }
 
-    private var rangePicker: some View {
-        Picker("Range", selection: $selectedRange) {
-            ForEach(SummaryTimeRange.allCases) { range in
-                Text(range.title).tag(range)
+    // MARK: - Tab Picker
+
+    private var tabPicker: some View {
+        Picker("Tab", selection: $selectedTab) {
+            ForEach(SummaryTab.allCases, id: \.self) { tab in
+                Text(tab.rawValue).tag(tab)
             }
         }
         .pickerStyle(.segmented)
@@ -47,94 +49,402 @@ public struct SummaryScreenView: View {
         )
     }
 
-    private var emptyState: some View {
-        VStack(alignment: .leading, spacing: 8) {
-            Text(viewModel.emptyStateTitle)
-                .font(.headline)
+    // MARK: - Today Tab
 
-            Text(viewModel.emptyStateMessage)
+    private var todayTabContent: some View {
+        let data = TodaySummaryCalculator.makeData(from: viewModel.events)
+        let hasAnyTodayData = data.bottleCount > 0 || data.breastFeedCount > 0
+            || data.totalSleepMinutes > 0 || data.totalNappies > 0
+
+        return Group {
+            if !hasAnyTodayData && viewModel.events.isEmpty {
+                emptyStateCard(
+                    title: viewModel.emptyStateTitle,
+                    message: viewModel.emptyStateMessage
+                )
+            } else {
+                VStack(alignment: .leading, spacing: 12) {
+                    todayMetricGrid(data: data)
+                    todayExtrasRow(data: data)
+                }
+            }
+        }
+    }
+
+    private func todayMetricGrid(data: TodaySummaryData) -> some View {
+        LazyVGrid(
+            columns: [
+                GridItem(.flexible(), spacing: 12),
+                GridItem(.flexible(), spacing: 12),
+            ],
+            spacing: 12
+        ) {
+            bottleCard(data: data)
+            breastCard(data: data)
+            sleepCard(data: data)
+            nappyCard(data: data)
+        }
+    }
+
+    private func bottleCard(data: TodaySummaryData) -> some View {
+        let volumeText = data.bottleCount == 0
+            ? "0 mL"
+            : "\(data.bottleTotalMilliliters) mL"
+
+        let subtitle: String
+        if data.bottleCount == 0 {
+            subtitle = "No bottle feeds today"
+        } else if let mins = data.minutesSinceLastFeed {
+            subtitle = "\(data.bottleCount) feed\(data.bottleCount == 1 ? "" : "s") • last \(formatInterval(mins)) ago"
+        } else {
+            subtitle = "\(data.bottleCount) feed\(data.bottleCount == 1 ? "" : "s")"
+        }
+
+        return metricCard(
+            title: "Bottle",
+            value: volumeText,
+            subtitle: subtitle,
+            symbol: "bottle.fill",
+            tint: .blue
+        )
+    }
+
+    private func breastCard(data: TodaySummaryData) -> some View {
+        let durationText = data.breastFeedCount == 0
+            ? "0m"
+            : formatMinutes(data.breastFeedTotalMinutes)
+
+        let subtitle: String
+        if data.breastFeedCount == 0 {
+            subtitle = "No breast feeds today"
+        } else if let interval = data.averageFeedIntervalMinutes {
+            subtitle = "\(data.breastFeedCount) feed\(data.breastFeedCount == 1 ? "" : "s") • avg \(formatInterval(interval))"
+        } else {
+            subtitle = "\(data.breastFeedCount) feed\(data.breastFeedCount == 1 ? "" : "s")"
+        }
+
+        return metricCard(
+            title: "Breast",
+            value: durationText,
+            subtitle: subtitle,
+            symbol: "heart.fill",
+            tint: .pink
+        )
+    }
+
+    private func sleepCard(data: TodaySummaryData) -> some View {
+        let totalText = data.totalSleepMinutes == 0
+            ? "0m"
+            : formatMinutes(data.totalSleepMinutes)
+
+        let subtitle: String
+        if data.totalSleepMinutes == 0 {
+            subtitle = "No sleep logged today"
+        } else {
+            var parts: [String] = []
+            if data.daytimeSleepMinutes > 0 {
+                parts.append("Day \(formatMinutes(data.daytimeSleepMinutes))")
+            }
+            if data.nighttimeSleepMinutes > 0 {
+                parts.append("Night \(formatMinutes(data.nighttimeSleepMinutes))")
+            }
+            if let longest = data.longestSleepBlockMinutes {
+                parts.append("Longest \(formatMinutes(longest))")
+            }
+            subtitle = parts.joined(separator: " • ")
+        }
+
+        return metricCard(
+            title: "Sleep",
+            value: totalText,
+            subtitle: subtitle,
+            symbol: "moon.zzz.fill",
+            tint: .indigo
+        )
+    }
+
+    private func nappyCard(data: TodaySummaryData) -> some View {
+        let subtitle: String
+        if data.totalNappies == 0 {
+            subtitle = "No nappy changes today"
+        } else {
+            var parts: [String] = []
+            parts.append("Wet: \(data.wetInclusiveCount)")
+            parts.append("Dirty: \(data.dirtyInclusiveCount)")
+            if data.mixedNappyCount > 0 {
+                parts.append("Mixed: \(data.mixedNappyCount)")
+            }
+            subtitle = parts.joined(separator: " • ")
+        }
+
+        return metricCard(
+            title: "Nappies",
+            value: "\(data.totalNappies)",
+            subtitle: subtitle,
+            symbol: "checklist.checked",
+            tint: .green
+        )
+    }
+
+    private func todayExtrasRow(data: TodaySummaryData) -> some View {
+        VStack(spacing: 0) {
+            if let mins = data.minutesSinceLastFeed {
+                extrasRow(
+                    symbol: "clock.fill",
+                    tint: .orange,
+                    label: "Last feed",
+                    value: "\(formatInterval(mins)) ago"
+                )
+                Divider().padding(.leading, 44)
+            }
+
+            if let interval = data.averageFeedIntervalMinutes {
+                extrasRow(
+                    symbol: "arrow.trianglehead.clockwise",
+                    tint: .orange,
+                    label: "Avg feed interval",
+                    value: formatInterval(interval)
+                )
+                Divider().padding(.leading, 44)
+            }
+
+            extrasRow(
+                symbol: "flame.fill",
+                tint: .orange,
+                label: "Logging streak",
+                value: "\(data.loggingStreakDays) day\(data.loggingStreakDays == 1 ? "" : "s")"
+            )
+        }
+        .background(cardBackground)
+    }
+
+    private func extrasRow(symbol: String, tint: Color, label: String, value: String) -> some View {
+        HStack(spacing: 12) {
+            Image(systemName: symbol)
+                .font(.subheadline)
+                .foregroundStyle(tint)
+                .frame(width: 24)
+
+            Text(label)
                 .font(.subheadline)
                 .foregroundStyle(.secondary)
+
+            Spacer()
+
+            Text(value)
+                .font(.subheadline.weight(.semibold))
         }
-        .padding(18)
-        .frame(maxWidth: .infinity, alignment: .leading)
-        .background(cardBackground)
-        .accessibilityIdentifier("summary-empty-state")
+        .padding(.horizontal, 16)
+        .padding(.vertical, 12)
     }
 
-    private func topMetrics(snapshot: SummarySnapshot) -> some View {
-        VStack(alignment: .leading, spacing: 12) {
-            Text("Top Metrics")
-                .font(.headline)
+    // MARK: - Trends Tab
 
-            LazyVGrid(
-                columns: [
-                    GridItem(.flexible(), spacing: 12),
-                    GridItem(.flexible(), spacing: 12),
-                ],
-                spacing: 12
-            ) {
-                metricCard(
-                    title: "Feeds",
-                    value: "\(snapshot.totalFeeds)",
-                    subtitle: subtitleForFeedAverage(snapshot),
-                    symbol: "drop.fill",
-                    tint: .blue
-                )
+    private var trendsTabContent: some View {
+        let data = TrendsSummaryCalculator.makeData(from: viewModel.events, range: selectedTrendsRange)
+        let hasData = data.dailyBottle.contains { $0.count > 0 }
+            || data.dailyBreastFeed.contains { $0.sessionCount > 0 }
+            || data.dailySleep.contains { $0.totalMinutes > 0 }
+            || data.dailyNappy.contains { $0.totalCount > 0 }
 
-                metricCard(
-                    title: "Nappy Changes",
-                    value: "\(snapshot.totalNappies)",
-                    subtitle: "Wet: \(snapshot.wetNappyCount) • Dirty: \(snapshot.dirtyNappyCount)",
-                    symbol: "checklist.checked",
-                    tint: .green
-                )
+        return VStack(alignment: .leading, spacing: 12) {
+            trendsRangePicker
 
-                metricCard(
-                    title: "Sleep",
-                    value: formatMinutes(snapshot.totalSleepMinutes),
-                    subtitle: sleepRangeSubtitle(snapshot),
-                    symbol: "moon.zzz.fill",
-                    tint: .indigo
+            if !hasData {
+                emptyStateCard(
+                    title: "No data for this period",
+                    message: "Try a broader range to see feeding, sleep, and nappy trends."
                 )
-
-                metricCard(
-                    title: "Logging Streak",
-                    value: "\(snapshot.loggingStreakDays) day\(snapshot.loggingStreakDays == 1 ? "" : "s")",
-                    subtitle: "Consecutive days with logs",
-                    symbol: "flame.fill",
-                    tint: .orange
-                )
+            } else {
+                bottleChartCard(data: data)
+                breastChartCard(data: data)
+                sleepChartCard(data: data)
+                nappyChartCard(data: data)
+                advancedSummaryLink
             }
         }
     }
 
-    private func chartSection(snapshot: SummarySnapshot) -> some View {
-        VStack(alignment: .leading, spacing: 12) {
-            Text("Trends")
-                .font(.headline)
-
-            chartCard(
-                title: "7-Day Activity",
-                subtitle: "Total events per day"
-            ) {
-                miniBarChart(
-                    points: snapshot.dailyEventCounts.map { ($0.label, $0.count) },
-                    tint: .orange
-                )
-            }
-
-            chartCard(
-                title: "Feed Time of Day",
-                subtitle: "Feeds by hour bucket"
-            ) {
-                miniBarChart(
-                    points: snapshot.feedCountsByHour.map { ($0.label, $0.count) },
-                    tint: Color.blue
-                )
+    private var trendsRangePicker: some View {
+        Picker("Range", selection: $selectedTrendsRange) {
+            ForEach(TrendsTimeRange.allCases) { range in
+                Text(range.rawValue).tag(range)
             }
         }
+        .pickerStyle(.segmented)
     }
+
+    private func bottleChartCard(data: TrendsSummaryData) -> some View {
+        let points = data.dailyBottle.map { ($0.label, $0.totalMilliliters) }
+        let avgText = data.avgDailyBottleMilliliters.map { "Avg \($0) mL/day" }
+
+        return chartCard(
+            title: "Bottle Feeds",
+            symbol: "bottle.fill",
+            tint: .blue,
+            subtitle: avgText ?? "No bottle feeds in this period"
+        ) {
+            miniBarChart(points: points, tint: .blue)
+        }
+    }
+
+    private func breastChartCard(data: TrendsSummaryData) -> some View {
+        let points = data.dailyBreastFeed.map { ($0.label, $0.sessionCount) }
+        let avgText = data.avgDailyBreastFeedSessions.map { "Avg \($0) session\($0 == 1 ? "" : "s")/day" }
+
+        return chartCard(
+            title: "Breast Feeds",
+            symbol: "heart.fill",
+            tint: .pink,
+            subtitle: avgText ?? "No breast feeds in this period"
+        ) {
+            miniBarChart(points: points, tint: .pink)
+        }
+    }
+
+    private func sleepChartCard(data: TrendsSummaryData) -> some View {
+        let points = data.dailySleep.map { ($0.label, $0.totalMinutes) }
+        let avgText = data.avgDailySleepMinutes.map { "Avg \(formatMinutes($0))/day" }
+
+        return chartCard(
+            title: "Sleep",
+            symbol: "moon.zzz.fill",
+            tint: .indigo,
+            subtitle: avgText ?? "No sleep logged in this period"
+        ) {
+            miniBarChart(points: points, tint: .indigo, valueFormatter: { formatMinutes($0) })
+        }
+    }
+
+    private func nappyChartCard(data: TrendsSummaryData) -> some View {
+        let avgText = data.avgDailyNappies.map { "Avg \($0)/day" }
+
+        return chartCard(
+            title: "Nappies",
+            symbol: "checklist.checked",
+            tint: .green,
+            subtitle: avgText ?? "No nappy changes in this period"
+        ) {
+            stackedNappyChart(data: data.dailyNappy)
+            nappyLegend
+        }
+    }
+
+    // MARK: - Chart Components
+
+    private func miniBarChart(
+        points: [(String, Int)],
+        tint: Color,
+        valueFormatter: ((Int) -> String)? = nil
+    ) -> some View {
+        let maxValue = max(1, points.map(\.1).max() ?? 0)
+
+        return HStack(alignment: .bottom, spacing: 4) {
+            ForEach(Array(points.enumerated()), id: \.offset) { _, point in
+                VStack(spacing: 4) {
+                    if point.1 > 0 {
+                        Text(valueFormatter?(point.1) ?? "\(point.1)")
+                            .font(.caption2)
+                            .foregroundStyle(.secondary)
+                            .lineLimit(1)
+                            .minimumScaleFactor(0.6)
+                    }
+
+                    RoundedRectangle(cornerRadius: 5, style: .continuous)
+                        .fill(tint.gradient)
+                        .frame(height: max(4, (CGFloat(point.1) / CGFloat(maxValue)) * 80))
+
+                    Text(point.0)
+                        .font(.caption2)
+                        .foregroundStyle(.secondary)
+                        .lineLimit(1)
+                        .minimumScaleFactor(0.5)
+                }
+                .frame(maxWidth: .infinity)
+            }
+        }
+        .frame(maxWidth: .infinity, minHeight: 110, alignment: .bottom)
+    }
+
+    private func stackedNappyChart(data: [DailyNappyData]) -> some View {
+        let maxTotal = max(1, data.map(\.totalCount).max() ?? 0)
+        let barHeight: CGFloat = 80
+
+        return HStack(alignment: .bottom, spacing: 4) {
+            ForEach(Array(data.enumerated()), id: \.offset) { _, day in
+                VStack(spacing: 4) {
+                    if day.totalCount > 0 {
+                        Text("\(day.totalCount)")
+                            .font(.caption2)
+                            .foregroundStyle(.secondary)
+                    }
+
+                    // Stacked bar: wet (bottom, blue) / dirty (middle, brown) / mixed (top, yellow)
+                    if day.totalCount == 0 {
+                        RoundedRectangle(cornerRadius: 5, style: .continuous)
+                            .fill(Color.gray.opacity(0.15))
+                            .frame(height: 4)
+                    } else {
+                        VStack(spacing: 1) {
+                            // Mixed (top)
+                            if day.mixedCount > 0 {
+                                RoundedRectangle(cornerRadius: 3, style: .continuous)
+                                    .fill(Color.yellow.opacity(0.85))
+                                    .frame(height: max(3, CGFloat(day.mixedCount) / CGFloat(maxTotal) * barHeight))
+                            }
+
+                            // Dirty (middle)
+                            if day.dirtyCount > 0 {
+                                Rectangle()
+                                    .fill(Color.brown.opacity(0.75))
+                                    .frame(height: max(3, CGFloat(day.dirtyCount) / CGFloat(maxTotal) * barHeight))
+                            }
+
+                            // Wet (bottom)
+                            if day.wetCount > 0 {
+                                RoundedRectangle(cornerRadius: 3, style: .continuous)
+                                    .fill(Color.blue.opacity(0.6))
+                                    .frame(height: max(3, CGFloat(day.wetCount) / CGFloat(maxTotal) * barHeight))
+                            }
+                        }
+                        .clipShape(RoundedRectangle(cornerRadius: 5, style: .continuous))
+                    }
+
+                    Text(day.label)
+                        .font(.caption2)
+                        .foregroundStyle(.secondary)
+                        .lineLimit(1)
+                        .minimumScaleFactor(0.5)
+                }
+                .frame(maxWidth: .infinity)
+            }
+        }
+        .frame(maxWidth: .infinity, minHeight: 110, alignment: .bottom)
+    }
+
+    private var nappyLegend: some View {
+        HStack(spacing: 12) {
+            legendItem(color: .blue.opacity(0.6), label: "Wet")
+            legendItem(color: .brown.opacity(0.75), label: "Dirty")
+            legendItem(color: .yellow.opacity(0.85), label: "Mixed")
+            Spacer()
+        }
+        .padding(.top, 4)
+    }
+
+    private func legendItem(color: Color, label: String) -> some View {
+        HStack(spacing: 4) {
+            RoundedRectangle(cornerRadius: 2, style: .continuous)
+                .fill(color)
+                .frame(width: 10, height: 10)
+
+            Text(label)
+                .font(.caption2)
+                .foregroundStyle(.secondary)
+        }
+    }
+
+    // MARK: - Shared Components
 
     private func metricCard(
         title: String,
@@ -157,18 +467,55 @@ public struct SummaryScreenView: View {
             Text(subtitle)
                 .font(.caption)
                 .foregroundStyle(.secondary)
-                .lineLimit(2)
+                .lineLimit(3)
         }
         .frame(maxWidth: .infinity, minHeight: 110, alignment: .leading)
         .padding(14)
         .background(cardBackground)
     }
 
+    private func chartCard<Content: View>(
+        title: String,
+        symbol: String,
+        tint: Color,
+        subtitle: String,
+        @ViewBuilder content: () -> Content
+    ) -> some View {
+        VStack(alignment: .leading, spacing: 10) {
+            Label(title, systemImage: symbol)
+                .font(.headline)
+                .foregroundStyle(tint)
+
+            Text(subtitle)
+                .font(.caption)
+                .foregroundStyle(.secondary)
+
+            content()
+        }
+        .padding(14)
+        .background(cardBackground)
+    }
+
+    private func emptyStateCard(title: String, message: String) -> some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text(title)
+                .font(.headline)
+
+            Text(message)
+                .font(.subheadline)
+                .foregroundStyle(.secondary)
+        }
+        .padding(18)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(cardBackground)
+        .accessibilityIdentifier("summary-empty-state")
+    }
+
     private var advancedSummaryLink: some View {
         NavigationLink {
             AdvancedSummaryView(
                 viewModel: viewModel,
-                initialSelection: .range(selectedRange)
+                initialSelection: .range(selectedTrendsRange.asSummaryTimeRange)
             )
         } label: {
             HStack(alignment: .center, spacing: 12) {
@@ -177,7 +524,7 @@ public struct SummaryScreenView: View {
                         .font(.headline)
                         .foregroundStyle(.primary)
 
-                    Text("Open feeds, sleep, nappies, and activity details for a range or a specific day.")
+                    Text("Detailed feeds, sleep, nappies, and activity for a range or specific day.")
                         .font(.subheadline)
                         .foregroundStyle(.secondary)
                 }
@@ -194,54 +541,6 @@ public struct SummaryScreenView: View {
         .buttonStyle(.plain)
     }
 
-    private func chartCard<Content: View>(
-        title: String,
-        subtitle: String,
-        @ViewBuilder content: () -> Content
-    ) -> some View {
-        VStack(alignment: .leading, spacing: 8) {
-            Text(title)
-                .font(.headline)
-
-            Text(subtitle)
-                .font(.caption)
-                .foregroundStyle(.secondary)
-
-            content()
-        }
-        .padding(14)
-        .background(cardBackground)
-    }
-
-    private func miniBarChart(points: [(String, Int)], tint: Color) -> some View {
-        let maxValue = max(1, points.map(\.1).max() ?? 0)
-
-        return HStack(alignment: .bottom, spacing: 8) {
-            ForEach(Array(points.enumerated()), id: \.offset) { _, point in
-                VStack(spacing: 6) {
-                    RoundedRectangle(cornerRadius: 6, style: .continuous)
-                        .fill(tint.gradient)
-                        .frame(height: max(6, (CGFloat(point.1) / CGFloat(maxValue)) * 84))
-                        .overlay(alignment: .top) {
-                            if point.1 > 0 {
-                                Text("\(point.1)")
-                                    .font(.caption2)
-                                    .foregroundStyle(.secondary)
-                                    .offset(y: -16)
-                            }
-                        }
-
-                    Text(point.0)
-                        .font(.caption2)
-                        .foregroundStyle(.secondary)
-                        .lineLimit(1)
-                }
-                .frame(maxWidth: .infinity)
-            }
-        }
-        .frame(maxWidth: .infinity, minHeight: 128, alignment: .bottom)
-    }
-
     private var cardBackground: some View {
         RoundedRectangle(cornerRadius: 18, style: .continuous)
             .fill(.thinMaterial)
@@ -252,34 +551,48 @@ public struct SummaryScreenView: View {
             .shadow(color: Color.black.opacity(0.05), radius: 14, y: 8)
     }
 
-    private func subtitleForFeedAverage(_ snapshot: SummarySnapshot) -> String {
-        guard let average = snapshot.averageFeedDurationMinutes else {
-            return "No breast feed duration data"
-        }
-
-        return "Average duration: \(average) min"
-    }
-
-    private func sleepRangeSubtitle(_ snapshot: SummarySnapshot) -> String {
-        guard let shortest = snapshot.shortestSleepBlockMinutes,
-              let longest = snapshot.longestSleepBlockMinutes else {
-            return "No completed sleeps"
-        }
-
-        return "Shortest: \(shortest)m • Longest: \(longest)m"
-    }
+    // MARK: - Formatters
 
     private func formatMinutes(_ minutes: Int) -> String {
         let hours = minutes / 60
-        let remainingMinutes = minutes % 60
+        let remainder = minutes % 60
 
         if hours == 0 {
-            return "\(remainingMinutes)m"
+            return "\(remainder)m"
         }
 
-        return "\(hours)h \(remainingMinutes)m"
+        return "\(hours)h \(remainder)m"
+    }
+
+    private func formatInterval(_ minutes: Int) -> String {
+        let hours = minutes / 60
+        let remainder = minutes % 60
+
+        if hours == 0 {
+            return "\(remainder)m"
+        }
+
+        if remainder == 0 {
+            return "\(hours)h"
+        }
+
+        return "\(hours)h \(remainder)m"
     }
 }
+
+// MARK: - TrendsTimeRange bridge
+
+private extension TrendsTimeRange {
+    var asSummaryTimeRange: SummaryTimeRange {
+        switch self {
+        case .sevenDays: .sevenDays
+        case .thirtyDays: .thirtyDays
+        case .allTime: .allTime
+        }
+    }
+}
+
+// MARK: - Previews
 
 #Preview("With Data") {
     NavigationStack {


### PR DESCRIPTION
Replaces the single-scroll summary with two focused sub-tabs:

Today tab — 4 metric cards (Bottle total mL, Breast total time,
Sleep with day/night split + longest stretch, Nappies with wet/dirty/mixed
breakdown) plus an extras row showing last feed time, average feed interval,
and logging streak.

Trends tab — time range picker (7 Days / 30 Days / All Time) with four
per-day bar charts: bottle volume, breast sessions, sleep duration, and a
stacked nappy chart (wet/dirty/mixed segments). Each chart shows a daily
average subtitle. Links through to AdvancedSummaryView for day-level drill-down.

New files: TodaySummaryData, TodaySummaryCalculator, TrendsSummaryData,
TrendsSummaryCalculator. Existing SummaryMetricsCalculator and
AdvancedSummaryView are unchanged.

https://claude.ai/code/session_0123FXxUrrMXigkAA9s6yyo9