### PR TITLE
Add current-time line to timeline day grid

### DIFF
--- a/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/TimelineDayGridView.swift
+++ b/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/TimelineDayGridView.swift
@@ -59,8 +59,12 @@ public struct TimelineDayGridView: View {
                             y: CGFloat(item.startSlotIndex) * slotHeight + itemVerticalInset
                         )
                     }
+                    }
+
+                    if isToday {
+                        currentTimeIndicator(columnWidth: columnWidth)
+                    }
                 }
-            }
             }
             .frame(height: CGFloat(slotCount) * slotHeight)
         }
@@ -143,6 +147,19 @@ public struct TimelineDayGridView: View {
         }
     }
 
+    private func currentTimeIndicator(columnWidth: CGFloat) -> some View {
+        TimelineView(.periodic(from: .now, by: 60)) { context in
+            Rectangle()
+                .fill(Color.red)
+                .frame(width: indicatorWidth(for: columnWidth), height: 1)
+                .offset(
+                    x: timeColumnWidth + columnSpacing,
+                    y: yOffsetForCurrentTime(at: context.date)
+                )
+                .accessibilityHidden(true)
+        }
+    }
+
     private var slotCount: Int {
         (24 * 60) / grid.slotMinutes
     }
@@ -153,6 +170,19 @@ public struct TimelineDayGridView: View {
 
     private func xOffset(for columnIndex: Int, columnWidth: CGFloat) -> CGFloat {
         timeColumnWidth + columnSpacing + CGFloat(columnIndex) * (columnWidth + columnSpacing)
+    }
+
+    private func indicatorWidth(for columnWidth: CGFloat) -> CGFloat {
+        (columnWidth * CGFloat(grid.columns.count)) + (columnSpacing * CGFloat(max(0, grid.columns.count - 1)))
+    }
+
+    private func yOffsetForCurrentTime(at date: Date) -> CGFloat {
+        let calendar = Calendar.autoupdatingCurrent
+        let components = calendar.dateComponents([.hour, .minute], from: date)
+        let currentMinutes = max(0, (components.hour ?? 0) * 60 + (components.minute ?? 0))
+        let clampedMinutes = min(24 * 60, currentMinutes)
+        let slotsFromStart = CGFloat(clampedMinutes) / CGFloat(grid.slotMinutes)
+        return min(CGFloat(slotCount) * slotHeight, slotsFromStart * slotHeight)
     }
 
     private func itemHeight(for item: TimelineDayGridItemViewState) -> CGFloat {
@@ -169,6 +199,10 @@ public struct TimelineDayGridView: View {
 
     private func hourAnchorID(for hour: Int) -> String {
         "timeline-day-grid-hour-\(hour)"
+    }
+
+    private var isToday: Bool {
+        Calendar.autoupdatingCurrent.isDateInToday(day)
     }
 
     private func eventKind(for columnKind: TimelineDayGridColumnKind) -> BabyEventKind {
@@ -227,8 +261,23 @@ public struct TimelineDayGridView: View {
     .background(Color(.systemGroupedBackground))
 }
 
+#Preview("Past Day (No Current Time Line)") {
+    ScrollView {
+        TimelineDayGridView(
+            day: TimelineDayGridPreviewFactory.previousDay,
+            grid: TimelineDayGridPreviewFactory.mixedGrid,
+            canManageEvents: true,
+            openItem: { _ in },
+            deleteItem: { _ in }
+        )
+        .padding()
+    }
+    .background(Color(.systemGroupedBackground))
+}
+
 private enum TimelineDayGridPreviewFactory {
     static let day = Calendar.autoupdatingCurrent.startOfDay(for: .now)
+    static let previousDay = Calendar.autoupdatingCurrent.date(byAdding: .day, value: -1, to: day) ?? day
 
     static let emptyGrid = TimelineDayGridViewState(
         slotMinutes: 15,

--- a/docs/plans/044-current-time-line-day-grid.md
+++ b/docs/plans/044-current-time-line-day-grid.md
@@ -1,0 +1,17 @@
+# 044 – Show current time line on day grid
+
+## Goal
+Add a thin current-time indicator to the timeline day grid so today's page clearly shows where "now" sits within the 24-hour chart.
+
+## Approach
+1. Update `TimelineDayGridView` to overlay a horizontal indicator line when the rendered day is today.
+2. Compute the indicator position from current minutes elapsed in the day and clamp it to the grid bounds.
+3. Keep the indicator width aligned to the event grid columns (excluding the hour label gutter) so it spans the chart area.
+4. Use a periodic timeline refresh so the line advances automatically while the view is visible.
+5. Add/update previews to make the indicator behavior easy to validate during development.
+
+## Verification
+1. Build the app target/package.
+2. Run relevant Swift package tests.
+
+- [x] Complete


### PR DESCRIPTION
### Motivation

- Make it easy for users to see the current time on the day timeline by drawing a thin live indicator on the day grid when viewing today.

### Description

- Overlay a live indicator in `TimelineDayGridView` using `TimelineView(.periodic)` so the line updates every minute while visible.
- Compute vertical position by converting minutes-since-midnight into grid slots and clamp the offset to grid bounds, and compute indicator width to span the event columns (excluding the hour-label gutter).
- Only render the indicator when the rendered `day` is today and keep the visual simple (1pt red line) and accessibility-hidden.
- Add a past-day preview to validate the indicator is hidden and add/complete the plan doc at `docs/plans/044-current-time-line-day-grid.md`.

### Testing

- Attempted to run the package test suite with `swift test` in `Packages/BabyTrackerFeature`, but the run failed due to a local Swift toolchain mismatch (package requires Swift 6.2.0 while the environment has Swift 6.1.3).
- No other automated tests were modified or added for this change and previews were updated to exercise the new behavior.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d424d0ed24832f8a29b1acde5bbd50)