### PR TITLE
Format long durations with hours

### DIFF
--- a/Baby TrackerTests/AppModelTests.swift
+++ b/Baby TrackerTests/AppModelTests.swift
@@ -234,6 +234,38 @@ struct AppModelTests {
     }
 
     @Test
+    func timelineShowsHourAwareBreastFeedTitles() throws {
+        let harness = try Harness()
+        defer { harness.cleanUp() }
+
+        let seed = try harness.seedOwnerProfile()
+        let calendar = Calendar.autoupdatingCurrent
+        let today = calendar.startOfDay(for: .now)
+        let breastStart = try #require(calendar.date(byAdding: .hour, value: 6, to: today))
+        let breastEnd = try #require(calendar.date(byAdding: .minute, value: 80, to: breastStart))
+
+        let breastFeed = try harness.saveBreastFeed(
+            childID: seed.child.id,
+            userID: seed.localUser.id,
+            start: breastStart,
+            end: breastEnd,
+            side: .left
+        )
+
+        harness.model.load(performLaunchSync: false)
+
+        let items = selectedTimelineItems(
+            pages: harness.model.timelinePages,
+            selectedDay: harness.model.timelineSelectedDay
+        )
+        let breastFeedItem = try #require(
+            items.first(where: { $0.primaryEventID == breastFeed.id })
+        )
+
+        #expect(breastFeedItem.title == "1h 20m")
+    }
+
+    @Test
     func timelineNavigationMovesBetweenDaysAndDisablesForwardNavigationOnToday() throws {
         let harness = try Harness()
         defer { harness.cleanUp() }

--- a/Baby TrackerTests/LastEventSummaryCalculatorTests.swift
+++ b/Baby TrackerTests/LastEventSummaryCalculatorTests.swift
@@ -56,8 +56,8 @@ struct LastEventSummaryCalculatorTests {
         let childID = UUID()
         let userID = UUID()
         let sleepStart = Date(timeIntervalSince1970: 3_000)
-        let sleepEnd = Date(timeIntervalSince1970: 4_200)
-        let feedEnd = Date(timeIntervalSince1970: 5_000)
+        let sleepEnd = Date(timeIntervalSince1970: 7_800)
+        let feedEnd = Date(timeIntervalSince1970: 9_000)
 
         let completedSleep = try #require(
             LastEventSummaryCalculator.makeSummary(
@@ -106,7 +106,7 @@ struct LastEventSummaryCalculatorTests {
                                 createdBy: userID
                             ),
                             side: .both,
-                            startedAt: feedEnd.addingTimeInterval(-900),
+                            startedAt: feedEnd.addingTimeInterval(-4_500),
                             endedAt: feedEnd
                         )
                     ),
@@ -114,8 +114,8 @@ struct LastEventSummaryCalculatorTests {
             )
         )
 
-        #expect(completedSleep.detailText == "20 min")
+        #expect(completedSleep.detailText == "1h 20m")
         #expect(activeSleep.detailText == "In progress")
-        #expect(breastFeed.detailText == "15 min • Both")
+        #expect(breastFeed.detailText == "1h 15m • Both")
     }
 }

