### PR TITLE
Show current-time indicator on TimelineDayGridView

### DIFF
--- a/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/TimelineDayGridView.swift
+++ b/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/TimelineDayGridView.swift
@@ -44,6 +44,10 @@ public struct TimelineDayGridView: View {
                 ZStack(alignment: .topLeading) {
                     slotGrid(columnWidth: columnWidth)
 
+                    if isToday {
+                        currentTimeIndicator(columnWidth: columnWidth)
+                    }
+
                     ForEach(Array(grid.columns.enumerated()), id: \.element.kind) { index, column in
                         ForEach(column.items) { item in
                             TimelineDayGridItemView(
@@ -59,8 +63,8 @@ public struct TimelineDayGridView: View {
                             y: CGFloat(item.startSlotIndex) * slotHeight + itemVerticalInset
                         )
                     }
+                    }
                 }
-            }
             }
             .frame(height: CGFloat(slotCount) * slotHeight)
         }
@@ -143,6 +147,19 @@ public struct TimelineDayGridView: View {
         }
     }
 
+    private func currentTimeIndicator(columnWidth: CGFloat) -> some View {
+        TimelineView(.periodic(from: .now, by: 60)) { context in
+            Rectangle()
+                .fill(Color.red)
+                .frame(width: indicatorWidth(for: columnWidth), height: 1)
+                .offset(
+                    x: timeColumnWidth + columnSpacing,
+                    y: yOffsetForCurrentTime(at: context.date)
+                )
+                .accessibilityHidden(true)
+        }
+    }
+
     private var slotCount: Int {
         (24 * 60) / grid.slotMinutes
     }
@@ -153,6 +170,19 @@ public struct TimelineDayGridView: View {
 
     private func xOffset(for columnIndex: Int, columnWidth: CGFloat) -> CGFloat {
         timeColumnWidth + columnSpacing + CGFloat(columnIndex) * (columnWidth + columnSpacing)
+    }
+
+    private func indicatorWidth(for columnWidth: CGFloat) -> CGFloat {
+        (columnWidth * CGFloat(grid.columns.count)) + (columnSpacing * CGFloat(max(0, grid.columns.count - 1)))
+    }
+
+    private func yOffsetForCurrentTime(at date: Date) -> CGFloat {
+        let calendar = Calendar.autoupdatingCurrent
+        let components = calendar.dateComponents([.hour, .minute], from: date)
+        let currentMinutes = max(0, (components.hour ?? 0) * 60 + (components.minute ?? 0))
+        let clampedMinutes = min(24 * 60, currentMinutes)
+        let slotsFromStart = CGFloat(clampedMinutes) / CGFloat(grid.slotMinutes)
+        return min(CGFloat(slotCount) * slotHeight, slotsFromStart * slotHeight)
     }
 
     private func itemHeight(for item: TimelineDayGridItemViewState) -> CGFloat {
@@ -169,6 +199,10 @@ public struct TimelineDayGridView: View {
 
     private func hourAnchorID(for hour: Int) -> String {
         "timeline-day-grid-hour-\(hour)"
+    }
+
+    private var isToday: Bool {
+        Calendar.autoupdatingCurrent.isDateInToday(day)
     }
 
     private func eventKind(for columnKind: TimelineDayGridColumnKind) -> BabyEventKind {
@@ -227,8 +261,23 @@ public struct TimelineDayGridView: View {
     .background(Color(.systemGroupedBackground))
 }
 
+#Preview("Past Day (No Current Time Line)") {
+    ScrollView {
+        TimelineDayGridView(
+            day: TimelineDayGridPreviewFactory.previousDay,
+            grid: TimelineDayGridPreviewFactory.mixedGrid,
+            canManageEvents: true,
+            openItem: { _ in },
+            deleteItem: { _ in }
+        )
+        .padding()
+    }
+    .background(Color(.systemGroupedBackground))
+}
+
 private enum TimelineDayGridPreviewFactory {
     static let day = Calendar.autoupdatingCurrent.startOfDay(for: .now)
+    static let previousDay = Calendar.autoupdatingCurrent.date(byAdding: .day, value: -1, to: day) ?? day
 
     static let emptyGrid = TimelineDayGridViewState(
         slotMinutes: 15,

--- a/docs/plans/044-current-time-line-day-grid.md
+++ b/docs/plans/044-current-time-line-day-grid.md
@@ -1,0 +1,18 @@
+# 044 – Show current time line on day grid
+
+## Goal
+Add a thin current-time indicator to the timeline day grid so today's page clearly shows where "now" sits within the 24-hour chart.
+
+## Approach
+1. Update `TimelineDayGridView` to overlay a horizontal indicator line when the rendered day is today.
+2. Compute the indicator position from current minutes elapsed in the day and clamp it to the grid bounds.
+3. Keep the indicator width aligned to the event grid columns (excluding the hour label gutter) so it spans the chart area.
+4. Use a periodic timeline refresh so the line advances automatically while the view is visible.
+5. Render the indicator below event blocks so active cards stay visually prioritized.
+6. Add/update previews to make the indicator behavior easy to validate during development.
+
+## Verification
+1. Build the app target/package.
+2. Run relevant Swift package tests.
+
+- [x] Complete


### PR DESCRIPTION
### Motivation
- Improve the timeline day grid visibility by showing where "now" sits within the 24-hour chart on the page for the current day.
- Keep the indicator aligned to the event columns and ensure it updates periodically while the view is visible.
- Provide developer previews and a short plan documenting the feature and verification steps.

### Description
- Add a thin horizontal current-time indicator in `TimelineDayGridView` that renders only when `isToday` is true and updates via `TimelineView(.periodic(...))`.
- Compute vertical position with `yOffsetForCurrentTime(at:)`, clamp it to grid bounds, and compute spanning width with `indicatorWidth(for:)` so the line aligns to the event columns (excluding the time gutter).
- Insert the indicator under event cells in the `ZStack` so event cards remain visually on top, and add an `isToday` helper property.
- Add a new plan doc `docs/plans/044-current-time-line-day-grid.md` and a preview showing a past day without the current-time line.

### Testing
- Built the package with `swift build` and ran tests with `swift test`, both commands completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d424d0ed24832f8a29b1acde5bbd50)