### PR TITLE
Move latest-event selection logic into BabyTrackerDomain

### DIFF
--- a/Packages/BabyTrackerDomain/Sources/BabyTrackerDomain/UseCases/FindLatestEventUseCases.swift
+++ b/Packages/BabyTrackerDomain/Sources/BabyTrackerDomain/UseCases/FindLatestEventUseCases.swift
@@ -1,0 +1,67 @@
+import Foundation
+
+public enum FindLatestEventUseCases {
+    public static func latestEvent(from events: [BabyEvent]) -> BabyEvent? {
+        events.max { left, right in
+            left.metadata.occurredAt < right.metadata.occurredAt
+        }
+    }
+
+    public static func latestNappy(from events: [BabyEvent]) -> NappyEvent? {
+        events.compactMap { event -> NappyEvent? in
+            guard case let .nappy(nappyEvent) = event else {
+                return nil
+            }
+
+            return nappyEvent
+        }.max { left, right in
+            left.metadata.occurredAt < right.metadata.occurredAt
+        }
+    }
+
+    public static func latestSleepSummary(
+        from events: [BabyEvent],
+        activeSleep: SleepEvent? = nil
+    ) -> LatestSleepSummary? {
+        if let activeSleep {
+            return LatestSleepSummary(
+                isActive: true,
+                startedAt: activeSleep.startedAt,
+                endedAt: nil
+            )
+        }
+
+        let completedSleeps = events.compactMap { event -> SleepEvent? in
+            guard case let .sleep(sleepEvent) = event,
+                  sleepEvent.endedAt != nil else {
+                return nil
+            }
+
+            return sleepEvent
+        }
+
+        guard let lastSleep = completedSleeps.max(by: { left, right in
+            (left.endedAt ?? left.startedAt) < (right.endedAt ?? right.startedAt)
+        }) else {
+            return nil
+        }
+
+        return LatestSleepSummary(
+            isActive: false,
+            startedAt: lastSleep.startedAt,
+            endedAt: lastSleep.endedAt
+        )
+    }
+}
+
+public struct LatestSleepSummary: Equatable, Sendable {
+    public let isActive: Bool
+    public let startedAt: Date
+    public let endedAt: Date?
+
+    public init(isActive: Bool, startedAt: Date, endedAt: Date?) {
+        self.isActive = isActive
+        self.startedAt = startedAt
+        self.endedAt = endedAt
+    }
+}

--- a/Packages/BabyTrackerDomain/Tests/BabyTrackerDomainTests/FindLatestEventUseCasesTests.swift
+++ b/Packages/BabyTrackerDomain/Tests/BabyTrackerDomainTests/FindLatestEventUseCasesTests.swift
@@ -1,0 +1,107 @@
+import BabyTrackerDomain
+import Foundation
+import Testing
+
+struct FindLatestEventUseCasesTests {
+    @Test
+    func latestEventReturnsMostRecentAcrossAllKinds() throws {
+        let childID = UUID()
+        let userID = UUID()
+        let earlier = Date(timeIntervalSince1970: 1_000)
+        let later = Date(timeIntervalSince1970: 2_000)
+
+        let bottle = try BottleFeedEvent(
+            metadata: EventMetadata(
+                childID: childID,
+                occurredAt: earlier,
+                createdAt: earlier,
+                createdBy: userID
+            ),
+            amountMilliliters: 120
+        )
+
+        let nappy = try NappyEvent(
+            metadata: EventMetadata(
+                childID: childID,
+                occurredAt: later,
+                createdAt: later,
+                createdBy: userID
+            ),
+            type: .mixed
+        )
+
+        let result = FindLatestEventUseCases.latestEvent(from: [.bottleFeed(bottle), .nappy(nappy)])
+
+        #expect(result?.metadata.occurredAt == later)
+    }
+
+    @Test
+    func latestNappySkipsNonNappyEvents() throws {
+        let childID = UUID()
+        let userID = UUID()
+        let feedTime = Date(timeIntervalSince1970: 1_000)
+        let nappyTime = Date(timeIntervalSince1970: 2_000)
+
+        let feed = try BottleFeedEvent(
+            metadata: EventMetadata(
+                childID: childID,
+                occurredAt: feedTime,
+                createdAt: feedTime,
+                createdBy: userID
+            ),
+            amountMilliliters: 100
+        )
+
+        let nappy = try NappyEvent(
+            metadata: EventMetadata(
+                childID: childID,
+                occurredAt: nappyTime,
+                createdAt: nappyTime,
+                createdBy: userID
+            ),
+            type: .wee
+        )
+
+        let result = FindLatestEventUseCases.latestNappy(from: [.bottleFeed(feed), .nappy(nappy)])
+
+        #expect(result?.metadata.occurredAt == nappyTime)
+    }
+
+    @Test
+    func latestSleepSummaryPrefersActiveSleepWhenProvided() throws {
+        let childID = UUID()
+        let userID = UUID()
+        let completedEnd = Date(timeIntervalSince1970: 1_000)
+        let activeStart = Date(timeIntervalSince1970: 2_000)
+
+        let completed = try SleepEvent(
+            metadata: EventMetadata(
+                childID: childID,
+                occurredAt: completedEnd,
+                createdAt: completedEnd,
+                createdBy: userID
+            ),
+            startedAt: completedEnd.addingTimeInterval(-600),
+            endedAt: completedEnd
+        )
+
+        let active = try SleepEvent(
+            metadata: EventMetadata(
+                childID: childID,
+                occurredAt: activeStart,
+                createdAt: activeStart,
+                createdBy: userID
+            ),
+            startedAt: activeStart
+        )
+
+        let summary = FindLatestEventUseCases.latestSleepSummary(
+            from: [.sleep(completed), .sleep(active)],
+            activeSleep: active
+        )
+
+        #expect(summary?.isActive == true)
+        #expect(summary?.startedAt == activeStart)
+        #expect(summary?.endedAt == nil)
+    }
+}

