### PR TITLE
Fix sync indicator: anchor to top right and improve transitions

### DIFF
--- a/Baby Tracker/App/AppRootView.swift
+++ b/Baby Tracker/App/AppRootView.swift
@@ -60,8 +60,16 @@ struct AppRootView: View {
                     SyncIndicatorView(state: syncBannerState)
                         .padding(.top, 8)
                         .padding(.trailing, 16)
+                        .transition(
+                            .asymmetric(
+                                insertion: .opacity.combined(with: .move(edge: .bottom)),
+                                removal: .opacity.combined(with: .move(edge: .bottom))
+                            )
+                        )
                 }
             }
+            .frame(maxWidth: .infinity, alignment: .topTrailing)
+            .animation(.spring(response: 0.38, dampingFraction: 0.82), value: model.syncBannerState != nil)
         }
         .onChange(of: scenePhase) { _, newPhase in
             if newPhase == .active {

--- a/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/SyncIndicatorView.swift
+++ b/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/SyncIndicatorView.swift
@@ -21,8 +21,9 @@ public struct SyncIndicatorView: View {
                     .strokeBorder(borderColor.opacity(0.28), lineWidth: 1)
             }
             .shadow(color: .black.opacity(0.14), radius: 10, y: 4)
-            .contentTransition(.symbolEffect(.replace))
-            .animation(.spring(response: 0.28, dampingFraction: 0.78), value: state)
+            .contentTransition(.symbolEffect(.replace.downUp.wholeSymbol))
+            .scaleEffect(1)
+            .animation(.spring(response: 0.28, dampingFraction: 0.65), value: state)
             .animation(
                 state == .syncing
                     ? .linear(duration: 0.85).repeatForever(autoreverses: false)


### PR DESCRIPTION
- Fixes the sync indicator anchoring by ensuring the overlay ZStack fills the full width, so the indicator always appears in the top-right corner
- Adds a fade + slide-from-bottom entry/exit transition when the indicator appears/disappears
- Improves the icon swap transition to a downUp whole-symbol replace effect
- Tightens the spring damping for a subtle pop on state change

Closes #137