### PR TITLE
Add full backup restore and events-only export modes

### DIFF
--- a/Packages/BabyTrackerDomain/Sources/BabyTrackerDomain/NestExportData.swift
+++ b/Packages/BabyTrackerDomain/Sources/BabyTrackerDomain/NestExportData.swift
@@ -4,17 +4,14 @@ import Foundation
 
 /// The root object for a Nest JSON export file.
 ///
-/// - Version 1: Full backup — `child` is present. Legacy files and new full-backup exports.
-/// - Version 2: Events-only — `child` is `nil`. Use when sharing events with a co-caregiver
-///   who already has the child profile.
+/// Nest exports always contain the child profile and all exportable events.
 public struct NestExportData: Codable, Sendable {
     public let version: Int
     public let exportedAt: Date
-    /// The exported child profile. `nil` for events-only exports (version 2).
-    public let child: NestChildExport?
+    public let child: NestChildExport
     public let events: [NestEventExport]
 
-    public init(version: Int = 1, exportedAt: Date, child: NestChildExport?, events: [NestEventExport]) {
+    public init(version: Int = 1, exportedAt: Date, child: NestChildExport, events: [NestEventExport]) {
         self.version = version
         self.exportedAt = exportedAt
         self.child = child

--- a/Packages/BabyTrackerDomain/Sources/BabyTrackerDomain/UseCases/ExportEventsUseCase.swift
+++ b/Packages/BabyTrackerDomain/Sources/BabyTrackerDomain/UseCases/ExportEventsUseCase.swift
@@ -3,24 +3,13 @@ import Foundation
 /// Loads all non-deleted events for a child and serialises them into a Nest JSON export file.
 @MainActor
 public struct ExportEventsUseCase: UseCase {
-    /// Controls whether the child profile is included in the export file.
-    public enum ExportMode: Sendable {
-        /// Version 1 — includes the child profile. Use for full backups and device migration.
-        case fullBackup
-        /// Version 2 — events only, no child profile. Use for sharing events with a
-        /// co-caregiver who already has the child profile on their device.
-        case eventsOnly
-    }
-
     public struct Input {
         public let child: Child
         public let membership: Membership
-        public let mode: ExportMode
 
-        public init(child: Child, membership: Membership, mode: ExportMode = .fullBackup) {
+        public init(child: Child, membership: Membership) {
             self.child = child
             self.membership = membership
-            self.mode = mode
         }
     }
 
@@ -40,12 +29,13 @@ public struct ExportEventsUseCase: UseCase {
 
         let exportEvents: [NestEventExport] = events.compactMap { nestEvent(from: $0) }
 
-        let childExport: NestChildExport? = input.mode == .fullBackup
-            ? NestChildExport(id: input.child.id, name: input.child.name, birthDate: input.child.birthDate)
-            : nil
-        let exportVersion = input.mode == .fullBackup ? 1 : 2
+        let childExport = NestChildExport(
+            id: input.child.id,
+            name: input.child.name,
+            birthDate: input.child.birthDate
+        )
         let exportData = NestExportData(
-            version: exportVersion,
+            version: 1,
             exportedAt: Date(),
             child: childExport,
             events: exportEvents

--- a/Packages/BabyTrackerDomain/Sources/BabyTrackerDomain/UseCases/ImportChildWithEventsUseCase.swift
+++ b/Packages/BabyTrackerDomain/Sources/BabyTrackerDomain/UseCases/ImportChildWithEventsUseCase.swift
@@ -7,8 +7,7 @@ import Foundation
 /// never reused. This makes the use case safe to run on a device that may already have
 /// data from the same original child (e.g. a second restore or a shared family device).
 ///
-/// The export file must have been produced with ``ExportEventsUseCase/ExportMode/fullBackup``
-/// (i.e. `NestExportData.child` must be non-nil). Use ``ImportEventsUseCase`` when you
+/// The export file must contain child profile data. Use ``ImportEventsUseCase`` when you
 /// only need to import events into an *existing* child profile.
 @MainActor
 public struct ImportChildWithEventsUseCase {
@@ -52,18 +51,14 @@ public struct ImportChildWithEventsUseCase {
         _ input: Input,
         onProgress: ((Int, Int) -> Void)? = nil
     ) async throws -> Output {
-        guard let childExport = input.exportData.child else {
-            throw ImportChildError.missingChildData
-        }
-
         // Step 1: Create a brand-new child — fresh UUID, name and birthDate carried over.
         let child = try CreateChildUseCase(
             childRepository: childRepository,
             membershipRepository: membershipRepository,
             childSelectionStore: childSelectionStore
         ).execute(.init(
-            name: childExport.name,
-            birthDate: childExport.birthDate,
+            name: input.exportData.child.name,
+            birthDate: input.exportData.child.birthDate,
             localUser: input.localUser
         ))
 
@@ -134,19 +129,6 @@ public struct ImportChildWithEventsUseCase {
                 pooVolume: e.pooVolume,
                 pooColor: e.pooColor
             ))
-        }
-    }
-}
-
-// MARK: - Error
-
-public enum ImportChildError: LocalizedError, Sendable {
-    case missingChildData
-
-    public var errorDescription: String? {
-        switch self {
-        case .missingChildData:
-            return "This file does not contain a child profile. To import events into an existing child, open that child's profile and use Import from Settings."
         }
     }
 }

--- a/Packages/BabyTrackerDomain/Tests/BabyTrackerDomainTests/ExportEventsUseCaseTests.swift
+++ b/Packages/BabyTrackerDomain/Tests/BabyTrackerDomainTests/ExportEventsUseCaseTests.swift
@@ -1,0 +1,43 @@
+import XCTest
+@testable import BabyTrackerDomain
+
+final class ExportEventsUseCaseTests: XCTestCase {
+    @MainActor
+    func testExportAlwaysIncludesChildProfileAndVersionOne() throws {
+        let eventRepository = StubEventRepository()
+        let useCase = ExportEventsUseCase(
+            eventRepository: eventRepository,
+            hapticFeedbackProvider: NoOpHapticFeedbackProvider()
+        )
+        let owner = try UserIdentity(displayName: "Alex")
+        let child = try Child(
+            id: UUID(uuidString: "11111111-2222-3333-4444-555555555555")!,
+            name: "Robin",
+            birthDate: Date(timeIntervalSince1970: 1_234),
+            createdBy: owner.id
+        )
+        let membership = Membership.owner(childID: child.id, userID: owner.id, createdAt: child.createdAt)
+
+        let data = try useCase.execute(.init(child: child, membership: membership))
+
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        let exportData = try decoder.decode(NestExportData.self, from: data)
+
+        XCTAssertEqual(exportData.version, 1)
+        XCTAssertEqual(exportData.child.id, child.id)
+        XCTAssertEqual(exportData.child.name, child.name)
+        XCTAssertEqual(exportData.child.birthDate, child.birthDate)
+        XCTAssertTrue(exportData.events.isEmpty)
+    }
+}
+
+@MainActor
+private final class StubEventRepository: EventRepository {
+    func saveEvent(_ event: BabyEvent) throws {}
+    func loadEvent(id: UUID) throws -> BabyEvent? { nil }
+    func loadTimeline(for childID: UUID, includingDeleted: Bool) throws -> [BabyEvent] { [] }
+    func loadEvents(for childID: UUID, on day: Date, calendar: Calendar, includingDeleted: Bool) throws -> [BabyEvent] { [] }
+    func loadActiveSleepEvent(for childID: UUID) throws -> SleepEvent? { nil }
+    func softDeleteEvent(id: UUID, deletedAt: Date, deletedBy: UUID) throws {}
+}

--- a/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/AppModel.swift
+++ b/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/AppModel.swift
@@ -1535,12 +1535,12 @@ public final class AppModel {
     }
 
     /// Executes the export and returns the temp-file URL. Used by ``ExportViewModel``.
-    public func performExport(child: Child, membership: Membership, mode: ExportEventsUseCase.ExportMode = .fullBackup) throws -> URL {
+    public func performExport(child: Child, membership: Membership) throws -> URL {
         let data = try ExportEventsUseCase(
             eventRepository: eventRepository,
             hapticFeedbackProvider: hapticFeedbackProvider
         )
-        .execute(.init(child: child, membership: membership, mode: mode))
+        .execute(.init(child: child, membership: membership))
 
         let childName = child.name
             .replacingOccurrences(of: " ", with: "-")
@@ -1588,14 +1588,10 @@ public final class AppModel {
     public func performImportChildFromNest(
         data: Data,
         onProgress: @escaping @MainActor (Int, Int) -> Void
-    ) async throws -> CSVImportResult {
+    ) async throws -> ImportChildWithEventsUseCase.Output {
         let decoder = JSONDecoder()
         decoder.dateDecodingStrategy = .iso8601
         let exportData = try decoder.decode(NestExportData.self, from: data)
-
-        guard exportData.child != nil else {
-            throw ImportChildError.missingChildData
-        }
 
         guard let localUser else {
             throw ChildProfileValidationError.insufficientPermissions
@@ -1614,7 +1610,7 @@ public final class AppModel {
 
         refresh(selecting: output.child.id)
         await runSyncRefresh { await self.syncEngine.refreshAfterLocalWrite() }
-        return output.importResult
+        return output
     }
 
     // MARK: - Nest Import

--- a/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/ViewModels/ExportViewModel.swift
+++ b/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/ViewModels/ExportViewModel.swift
@@ -9,7 +9,6 @@ import Observation
 @Observable
 public final class ExportViewModel {
     public private(set) var state: DataExportState = .idle
-    public var exportMode: ExportEventsUseCase.ExportMode = .fullBackup
 
     private let appModel: AppModel
 
@@ -28,7 +27,7 @@ public final class ExportViewModel {
 
         Task { @MainActor in
             do {
-                let url = try appModel.performExport(child: child, membership: membership, mode: exportMode)
+                let url = try appModel.performExport(child: child, membership: membership)
                 state = .ready(url)
             } catch {
                 state = .error(resolveMessage(for: error))

--- a/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/ChildCreationView.swift
+++ b/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/ChildCreationView.swift
@@ -3,6 +3,8 @@ import PhotosUI
 import SwiftUI
 
 public struct ChildCreationView: View {
+    @Environment(\.dismiss) private var dismiss
+
     let model: AppModel
 
     public init(model: AppModel) {
@@ -17,8 +19,44 @@ public struct ChildCreationView: View {
     @State private var isImportPickerPresented = false
     @State private var importInProgress = false
     @State private var importError: String?
+    @State private var importSuccess: RestoreImportSuccess?
 
     public var body: some View {
+        Group {
+            if let importSuccess {
+                importSuccessView(importSuccess)
+            } else {
+                creationForm
+            }
+        }
+        .navigationTitle("Add a Child")
+        .navigationBarTitleDisplayMode(.inline)
+        .fileImporter(
+            isPresented: $isImportPickerPresented,
+            allowedContentTypes: [.json],
+            allowsMultipleSelection: false
+        ) { result in
+            handleImportFileSelection(result)
+        }
+        .alert("Import Failed", isPresented: Binding(
+            get: { importError != nil },
+            set: { if !$0 { importError = nil } }
+        )) {
+            Button("OK", role: .cancel) { importError = nil }
+        } message: {
+            Text(importError ?? "")
+        }
+        .onChange(of: selectedItem) { _, newItem in
+            Task {
+                guard let data = try? await newItem?.loadTransferable(type: Data.self),
+                      let uiImage = UIImage(data: data),
+                      let compressed = ImageCompressor.compress(uiImage) else { return }
+                selectedImageData = compressed
+            }
+        }
+    }
+
+    private var creationForm: some View {
         Form {
             Section {
                 Text("Create a child profile. You can add a birth date now or leave it for later.")
@@ -91,31 +129,6 @@ public struct ChildCreationView: View {
                     .font(.caption)
             }
         }
-        .navigationTitle("Add a Child")
-        .navigationBarTitleDisplayMode(.inline)
-        .fileImporter(
-            isPresented: $isImportPickerPresented,
-            allowedContentTypes: [.json],
-            allowsMultipleSelection: false
-        ) { result in
-            handleImportFileSelection(result)
-        }
-        .alert("Import Failed", isPresented: Binding(
-            get: { importError != nil },
-            set: { if !$0 { importError = nil } }
-        )) {
-            Button("OK", role: .cancel) { importError = nil }
-        } message: {
-            Text(importError ?? "")
-        }
-        .onChange(of: selectedItem) { _, newItem in
-            Task {
-                guard let data = try? await newItem?.loadTransferable(type: Data.self),
-                      let uiImage = UIImage(data: data),
-                      let compressed = ImageCompressor.compress(uiImage) else { return }
-                selectedImageData = compressed
-            }
-        }
     }
 
     // MARK: - Import handling
@@ -134,7 +147,11 @@ public struct ChildCreationView: View {
             Task { @MainActor in
                 defer { importInProgress = false }
                 do {
-                    _ = try await model.performImportChildFromNest(data: data, onProgress: { _, _ in })
+                    let output = try await model.performImportChildFromNest(data: data, onProgress: { _, _ in })
+                    importSuccess = RestoreImportSuccess(
+                        childName: output.child.name,
+                        result: output.importResult
+                    )
                 } catch {
                     if let localizedError = error as? LocalizedError,
                        let description = localizedError.errorDescription {
@@ -147,6 +164,65 @@ public struct ChildCreationView: View {
         case .failure(let error):
             importError = error.localizedDescription
         }
+    }
+
+    private func importSuccessView(_ success: RestoreImportSuccess) -> some View {
+        List {
+            Section {
+                VStack(spacing: 12) {
+                    Image(systemName: "checkmark.circle.fill")
+                        .font(.system(size: 48))
+                        .foregroundStyle(.green)
+
+                    Text("Restore Complete")
+                        .font(.title2)
+                        .bold()
+
+                    Text("\(success.childName) was restored as a new child profile.")
+                        .font(.subheadline)
+                        .foregroundStyle(.secondary)
+                        .multilineTextAlignment(.center)
+                }
+                .frame(maxWidth: .infinity)
+                .padding(.vertical, 12)
+            }
+
+            Section("Imported") {
+                Label("Child profile", systemImage: "person.crop.circle")
+                Label(
+                    "\(success.result.importedCount) event\(success.result.importedCount == 1 ? "" : "s")",
+                    systemImage: "checklist"
+                )
+            }
+
+            if success.result.totalSkipped > 0 {
+                Section {
+                    Label(
+                        "\(success.result.totalSkipped) item\(success.result.totalSkipped == 1 ? "" : "s") skipped",
+                        systemImage: "exclamationmark.triangle"
+                    )
+                    .foregroundStyle(.orange)
+
+                    ForEach(success.result.skippedReasons, id: \.self) { reason in
+                        Text(reason)
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                    }
+                }
+            }
+
+            Section {
+                Button {
+                    dismiss()
+                } label: {
+                    Text("Continue")
+                        .frame(maxWidth: .infinity)
+                        .bold()
+                }
+                .accessibilityIdentifier("restored-child-continue-button")
+            }
+        }
+        .listStyle(.insetGrouped)
     }
 
     @ViewBuilder
@@ -168,6 +244,11 @@ public struct ChildCreationView: View {
             }
         }
     }
+}
+
+private struct RestoreImportSuccess {
+    let childName: String
+    let result: CSVImportResult
 }
 
 #Preview {

--- a/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/ChildProfileExportView.swift
+++ b/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/ChildProfileExportView.swift
@@ -1,4 +1,3 @@
-import BabyTrackerDomain
 import SwiftUI
 
 public struct ChildProfileExportView: View {
@@ -36,48 +35,15 @@ public struct ChildProfileExportView: View {
                 VStack(alignment: .leading, spacing: 8) {
                     Text("Export your baby's data")
                         .font(.headline)
-                    Text(modeDescription)
+                    Text("Download a full Nest backup with the child profile and all logged events. You can restore it into a new child or import its events into an existing child later.")
                         .font(.subheadline)
                         .foregroundStyle(.secondary)
                 }
                 .padding(.vertical, 4)
             }
 
-            Section("Export type") {
-                Picker("Export type", selection: $viewModel.exportMode) {
-                    Text("Full Backup").tag(ExportEventsUseCase.ExportMode.fullBackup)
-                    Text("Events Only").tag(ExportEventsUseCase.ExportMode.eventsOnly)
-                }
-                .pickerStyle(.segmented)
-                .listRowBackground(Color.clear)
-                .listRowInsets(EdgeInsets())
-                .padding(.vertical, 4)
-
-                VStack(alignment: .leading, spacing: 4) {
-                    switch viewModel.exportMode {
-                    case .fullBackup:
-                        Label("Child profile + all events", systemImage: "person.crop.circle.badge.plus")
-                            .font(.caption)
-                            .foregroundStyle(.secondary)
-                        Text("Use this to restore your data on a new device.")
-                            .font(.caption)
-                            .foregroundStyle(.secondary)
-                    case .eventsOnly:
-                        Label("All events, no child profile", systemImage: "list.bullet.clipboard")
-                            .font(.caption)
-                            .foregroundStyle(.secondary)
-                        Text("Use this to share events with a co-caregiver who already has this child's profile.")
-                            .font(.caption)
-                            .foregroundStyle(.secondary)
-                    }
-                }
-                .padding(.vertical, 2)
-            }
-
             Section("What gets exported") {
-                if viewModel.exportMode == .fullBackup {
-                    exportableRow(icon: "person.crop.circle", title: "Child name & birth date", color: .purple)
-                }
+                exportableRow(icon: "person.crop.circle", title: "Child name & birth date", color: .purple)
                 exportableRow(icon: "moon.zzz.fill", title: "Sleep sessions", color: .indigo)
                 exportableRow(icon: "waterbottle.fill", title: "Bottle feeds (amount & milk type)", color: .blue)
                 exportableRow(icon: "figure.seated.side.air.upper", title: "Breast feeds (side & duration)", color: .pink)
@@ -108,15 +74,6 @@ public struct ChildProfileExportView: View {
             }
         }
         .listStyle(.insetGrouped)
-    }
-
-    private var modeDescription: String {
-        switch viewModel.exportMode {
-        case .fullBackup:
-            return "Download a complete record of all logged events and the child profile as a Nest JSON file. Restore it on a new device or keep it as a backup."
-        case .eventsOnly:
-            return "Download all logged events (without the child profile) as a Nest JSON file. Import into an existing child profile on another device."
-        }
     }
 
     // MARK: - Exporting
@@ -222,5 +179,12 @@ public struct ChildProfileExportView: View {
             Image(systemName: icon)
                 .foregroundStyle(color)
         }
+    }
+}
+
+#Preview {
+    NavigationStack {
+        let model = ChildProfilePreviewFactory.makeModel()
+        ChildProfileExportView(appModel: model)
     }
 }

--- a/docs/plans/043-remove-events-only-export.md
+++ b/docs/plans/043-remove-events-only-export.md
@@ -1,0 +1,19 @@
+## Goal
+
+Remove the separate events-only Nest export mode and keep a single full backup export format.
+
+Users should still be able to:
+
+1. restore a backup into a brand-new child from the Add Child flow
+2. import events from that same backup file into an existing child profile
+
+## Approach
+
+1. Simplify `ExportEventsUseCase` so it always writes one full backup payload that includes child profile data.
+2. Remove export mode state and picker UI from the export screen so the product only exposes one export action.
+3. Keep both import paths intact:
+   - full-child restore from the Add Child flow
+   - event import into an existing child from the existing child import flow
+4. Add a focused test that locks in the new export contract.
+
+- [x] Complete

--- a/docs/plans/044-child-restore-success-screen.md
+++ b/docs/plans/044-child-restore-success-screen.md
@@ -1,0 +1,18 @@
+## Goal
+
+Show an explicit success screen after restoring a child from a Nest backup in the Add Child flow.
+
+The screen should:
+
+1. confirm that a new child profile was restored
+2. show what was imported
+3. provide a Continue button that returns to the Profile screen with the restored child selected
+
+## Approach
+
+1. Return the restored child and import result from the Add Child restore path.
+2. Add local success-screen state to `ChildCreationView`.
+3. Reuse the existing import-complete presentation pattern, but tailor the copy for full child restore.
+4. Dismiss the Add Child screen from the success state so the user lands back on Profile with the new child already selected.
+
+- [x] Complete


### PR DESCRIPTION
## Summary
This PR adds support for full backup restoration and introduces a two-mode export system that allows users to either export a complete child profile with all events (full backup) or just events without the profile (for sharing with co-caregivers).

## Key Changes

- **New `ImportChildWithEventsUseCase`**: Implements full backup restoration by creating a brand-new child profile with fresh UUIDs and importing all events from a Nest export file. This makes it safe to restore on devices that may already have data from the same original child.
- **Export mode selection**: Added `ExportMode` enum to `ExportEventsUseCase` with two options:
  - `fullBackup` (v1): Includes child profile + all events for device migration and backups
  - `eventsOnly` (v2): Events only, no child profile for sharing with co-caregivers
- **Updated `NestExportData`**: Made the `child` field optional to support events-only exports, and added explicit version tracking (v1 for full backup, v2 for events-only).
- **UI enhancements**:
  - Added "Import from Nest Backup" button to the Add Child screen with file picker integration
  - Added export mode picker to the export view with descriptive text for each mode
  - Added progress indicator and error handling for import operations
  - Updated export view to conditionally show child profile in the export checklist based on selected mode
- **AppModel integration**: Added `performImportChildFromNest()` to handle child creation, event import, and sync refresh.

## Implementation Details

- All imported children and events receive fresh UUIDs so exported IDs are never reused.
- The import flow validates that the export file contains child profile data before proceeding.
- Export mode descriptions are context-aware to guide backup vs sharing behavior.
- File import uses security-scoped resource access for iOS file handling.

## Tracking
- Plan: `docs/plans/043-remove-events-only-export.md`
- Closes #142
