### PR TITLE
Restore compilation for code paths that still reference UserIdentity.name

### DIFF
--- a/Packages/BabyTrackerDomain/Sources/BabyTrackerDomain/UserIdentity.swift
+++ b/Packages/BabyTrackerDomain/Sources/BabyTrackerDomain/UserIdentity.swift
@@ -6,6 +6,11 @@ public struct UserIdentity: Equatable, Identifiable, Sendable {
     public let createdAt: Date
     public var cloudKitUserRecordName: String?
 
+    @available(*, deprecated, message: "Use displayName instead.")
+    public var name: String {
+        displayName
+    }
+
     public init(
         id: UUID = UUID(),
         displayName: String,

--- a/docs/plans/045-fix-useridentity-name-compile-regression.md
+++ b/docs/plans/045-fix-useridentity-name-compile-regression.md
@@ -1,0 +1,11 @@
+# 045 Fix `UserIdentity.name` compile regression
+
+## Goal
+Restore compatibility for code paths that still reference `UserIdentity.name` so the project compiles cleanly in PR #150.
+
+## Approach
+1. Add a lightweight computed `name` property on `UserIdentity` that returns `displayName`.
+2. Mark `name` as deprecated with a message directing call sites to `displayName`.
+3. Run targeted package tests to verify the domain package still builds and tests pass.
+
+- [x] Complete


### PR DESCRIPTION
### Motivation
- Restore compilation for code paths that still reference `UserIdentity.name` (e.g. caregiver membership flow) after the `displayName` rename caused build failures in the feature package.

### Description
- Add a deprecated computed property `name` on `UserIdentity` that returns `displayName` to provide a source-compatible alias at `Packages/BabyTrackerDomain/Sources/BabyTrackerDomain/UserIdentity.swift`.
- Add a short plan documenting the change at `docs/plans/045-fix-useridentity-name-compile-regression.md` and mark it complete.

### Testing
- Ran `swift test --package-path Packages/BabyTrackerDomain`, which could not run in this environment because the package requires Swift tools `6.2.0` while the runner has `6.1.3` (toolchain mismatch blocked automated tests).
- No other automated tests were run in this environment due to the toolchain limitation; the change is a lightweight, source-compatible alias and should allow the previously failing compile errors to be resolved when built with the required toolchain.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d4c2033f00832f9c960b7e4fd5ced0)