### PR TITLE
Fix loadEvents to include duration events that span midnight

### DIFF
--- a/Baby TrackerTests/EventRepositoryTests.swift
+++ b/Baby TrackerTests/EventRepositoryTests.swift
@@ -327,7 +327,7 @@ struct EventRepositoryTests {
     }
 
     @Test
-    func loadEventsUsesOccurredAtDayForSleepThatSpansMidnight() throws {
+    func loadEventsIncludesSleepOnBothDaysWhenItSpansMidnight() throws {
         let harness = try RepositoryHarness()
         defer { harness.cleanUp() }
 
@@ -372,7 +372,7 @@ struct EventRepositoryTests {
             includingDeleted: false
         )
 
-        #expect(firstDayEvents.isEmpty)
+        #expect(firstDayEvents.map(\.id) == [sleep.id])
         #expect(secondDayEvents.map(\.id) == [sleep.id])
     }
 }

--- a/Packages/BabyTrackerPersistence/Sources/BabyTrackerPersistence/SwiftDataEventRepository.swift
+++ b/Packages/BabyTrackerPersistence/Sources/BabyTrackerPersistence/SwiftDataEventRepository.swift
@@ -125,9 +125,27 @@ public final class SwiftDataEventRepository: EventRepository {
 
         return try loadTimeline(for: childID, includingDeleted: includingDeleted)
             .filter { event in
-                event.metadata.occurredAt >= startOfDay &&
-                event.metadata.occurredAt < endOfDay
+                eventOverlapsDay(event, startOfDay: startOfDay, endOfDay: endOfDay)
             }
+    }
+
+    private func eventOverlapsDay(
+        _ event: BabyEvent,
+        startOfDay: Date,
+        endOfDay: Date
+    ) -> Bool {
+        switch event {
+        case let .sleep(sleep):
+            // Active sleep (nil endedAt) is treated as still ongoing
+            let end = sleep.endedAt ?? Date.distantFuture
+            return sleep.startedAt < endOfDay && end > startOfDay
+        case let .breastFeed(feed):
+            return feed.startedAt < endOfDay && feed.endedAt > startOfDay
+        case let .bottleFeed(feed):
+            return feed.metadata.occurredAt >= startOfDay && feed.metadata.occurredAt < endOfDay
+        case let .nappy(nappy):
+            return nappy.metadata.occurredAt >= startOfDay && nappy.metadata.occurredAt < endOfDay
+        }
     }
 
     public func loadActiveSleepEvent(for childID: UUID) throws -> SleepEvent? {


### PR DESCRIPTION
Events like sleep that start on one day and end on the next were only
appearing on the end day. loadEvents now uses overlap detection for
sleep and breast feed events so they show on every day they cover.

Closes #134

https://claude.ai/code/session_018mjTTwbw4q76gHuYvn9isN