### PR TITLE
Fix event date section headers

### DIFF
--- a/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/EventHistoryView.swift
+++ b/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/EventHistoryView.swift
@@ -181,10 +181,27 @@ public struct EventHistoryView: View {
     }
 
     private func sectionHeader(for date: Date) -> some View {
-        Text(date.formatted(date: .abbreviated, time: .omitted))
-            .font(.subheadline.weight(.semibold))
-            .foregroundStyle(.secondary)
+        let calendar = Calendar.autoupdatingCurrent
+        let label: String
+        if calendar.isDateInToday(date) {
+            label = "Today"
+        } else if calendar.isDateInYesterday(date) {
+            label = "Yesterday"
+        } else {
+            label = date.formatted(date: .abbreviated, time: .omitted)
+        }
+
+        return Text(label)
+            .font(.footnote.weight(.bold))
+            .foregroundStyle(.primary)
             .textCase(.none)
+            .padding(.horizontal, 10)
+            .padding(.vertical, 4)
+            .background(
+                Capsule()
+                    .fill(Color(.tertiarySystemFill))
+            )
+            .padding(.vertical, 4)
     }
 }
 


### PR DESCRIPTION
## Summary
- Event history date section headers now have a visible pill-shaped background (capsule with `tertiarySystemFill`) so they stand out from the list background
- Displays "Today" and "Yesterday" labels for recent dates instead of an abbreviated date string
- Text uses `.primary` foreground colour and bold weight for better legibility

## Test plan
- [ ] Open the event history screen and verify section headers are visually distinct from the list background
- [ ] Confirm today's section shows "Today" and yesterday's shows "Yesterday"
- [ ] Confirm older dates still show an abbreviated date (e.g. "Apr 3, 2026")
- [ ] Verify the pill background looks correct in both light and dark mode

Closes #133

https://claude.ai/code/session_014iwkfg1MnHPLTwPqWwCfjE