--- a/Baby TrackerTests/LastSleepSummaryCalculatorTests.swift
+++ b/Baby TrackerTests/LastSleepSummaryCalculatorTests.swift
@@ -90,7 +90,7 @@ struct LastSleepSummaryCalculatorTests {
         let childID = UUID()
         let userID = UUID()
         let earlierEnd = Date(timeIntervalSince1970: 1_500)
-        let laterEnd = Date(timeIntervalSince1970: 2_500)
+        let laterEnd = Date(timeIntervalSince1970: 6_100)
         let activeStart = Date(timeIntervalSince1970: 3_500)
         let earlierSleep = try SleepEvent(
             metadata: EventMetadata(
@@ -109,7 +109,7 @@ struct LastSleepSummaryCalculatorTests {
                 createdAt: laterEnd,
                 createdBy: userID
             ),
-            startedAt: laterEnd.addingTimeInterval(-900),
+            startedAt: laterEnd.addingTimeInterval(-4_500),
             endedAt: laterEnd
         )
         let activeSleep = try SleepEvent(
@@ -130,7 +130,7 @@ struct LastSleepSummaryCalculatorTests {
 
         #expect(rows.count == 2)
         #expect(rows.map(\.id) == [laterSleep.id, earlierSleep.id])
-        #expect(rows.first?.detailText.contains("15 min") == true)
+        #expect(rows.first?.detailText.contains("1h 15m") == true)
         #expect(rows.first?.detailText.contains("-") == true)
     }
 }

--- a/Packages/BabyTrackerDomain/Sources/BabyTrackerDomain/DurationText.swift
+++ b/Packages/BabyTrackerDomain/Sources/BabyTrackerDomain/DurationText.swift
@@ -1,0 +1,51 @@
+import Foundation
+
+public enum DurationText {
+    public enum MinuteStyle: Sendable {
+        case letter
+        case word
+    }
+
+    public static func short(
+        minutes: Int,
+        minuteStyle: MinuteStyle = .letter
+    ) -> String {
+        let clampedMinutes = max(0, minutes)
+        let hours = clampedMinutes / 60
+        let remainingMinutes = clampedMinutes % 60
+
+        if hours == 0 {
+            return minuteStyle == .word ? "\(remainingMinutes) min" : "\(remainingMinutes)m"
+        }
+
+        if remainingMinutes == 0 {
+            return "\(hours)h"
+        }
+
+        return "\(hours)h \(remainingMinutes)m"
+    }
+
+    public static func spoken(minutes: Int) -> String {
+        let clampedMinutes = max(0, minutes)
+        let hours = clampedMinutes / 60
+        let remainingMinutes = clampedMinutes % 60
+
+        if hours == 0 {
+            return minutePhrase(remainingMinutes)
+        }
+
+        if remainingMinutes == 0 {
+            return hourPhrase(hours)
+        }
+
+        return "\(hourPhrase(hours)) \(minutePhrase(remainingMinutes))"
+    }
+
+    private static func hourPhrase(_ hours: Int) -> String {
+        hours == 1 ? "1 hour" : "\(hours) hours"
+    }
+
+    private static func minutePhrase(_ minutes: Int) -> String {
+        minutes == 1 ? "1 minute" : "\(minutes) minutes"
+    }
+}

--- a/Packages/BabyTrackerDomain/Sources/BabyTrackerDomain/ImportableEvent.swift
+++ b/Packages/BabyTrackerDomain/Sources/BabyTrackerDomain/ImportableEvent.swift
@@ -38,19 +38,14 @@ public enum ImportableEvent: Equatable, Sendable, Identifiable {
             }
             return parts.joined(separator: " ")
         case .breastFeed(let e):
-            let mins = e.durationMinutes
+            let durationText = DurationText.short(minutes: e.durationMinutes)
             if let side = e.side {
-                return "\(side.displayName) · \(mins)m"
+                return "\(side.displayName) · \(durationText)"
             }
-            return "\(mins)m"
+            return durationText
         case .sleep(let e):
-            let duration = e.endedAt.timeIntervalSince(e.startedAt)
-            let hours = Int(duration) / 3600
-            let minutes = (Int(duration) % 3600) / 60
-            if hours > 0 {
-                return "\(hours)h \(minutes)m"
-            }
-            return "\(minutes)m"
+            let durationMinutes = max(0, Int(e.endedAt.timeIntervalSince(e.startedAt) / 60))
+            return DurationText.short(minutes: durationMinutes)
         case .nappy(let e):
             return e.type.displayName
         }

--- a/Packages/BabyTrackerDomain/Tests/BabyTrackerDomainTests/DurationTextTests.swift
+++ b/Packages/BabyTrackerDomain/Tests/BabyTrackerDomainTests/DurationTextTests.swift
@@ -1,0 +1,18 @@
+import BabyTrackerDomain
+import Testing
+
+struct DurationTextTests {
+    @Test
+    func shortFormatterSwitchesToHoursAtSixtyMinutes() {
+        #expect(DurationText.short(minutes: 59, minuteStyle: .word) == "59 min")
+        #expect(DurationText.short(minutes: 60, minuteStyle: .word) == "1h")
+        #expect(DurationText.short(minutes: 75, minuteStyle: .word) == "1h 15m")
+    }
+
+    @Test
+    func spokenFormatterUsesHourAndMinuteWords() {
+        #expect(DurationText.spoken(minutes: 1) == "1 minute")
+        #expect(DurationText.spoken(minutes: 60) == "1 hour")
+        #expect(DurationText.spoken(minutes: 125) == "2 hours 5 minutes")
+    }
+}

--- a/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/AppModel.swift
+++ b/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/AppModel.swift
@@ -1247,7 +1247,7 @@ public final class AppModel {
         case let .breastFeed(feed):
             let durationMinutes = max(1, Int(feed.endedAt.timeIntervalSince(feed.startedAt) / 60))
             return (
-                title: "\(durationMinutes) min",
+                title: DurationText.short(minutes: durationMinutes, minuteStyle: .word),
                 detailText: "",
                 timeText: ""
             )
@@ -1257,18 +1257,7 @@ public final class AppModel {
     private func sleepDurationText(for sleep: SleepEvent) -> String {
         let end = sleep.endedAt ?? .now
         let durationMinutes = max(1, Int(end.timeIntervalSince(sleep.startedAt) / 60))
-        let hours = durationMinutes / 60
-        let minutes = durationMinutes % 60
-
-        if hours > 0, minutes > 0 {
-            return "\(hours)h \(minutes)m"
-        }
-
-        if hours > 0 {
-            return "\(hours)h"
-        }
-
-        return "\(minutes)m"
+        return DurationText.short(minutes: durationMinutes)
     }
 
     private func timelineNappyTypeText(for type: NappyType) -> String {

--- a/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/BabyEventPresentation.swift
+++ b/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/BabyEventPresentation.swift
@@ -70,10 +70,10 @@ public enum BabyEventPresentation {
         )
 
         guard let side = feed.side else {
-            return "\(durationMinutes) min"
+            return DurationText.short(minutes: durationMinutes, minuteStyle: .word)
         }
 
-        return "\(durationMinutes) min • \(breastSideTitle(for: side))"
+        return "\(DurationText.short(minutes: durationMinutes, minuteStyle: .word)) • \(breastSideTitle(for: side))"
     }
 
     private static func bottleFeedDetailText(
@@ -103,7 +103,7 @@ public enum BabyEventPresentation {
             1,
             Int(endedAt.timeIntervalSince(event.startedAt) / 60)
         )
-        return "\(durationMinutes) min"
+        return DurationText.short(minutes: durationMinutes, minuteStyle: .word)
     }
 
     private static func nappyDetailText(

--- a/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/RecentSleepEventViewState.swift
+++ b/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/RecentSleepEventViewState.swift
@@ -23,7 +23,7 @@ public struct RecentSleepEventViewState: Equatable, Identifiable, Sendable {
         )
         let startTimeText = sleepEvent.startedAt.formatted(date: .omitted, time: .shortened)
         let endTimeText = endedAt.formatted(date: .omitted, time: .shortened)
-        detailText = "\(durationMinutes) min • \(startTimeText)-\(endTimeText)"
+        detailText = "\(DurationText.short(minutes: durationMinutes, minuteStyle: .word)) • \(startTimeText)-\(endTimeText)"
         timestampText = endedAt.formatted(
             date: .abbreviated,
             time: .shortened

--- a/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/AdvancedSummaryView.swift
+++ b/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/AdvancedSummaryView.swift
@@ -1,3 +1,4 @@
+import BabyTrackerDomain
 import SwiftUI
 
 public struct AdvancedSummaryView: View {
@@ -102,14 +103,14 @@ public struct AdvancedSummaryView: View {
     private func sleepSection(viewState: AdvancedSummaryViewState) -> some View {
         sectionCard(title: "Sleep", tint: .indigo, symbol: "moon.zzz.fill") {
             metricRow(title: "Completed sleeps", value: "\(viewState.completedSleepCount)")
-            metricRow(title: "Total sleep", value: formatMinutes(viewState.totalSleepMinutes))
+            metricRow(title: "Total sleep", value: DurationText.short(minutes: viewState.totalSleepMinutes))
             metricRow(
                 title: "Average sleep block",
-                value: viewState.averageSleepBlockMinutes.map { formatMinutes($0) } ?? "No completed sleeps"
+                value: viewState.averageSleepBlockMinutes.map { DurationText.short(minutes: $0) } ?? "No completed sleeps"
             )
             metricRow(
                 title: "Longest sleep block",
-                value: viewState.longestSleepBlockMinutes.map { formatMinutes($0) } ?? "No completed sleeps"
+                value: viewState.longestSleepBlockMinutes.map { DurationText.short(minutes: $0) } ?? "No completed sleeps"
             )
         }
     }
@@ -233,16 +234,6 @@ public struct AdvancedSummaryView: View {
             .shadow(color: Color.black.opacity(0.05), radius: 14, y: 8)
     }
 
-    private func formatMinutes(_ minutes: Int) -> String {
-        let hours = minutes / 60
-        let remainingMinutes = minutes % 60
-
-        if hours == 0 {
-            return "\(remainingMinutes)m"
-        }
-
-        return "\(hours)h \(remainingMinutes)m"
-    }
 }
 
 #Preview {

--- a/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/BreastFeedEditorSheetView.swift
+++ b/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/BreastFeedEditorSheetView.swift
@@ -292,7 +292,7 @@ public struct BreastFeedEditorSheetView: View {
             HStack {
                 VStack(alignment: .leading, spacing: 2) {
                     Text("Left").font(.caption).foregroundStyle(.secondary)
-                    Text("\(leftMins) min").font(.subheadline.weight(.semibold)).monospacedDigit()
+                    Text(DurationText.short(minutes: leftMins, minuteStyle: .word)).font(.subheadline.weight(.semibold)).monospacedDigit()
                 }
                 Spacer()
                 if leftMins == rightMins {
@@ -301,7 +301,7 @@ public struct BreastFeedEditorSheetView: View {
                 }
                 VStack(alignment: .trailing, spacing: 2) {
                     Text("Right").font(.caption).foregroundStyle(.secondary)
-                    Text("\(rightMins) min").font(.subheadline.weight(.semibold)).monospacedDigit()
+                    Text(DurationText.short(minutes: rightMins, minuteStyle: .word)).font(.subheadline.weight(.semibold)).monospacedDigit()
                 }
             }
 
@@ -375,7 +375,7 @@ public struct BreastFeedEditorSheetView: View {
             }
             let total = leftElapsed + rightElapsed
             let mins = Int(total / 60)
-            let durationStr = mins == 0 ? "less than a minute" : "\(mins) min"
+            let durationStr = mins == 0 ? "less than a minute" : DurationText.spoken(minutes: mins)
             let hasLeft = leftElapsed > 0
             let hasRight = rightElapsed > 0
             var s = summaryVariable(childName, color: Self.eventColor)
@@ -402,7 +402,7 @@ public struct BreastFeedEditorSheetView: View {
                 s += summaryVariable(timeStr, color: Self.eventColor)
                 return s
             }
-            let durationStr = total == 1 ? "1 minute" : "\(total) minutes"
+            let durationStr = DurationText.spoken(minutes: total)
             switch side {
             case .notSet:
                 s += AttributedString(" breast fed for ")
@@ -488,7 +488,7 @@ extension BreastFeedEditorSheetView {
         navigationTitle: "Log Feed",
         primaryActionTitle: "Save",
         childName: "Robyn",
-        initialDurationMinutes: 15,
+        initialDurationMinutes: 75,
         initialEndTime: Date(),
         initialSide: .both
     ) { _, _, _, _, _ in true }

--- a/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/EventFilterView.swift
+++ b/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/EventFilterView.swift
@@ -243,10 +243,10 @@ public struct EventFilterView: View {
                 .buttonStyle(.plain)
                 .disabled(value == nil)
 
-                Text(value.map { "\($0) min" } ?? "Any")
+                Text(value.map { DurationText.short(minutes: $0, minuteStyle: .word) } ?? "Any")
                     .font(.subheadline.weight(.medium))
                     .foregroundStyle(value == nil ? .secondary : .primary)
-                    .frame(minWidth: 56)
+                    .frame(minWidth: 72)
                     .multilineTextAlignment(.center)
 
                 Button(action: onIncrement) {
@@ -414,5 +414,16 @@ extension BreastSide {
 }
 
 #Preview {
-    EventFilterView(currentFilter: .empty) { _ in }
+    EventFilterView(
+        currentFilter: EventFilter(
+            eventTypes: [],
+            nappyTypes: [],
+            milkTypes: [],
+            breastSides: [],
+            sleepMinDurationMinutes: 75,
+            sleepMaxDurationMinutes: 135,
+            occurredOnOrAfter: nil,
+            occurredOnOrBefore: nil
+        )
+    ) { _ in }
 }

--- a/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/EventHistoryView.swift
+++ b/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/EventHistoryView.swift
@@ -282,7 +282,7 @@ struct ActiveFilterPill: Identifiable {
         if let min = filter.sleepMinDurationMinutes {
             pills.append(ActiveFilterPill(
                 id: "sleepMin_\(min)",
-                label: "≥ \(min) min",
+                label: "≥ \(DurationText.short(minutes: min, minuteStyle: .word))",
                 color: BabyEventStyle.accentColor(for: .sleep),
                 criterion: .sleepMin
             ))
@@ -291,7 +291,7 @@ struct ActiveFilterPill: Identifiable {
         if let max = filter.sleepMaxDurationMinutes {
             pills.append(ActiveFilterPill(
                 id: "sleepMax_\(max)",
-                label: "≤ \(max) min",
+                label: "≤ \(DurationText.short(minutes: max, minuteStyle: .word))",
                 color: BabyEventStyle.accentColor(for: .sleep),
                 criterion: .sleepMax
             ))

--- a/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/SleepEditorSheetView.swift
+++ b/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/SleepEditorSheetView.swift
@@ -270,15 +270,7 @@ public struct SleepEditorSheetView: View {
 
     private var sleepDurationString: String {
         let mins = max(0, Int(endedAt.timeIntervalSince(startedAt) / 60))
-        let hours = mins / 60
-        let remaining = mins % 60
-        if hours > 0 {
-            return remaining > 0 ? "\(hours)h \(remaining)m" : "\(hours)h"
-        } else if mins > 0 {
-            return "\(mins) min"
-        } else {
-            return "less than a minute"
-        }
+        return mins > 0 ? DurationText.short(minutes: mins, minuteStyle: .word) : "less than a minute"
     }
 
     // MARK: - Validation
@@ -336,7 +328,7 @@ extension SleepEditorSheetView {
     SleepEditorSheetView(
         mode: .edit,
         childName: "Isla",
-        initialStartedAt: Date(timeIntervalSinceNow: -3_600),
+        initialStartedAt: Date(timeIntervalSinceNow: -7_200),
         initialEndedAt: Date(timeIntervalSinceNow: -1_800),
         endTimeInitialPreset: .custom,
         saveAction: { _, _ in true },

--- a/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/SummaryScreenView.swift
+++ b/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/SummaryScreenView.swift
@@ -1,3 +1,4 @@
+import BabyTrackerDomain
 import SwiftUI
 
 private enum SummaryTab: String, CaseIterable {
@@ -95,7 +96,7 @@ public struct SummaryScreenView: View {
         if data.bottleCount == 0 {
             subtitle = "No bottle feeds today"
         } else if let mins = data.minutesSinceLastFeed {
-            subtitle = "\(data.bottleCount) feed\(data.bottleCount == 1 ? "" : "s") • last \(formatInterval(mins)) ago"
+            subtitle = "\(data.bottleCount) feed\(data.bottleCount == 1 ? "" : "s") • last \(DurationText.short(minutes: mins)) ago"
         } else {
             subtitle = "\(data.bottleCount) feed\(data.bottleCount == 1 ? "" : "s")"
         }
@@ -112,13 +113,13 @@ public struct SummaryScreenView: View {
     private func breastCard(data: TodaySummaryData) -> some View {
         let durationText = data.breastFeedCount == 0
             ? "0m"
-            : formatMinutes(data.breastFeedTotalMinutes)
+            : DurationText.short(minutes: data.breastFeedTotalMinutes)
 
         let subtitle: String
         if data.breastFeedCount == 0 {
             subtitle = "No breast feeds today"
         } else if let interval = data.averageFeedIntervalMinutes {
-            subtitle = "\(data.breastFeedCount) feed\(data.breastFeedCount == 1 ? "" : "s") • avg \(formatInterval(interval))"
+            subtitle = "\(data.breastFeedCount) feed\(data.breastFeedCount == 1 ? "" : "s") • avg \(DurationText.short(minutes: interval))"
         } else {
             subtitle = "\(data.breastFeedCount) feed\(data.breastFeedCount == 1 ? "" : "s")"
         }
@@ -135,7 +136,7 @@ public struct SummaryScreenView: View {
     private func sleepCard(data: TodaySummaryData) -> some View {
         let totalText = data.totalSleepMinutes == 0
             ? "0m"
-            : formatMinutes(data.totalSleepMinutes)
+            : DurationText.short(minutes: data.totalSleepMinutes)
 
         let subtitle: String
         if data.totalSleepMinutes == 0 {
@@ -143,13 +144,13 @@ public struct SummaryScreenView: View {
         } else {
             var parts: [String] = []
             if data.daytimeSleepMinutes > 0 {
-                parts.append("Day \(formatMinutes(data.daytimeSleepMinutes))")
+                parts.append("Day \(DurationText.short(minutes: data.daytimeSleepMinutes))")
             }
             if data.nighttimeSleepMinutes > 0 {
-                parts.append("Night \(formatMinutes(data.nighttimeSleepMinutes))")
+                parts.append("Night \(DurationText.short(minutes: data.nighttimeSleepMinutes))")
             }
             if let longest = data.longestSleepBlockMinutes {
-                parts.append("Longest \(formatMinutes(longest))")
+                parts.append("Longest \(DurationText.short(minutes: longest))")
             }
             subtitle = parts.joined(separator: " • ")
         }
@@ -193,7 +194,7 @@ public struct SummaryScreenView: View {
                     symbol: "clock.fill",
                     tint: .orange,
                     label: "Last feed",
-                    value: "\(formatInterval(mins)) ago"
+                    value: "\(DurationText.short(minutes: mins)) ago"
                 )
                 Divider().padding(.leading, 44)
             }
@@ -203,7 +204,7 @@ public struct SummaryScreenView: View {
                     symbol: "arrow.trianglehead.clockwise",
                     tint: .orange,
                     label: "Avg feed interval",
-                    value: formatInterval(interval)
+                    value: DurationText.short(minutes: interval)
                 )
                 Divider().padding(.leading, 44)
             }
@@ -304,7 +305,7 @@ public struct SummaryScreenView: View {
 
     private func sleepChartCard(data: TrendsSummaryData) -> some View {
         let points = data.dailySleep.map { ($0.label, $0.totalMinutes) }
-        let avgText = data.avgDailySleepMinutes.map { "Avg \(formatMinutes($0))/day" }
+        let avgText = data.avgDailySleepMinutes.map { "Avg \(DurationText.short(minutes: $0))/day" }
 
         return chartCard(
             title: "Sleep",
@@ -312,7 +313,7 @@ public struct SummaryScreenView: View {
             tint: .indigo,
             subtitle: avgText ?? "No sleep logged in this period"
         ) {
-            miniBarChart(points: points, tint: .indigo, valueFormatter: { formatMinutes($0) })
+            miniBarChart(points: points, tint: .indigo, valueFormatter: { DurationText.short(minutes: $0) })
         }
     }
 
@@ -551,33 +552,6 @@ public struct SummaryScreenView: View {
             .shadow(color: Color.black.opacity(0.05), radius: 14, y: 8)
     }
 
-    // MARK: - Formatters
-
-    private func formatMinutes(_ minutes: Int) -> String {
-        let hours = minutes / 60
-        let remainder = minutes % 60
-
-        if hours == 0 {
-            return "\(remainder)m"
-        }
-
-        return "\(hours)h \(remainder)m"
-    }
-
-    private func formatInterval(_ minutes: Int) -> String {
-        let hours = minutes / 60
-        let remainder = minutes % 60
-
-        if hours == 0 {
-            return "\(remainder)m"
-        }
-
-        if remainder == 0 {
-            return "\(hours)h"
-        }
-
-        return "\(hours)h \(remainder)m"
-    }
 }
 
 // MARK: - TrendsTimeRange bridge

--- a/docs/plans/045-hour-aware-duration-formatting.md
+++ b/docs/plans/045-hour-aware-duration-formatting.md
@@ -1,0 +1,16 @@
+# 045 - Show hours for long durations
+
+## Goal
+Update user-facing duration text so displays stop showing large raw minute counts and switch to hour-aware formatting once a duration reaches one hour.
+
+## Approach
+1. Audit the feature layer for places that render durations as raw minutes.
+2. Add a shared duration formatter in `BabyTrackerFeature` so event cards, summaries, timeline items, filters, and editors all use the same hour-aware formatting rules.
+3. Keep short durations readable and preserve existing non-duration copy where possible.
+4. Update tests that assert duration text so hour-based output is covered explicitly.
+5. Run the relevant test target and mark the plan complete if the suite passes.
+
+## Verification
+1. Run the relevant `Baby TrackerTests` cases for duration formatting.
+
+- [x] Complete


### PR DESCRIPTION
## Summary
- add a shared duration formatter so 60+ minute values render with hours instead of raw minute counts
- update event, timeline, summary, filter, and editor duration text to use the shared formatter
- add formatter coverage plus test updates for hour-aware timeline and summary output

## Testing
- xcodebuild test -project "Baby Tracker.xcodeproj" -scheme "Baby Tracker" -destination "platform=iOS Simulator,id=042006BE-58B6-4B51-9FEA-3F1967D443A5" -only-testing:"Baby TrackerTests/LastEventSummaryCalculatorTests" -only-testing:"Baby TrackerTests/LastSleepSummaryCalculatorTests"
- xcodebuild test -project "Baby Tracker.xcodeproj" -scheme "Baby Tracker" -destination "platform=iOS Simulator,id=042006BE-58B6-4B51-9FEA-3F1967D443A5" -only-testing:"Baby TrackerTests/AppModelTests"

## Plan
- [docs/plans/045-hour-aware-duration-formatting.md](docs/plans/045-hour-aware-duration-formatting.md)
- No GitHub issue was created because this was a small UI formatting change.