--- a/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/LastEventSummaryCalculator.swift
+++ b/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/LastEventSummaryCalculator.swift
@@ -5,9 +5,7 @@ public enum LastEventSummaryCalculator {
     public static func makeSummary(
         from events: [BabyEvent]
     ) -> LastEventSummaryViewState? {
-        guard let lastEvent = events.max(by: { left, right in
-            left.metadata.occurredAt < right.metadata.occurredAt
-        }) else {
+        guard let lastEvent = FindLatestEventUseCases.latestEvent(from: events) else {
             return nil
         }
 

--- a/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/LastNappySummaryCalculator.swift
+++ b/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/LastNappySummaryCalculator.swift
@@ -5,17 +5,7 @@ public enum LastNappySummaryCalculator {
     public static func makeSummary(
         from events: [BabyEvent]
     ) -> LastNappySummaryViewState? {
-        let nappyEvents = events.compactMap { event -> NappyEvent? in
-            guard case let .nappy(nappyEvent) = event else {
-                return nil
-            }
-
-            return nappyEvent
-        }
-
-        guard let lastNappy = nappyEvents.max(by: { left, right in
-            left.metadata.occurredAt < right.metadata.occurredAt
-        }) else {
+        guard let lastNappy = FindLatestEventUseCases.latestNappy(from: events) else {
             return nil
         }
 

--- a/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/LastSleepSummaryCalculator.swift
+++ b/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/LastSleepSummaryCalculator.swift
@@ -6,33 +6,17 @@ public enum LastSleepSummaryCalculator {
         from events: [BabyEvent],
         activeSleep: SleepEvent? = nil
     ) -> LastSleepSummaryViewState? {
-        if let activeSleep {
-            return LastSleepSummaryViewState(
-                isActive: true,
-                startedAt: activeSleep.startedAt,
-                endedAt: nil
-            )
-        }
-
-        let completedSleeps = events.compactMap { event -> SleepEvent? in
-            guard case let .sleep(sleepEvent) = event,
-                  sleepEvent.endedAt != nil else {
-                return nil
-            }
-
-            return sleepEvent
-        }
-
-        guard let lastSleep = completedSleeps.max(by: { left, right in
-            (left.endedAt ?? left.startedAt) < (right.endedAt ?? right.startedAt)
-        }) else {
+        guard let summary = FindLatestEventUseCases.latestSleepSummary(
+            from: events,
+            activeSleep: activeSleep
+        ) else {
             return nil
         }
 
         return LastSleepSummaryViewState(
-            isActive: false,
-            startedAt: lastSleep.startedAt,
-            endedAt: lastSleep.endedAt
+            isActive: summary.isActive,
+            startedAt: summary.startedAt,
+            endedAt: summary.endedAt
         )
     }
 }

--- a/docs/plans/049-domain-boundary-latest-event-selection.md
+++ b/docs/plans/049-domain-boundary-latest-event-selection.md
@@ -1,0 +1,11 @@
+# 049 - Domain boundary for latest event selection
+
+## Goal
+Move event-selection logic that does not require presentation formatting into the domain layer so it can be reused by pure Swift use cases and tested independently of UI state types.
+
+## Approach
+1. Add domain use cases for selecting the latest event, latest nappy event, and latest sleep summary.
+2. Update feature-layer summary calculators to delegate event-selection logic to the domain use cases while keeping presentation formatting in feature.
+3. Add domain tests that cover the new selection use cases.
+
+- [x] Complete


### PR DESCRIPTION
### Motivation
- Extract pure event-selection logic into the domain layer so selection behavior can be reused by pure-Swift use cases and tested without presentation concerns.
- Raise the abstraction boundary so presentation code (`BabyTrackerFeature`) only handles formatting while the domain (`BabyTrackerDomain`) owns decision logic and value types.

### Description
- Add `FindLatestEventUseCases` with `latestEvent(from:)`, `latestNappy(from:)`, and `latestSleepSummary(from:activeSleep:)` in `Packages/BabyTrackerDomain/Sources/BabyTrackerDomain/UseCases/FindLatestEventUseCases.swift` and introduce the `LatestSleepSummary` value type.
- Update feature-layer calculators (`LastEventSummaryCalculator`, `LastNappySummaryCalculator`, `LastSleepSummaryCalculator`) to delegate selection to the new domain use cases while keeping presentation formatting via `BabyEventPresentation` in the feature package.
- Add domain unit tests in `Packages/BabyTrackerDomain/Tests/BabyTrackerDomainTests/FindLatestEventUseCasesTests.swift` that cover latest-event, latest-nappy, and active-sleep preference behavior.
- Add plan documentation `docs/plans/049-domain-boundary-latest-event-selection.md` describing the change and mark it complete.

### Testing
- Added domain tests in `Packages/BabyTrackerDomain/Tests/BabyTrackerDomainTests/FindLatestEventUseCasesTests.swift` (these tests exercise `FindLatestEventUseCases`).
- Attempted to run `swift test --package-path Packages/BabyTrackerDomain` but the run failed due to a Swift tools version mismatch (`Package` requires 6.2 while the environment has 6.1.3), so tests were not executed in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d726aecd64832f99a33cee5c3d82b4)