### PR TITLE
Introduce DependencyContainer and centralize AppContainer wiring

### DIFF
--- a/Baby Tracker/App/AppContainer.swift
+++ b/Baby Tracker/App/AppContainer.swift
@@ -11,40 +11,56 @@ struct AppContainer {
 
     init(processInfo: ProcessInfo = .processInfo) {
         let launchConfiguration = LaunchConfiguration(processInfo: processInfo)
-        let userDefaults = launchConfiguration.makeUserDefaults()
-        let store = try! BabyTrackerModelStore(
-            isStoredInMemoryOnly: launchConfiguration.usesInMemoryStore
+        self = Self.makeContainer(launchConfiguration: launchConfiguration)
+    }
+
+    static let live = AppContainer()
+
+    static let preview: AppContainer = {
+        let previewLaunchConfiguration = LaunchConfiguration(
+            usesInMemoryStore: true,
+            userDefaultsSuiteName: "BabyTrackerPreview",
+            scenario: .mixedEventsPreview
         )
-        let childRepository = SwiftDataChildRepository(store: store)
-        let userIdentityRepository = SwiftDataUserIdentityRepository(store: store, userDefaults: userDefaults)
-        let membershipRepository = SwiftDataMembershipRepository(store: store)
-        let childSelectionStore = UserDefaultsChildSelectionStore(userDefaults: userDefaults)
-        let eventRepository = SwiftDataEventRepository(store: store)
-        let syncStateRepository = SwiftDataSyncStateRepository(store: store)
-        let recordMetadataRepository = SwiftDataCloudKitRecordMetadataRepository(store: store)
-        let liveActivityPreferenceStore = UserDefaultsLiveActivityPreferenceStore(userDefaults: userDefaults)
+        return Self.makeContainer(
+            launchConfiguration: previewLaunchConfiguration,
+            configureDependencies: { dependencies in
+                dependencies.register(.cloudKitClient, value: UnavailableCloudKitClient())
+                dependencies.register(.liveActivityManager, value: NoOpFeedLiveActivityManager())
+                dependencies.register(.localNotificationManager, value: NoOpLocalNotificationManager())
+                dependencies.register(.hapticFeedbackProvider, value: NoOpHapticFeedbackProvider())
+            }
+        )
+    }()
 
-        if let scenario = launchConfiguration.scenario {
-            try? Self.seed(
-                scenario: scenario,
-                childRepository: childRepository,
-                userIdentityRepository: userIdentityRepository,
-                membershipRepository: membershipRepository,
-                childSelectionStore: childSelectionStore,
-                eventRepository: eventRepository
-            )
-        }
+    private init(
+        appModel: AppModel,
+        shareAcceptanceHandler: ShareAcceptanceHandler
+    ) {
+        self.appModel = appModel
+        self.shareAcceptanceHandler = shareAcceptanceHandler
+    }
 
-        let cloudKitClient: any CloudKitClient = launchConfiguration.usesUnavailableCloudKitClient ?
-            UnavailableCloudKitClient() :
-            LiveCloudKitClient()
-        let liveActivityManager: any FeedLiveActivityManaging = launchConfiguration.usesNoOpLiveActivities ?
-            NoOpFeedLiveActivityManager() :
-            FeedLiveActivityManager()
-        let localNotificationManager: any LocalNotificationManaging = launchConfiguration.usesUnavailableCloudKitClient ?
-            NoOpLocalNotificationManager() :
-            SystemLocalNotificationManager()
-        let hapticFeedbackProvider: any HapticFeedbackProviding = SystemHapticFeedbackProvider()
+    private static func makeContainer(
+        launchConfiguration: LaunchConfiguration,
+        configureDependencies: ((inout DependencyContainer) -> Void)? = nil
+    ) -> AppContainer {
+        var dependencies = makeDependencies(launchConfiguration: launchConfiguration)
+        configureDependencies?(&dependencies)
+
+        let childRepository: SwiftDataChildRepository = dependencies.resolve(.childRepository)
+        let userIdentityRepository: SwiftDataUserIdentityRepository = dependencies.resolve(.userIdentityRepository)
+        let membershipRepository: SwiftDataMembershipRepository = dependencies.resolve(.membershipRepository)
+        let childSelectionStore: UserDefaultsChildSelectionStore = dependencies.resolve(.childSelectionStore)
+        let eventRepository: SwiftDataEventRepository = dependencies.resolve(.eventRepository)
+        let syncStateRepository: SwiftDataSyncStateRepository = dependencies.resolve(.syncStateRepository)
+        let recordMetadataRepository: SwiftDataCloudKitRecordMetadataRepository = dependencies.resolve(.recordMetadataRepository)
+        let liveActivityPreferenceStore: UserDefaultsLiveActivityPreferenceStore = dependencies.resolve(.liveActivityPreferenceStore)
+        let cloudKitClient: any CloudKitClient = dependencies.resolve(.cloudKitClient)
+        let liveActivityManager: any FeedLiveActivityManaging = dependencies.resolve(.liveActivityManager)
+        let localNotificationManager: any LocalNotificationManaging = dependencies.resolve(.localNotificationManager)
+        let hapticFeedbackProvider: any HapticFeedbackProviding = dependencies.resolve(.hapticFeedbackProvider)
+
         let syncEngine = CloudKitSyncEngine(
             childRepository: childRepository,
             userIdentityRepository: userIdentityRepository,
@@ -80,21 +96,20 @@ struct AppContainer {
         )
         appModel.load(performLaunchSync: !launchConfiguration.skipsLaunchSync)
 
-        self.appModel = appModel
-        self.shareAcceptanceHandler = shareAcceptanceHandler
+        return AppContainer(
+            appModel: appModel,
+            shareAcceptanceHandler: shareAcceptanceHandler
+        )
     }
 
-    static let live = AppContainer()
-
-    static let preview: AppContainer = {
-        let processInfo = ProcessInfo.processInfo
-        let launchConfiguration = LaunchConfiguration(
-            usesInMemoryStore: true,
-            userDefaultsSuiteName: "BabyTrackerPreview",
-            scenario: .mixedEventsPreview
-        )
+    private static func makeDependencies(
+        launchConfiguration: LaunchConfiguration
+    ) -> DependencyContainer {
+        var dependencies = DependencyContainer()
         let userDefaults = launchConfiguration.makeUserDefaults()
-        let store = try! BabyTrackerModelStore(isStoredInMemoryOnly: true)
+        let store = try! BabyTrackerModelStore(
+            isStoredInMemoryOnly: launchConfiguration.usesInMemoryStore
+        )
         let childRepository = SwiftDataChildRepository(store: store)
         let userIdentityRepository = SwiftDataUserIdentityRepository(store: store, userDefaults: userDefaults)
         let membershipRepository = SwiftDataMembershipRepository(store: store)
@@ -104,63 +119,46 @@ struct AppContainer {
         let recordMetadataRepository = SwiftDataCloudKitRecordMetadataRepository(store: store)
         let liveActivityPreferenceStore = UserDefaultsLiveActivityPreferenceStore(userDefaults: userDefaults)
 
-        try? seed(
-            scenario: .mixedEventsPreview,
-            childRepository: childRepository,
-            userIdentityRepository: userIdentityRepository,
-            membershipRepository: membershipRepository,
-            childSelectionStore: childSelectionStore,
-            eventRepository: eventRepository
-        )
+        if let scenario = launchConfiguration.scenario {
+            try? seed(
+                scenario: scenario,
+                childRepository: childRepository,
+                userIdentityRepository: userIdentityRepository,
+                membershipRepository: membershipRepository,
+                childSelectionStore: childSelectionStore,
+                eventRepository: eventRepository
+            )
+        }
 
-        let syncEngine = CloudKitSyncEngine(
-            childRepository: childRepository,
-            userIdentityRepository: userIdentityRepository,
-            membershipRepository: membershipRepository,
-            eventRepository: eventRepository,
-            syncStateRepository: syncStateRepository,
-            recordMetadataRepository: recordMetadataRepository,
-            client: UnavailableCloudKitClient()
+        dependencies.register(.childRepository, value: childRepository)
+        dependencies.register(.userIdentityRepository, value: userIdentityRepository)
+        dependencies.register(.membershipRepository, value: membershipRepository)
+        dependencies.register(.childSelectionStore, value: childSelectionStore)
+        dependencies.register(.eventRepository, value: eventRepository)
+        dependencies.register(.syncStateRepository, value: syncStateRepository)
+        dependencies.register(.recordMetadataRepository, value: recordMetadataRepository)
+        dependencies.register(.liveActivityPreferenceStore, value: liveActivityPreferenceStore)
+        dependencies.register(
+            .cloudKitClient,
+            value: launchConfiguration.usesUnavailableCloudKitClient ?
+                UnavailableCloudKitClient() :
+                LiveCloudKitClient()
         )
-        let appModel = AppModel(
-            childRepository: childRepository,
-            userIdentityRepository: userIdentityRepository,
-            membershipRepository: membershipRepository,
-            childSelectionStore: childSelectionStore,
-            eventRepository: eventRepository,
-            syncEngine: syncEngine,
-            liveActivityManager: NoOpFeedLiveActivityManager(),
-            liveActivityPreferenceStore: liveActivityPreferenceStore,
-            localNotificationManager: NoOpLocalNotificationManager(),
-            hapticFeedbackProvider: NoOpHapticFeedbackProvider()
+        dependencies.register(
+            .liveActivityManager,
+            value: launchConfiguration.usesNoOpLiveActivities ?
+                NoOpFeedLiveActivityManager() :
+                FeedLiveActivityManager()
         )
-        let shareAcceptanceHandler = ShareAcceptanceHandler(
-            syncEngine: syncEngine,
-            onStartAcceptingShare: {
-                appModel.beginAcceptingSharedChild()
-            },
-            onAcceptedShare: {
-                appModel.completeAcceptingSharedChild()
-            },
-            onFailedToAcceptShare: { error in
-                appModel.failAcceptingSharedChild(error)
-            }
+        dependencies.register(
+            .localNotificationManager,
+            value: launchConfiguration.usesUnavailableCloudKitClient ?
+                NoOpLocalNotificationManager() :
+                SystemLocalNotificationManager()
         )
-        appModel.load()
+        dependencies.register(.hapticFeedbackProvider, value: SystemHapticFeedbackProvider())
 
-        _ = processInfo
-        return AppContainer(
-            appModel: appModel,
-            shareAcceptanceHandler: shareAcceptanceHandler
-        )
-    }()
-
-    private init(
-        appModel: AppModel,
-        shareAcceptanceHandler: ShareAcceptanceHandler
-    ) {
-        self.appModel = appModel
-        self.shareAcceptanceHandler = shareAcceptanceHandler
+        return dependencies
     }
 
     private static func seed(

--- a/Baby Tracker/App/DependencyContainer.swift
+++ b/Baby Tracker/App/DependencyContainer.swift
@@ -1,0 +1,45 @@
+import BabyTrackerDomain
+import BabyTrackerFeature
+import BabyTrackerPersistence
+import BabyTrackerSync
+import Foundation
+
+struct DependencyKey<Value> {
+    let name: String
+
+    init(_ name: String) {
+        self.name = name
+    }
+}
+
+struct DependencyContainer {
+    private var registrations: [String: Any] = [:]
+
+    mutating func register<Value>(_ key: DependencyKey<Value>, value: Value) {
+        registrations[key.name] = value
+    }
+
+    func resolve<Value>(_ key: DependencyKey<Value>) -> Value {
+        guard let value = registrations[key.name] as? Value else {
+            fatalError("Dependency not registered for key: \(key.name)")
+        }
+
+        return value
+    }
+}
+
+extension DependencyKey {
+    static let childRepository = DependencyKey<SwiftDataChildRepository>("childRepository")
+    static let userIdentityRepository = DependencyKey<SwiftDataUserIdentityRepository>("userIdentityRepository")
+    static let membershipRepository = DependencyKey<SwiftDataMembershipRepository>("membershipRepository")
+    static let childSelectionStore = DependencyKey<UserDefaultsChildSelectionStore>("childSelectionStore")
+    static let eventRepository = DependencyKey<SwiftDataEventRepository>("eventRepository")
+    static let syncStateRepository = DependencyKey<SwiftDataSyncStateRepository>("syncStateRepository")
+    static let recordMetadataRepository = DependencyKey<SwiftDataCloudKitRecordMetadataRepository>("recordMetadataRepository")
+    static let liveActivityPreferenceStore = DependencyKey<UserDefaultsLiveActivityPreferenceStore>("liveActivityPreferenceStore")
+
+    static let cloudKitClient = DependencyKey<any CloudKitClient>("cloudKitClient")
+    static let liveActivityManager = DependencyKey<any FeedLiveActivityManaging>("liveActivityManager")
+    static let localNotificationManager = DependencyKey<any LocalNotificationManaging>("localNotificationManager")
+    static let hapticFeedbackProvider = DependencyKey<any HapticFeedbackProviding>("hapticFeedbackProvider")
+}

--- a/docs/plans/049-dependency-container-improvements.md
+++ b/docs/plans/049-dependency-container-improvements.md
@@ -1,0 +1,12 @@
+# 049 Dependency Container Improvements
+
+## Goal
+Make app dependency wiring easier to maintain and easier to customize for tests and SwiftUI previews.
+
+## Approach
+1. Add a small dependency container type that supports explicit register and resolve operations.
+2. Refactor `AppContainer` to build dependencies once and resolve them when constructing `AppModel` and share acceptance handling.
+3. Keep default launch behavior unchanged while allowing preview-specific overrides without duplicating the full dependency wiring block.
+4. Run focused tests to verify the app and feature package still build and pass relevant tests.
+
+- [x] Complete


### PR DESCRIPTION
### Motivation

- Reduce duplicated startup wiring and make it straightforward to swap implementations for testing and SwiftUI previews.
- Provide an explicit, easy-to-use register/resolve API so dependencies can be configured in one place and overridden where needed.

### Description

- Add a lightweight `DependencyContainer` with typed `DependencyKey` entries and `register`/`resolve` semantics (new file `Baby Tracker/App/DependencyContainer.swift`).
- Refactor `AppContainer` to build a single `DependencyContainer` via `makeDependencies` and construct the runtime `AppModel`/`ShareAcceptanceHandler` by resolving from that container (`makeContainer`), replacing duplicated wiring.
- Allow targeted overrides for previews and tests via an optional `configureDependencies` closure passed to `makeContainer`, so preview behavior no longer duplicates the full wiring block (`AppContainer.swift` changes).
- Add a short plan document describing the change at `docs/plans/049-dependency-container-improvements.md` and mark it complete.

### Testing

- Ran `swift test --package-path Packages/BabyTrackerDomain`, which failed in this environment due to a Swift tools version mismatch (package requires Swift 6.2.0; environment has Swift 6.1.3).
- Attempted `xcodebuild -list -project 'Baby Tracker.xcodeproj'`, which could not run in this environment because `xcodebuild` is not available.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d726d326c4832faccb43295ff4173a)