### PR TITLE
[codex] Requested UI settings polish

### DIFF
--- a/Baby Tracker/App/AppRootView.swift
+++ b/Baby Tracker/App/AppRootView.swift
@@ -80,7 +80,6 @@ struct AppRootView: View {
             }
 
             model.selectChild(id: childID)
-            model.requestSleepSheetPresentation()
         }
         .safeAreaInset(edge: .bottom) {
             VStack(spacing: 8) {

--- a/Baby TrackerTests/HelpFAQContentTests.swift
+++ b/Baby TrackerTests/HelpFAQContentTests.swift
@@ -3,23 +3,25 @@ import Testing
 
 struct HelpFAQContentTests {
     @Test
-    func faqContentCoversSummarySharingAndExportTopics() {
+    func faqContentCoversCurrentSummarySharingAndExportTopics() {
         let titles = HelpFAQContent.sections.map(\.title)
 
-        #expect(titles.contains("Summary and Ranges"))
+        #expect(titles.contains("Summary, Today, and Trends"))
         #expect(titles.contains("Sharing and Caregiver Access"))
         #expect(titles.contains("Exporting and Talking to a Clinician"))
     }
 
     @Test
-    func faqItemsUseCurrentSummaryTerminology() {
+    func faqItemsUseCurrentNavigationAndSummaryTerminology() {
         let answers = HelpFAQContent.sections
             .flatMap(\.items)
             .map(\.answer)
             .joined(separator: " ")
 
+        #expect(answers.contains("Today"))
+        #expect(answers.contains("Trends"))
         #expect(answers.contains("More Information"))
-        #expect(answers.contains("specific day"))
-        #expect(answers.contains("Export Data"))
+        #expect(answers.contains("Sharing & Caregivers"))
+        #expect(answers.contains("App Settings > Export Data"))
     }
 }

--- a/Baby TrackerTests/RelativeSyncTextFormatterTests.swift
+++ b/Baby TrackerTests/RelativeSyncTextFormatterTests.swift
@@ -1,0 +1,32 @@
+import BabyTrackerFeature
+import Foundation
+import Testing
+
+struct RelativeSyncTextFormatterTests {
+    @Test
+    func lastSyncedTextUsesAgoForPastDates() {
+        let referenceDate = Date(timeIntervalSince1970: 1_000)
+        let lastSyncedAt = Date(timeIntervalSince1970: 940)
+
+        let text = RelativeSyncTextFormatter.lastSyncedText(
+            for: lastSyncedAt,
+            relativeTo: referenceDate
+        )
+
+        #expect(text.contains("Last Synced:"))
+        #expect(text.contains("ago"))
+    }
+
+    @Test
+    func lastSyncedTextClampsFutureDatesToJustNow() {
+        let referenceDate = Date(timeIntervalSince1970: 1_000)
+        let lastSyncedAt = Date(timeIntervalSince1970: 1_060)
+
+        let text = RelativeSyncTextFormatter.lastSyncedText(
+            for: lastSyncedAt,
+            relativeTo: referenceDate
+        )
+
+        #expect(text == "Last Synced: just now")
+    }
+}

--- a/Packages/BabyTrackerDomain/Sources/BabyTrackerDomain/UseCases/UpdateLocalUserUseCase.swift
+++ b/Packages/BabyTrackerDomain/Sources/BabyTrackerDomain/UseCases/UpdateLocalUserUseCase.swift
@@ -1,0 +1,37 @@
+import Foundation
+
+@MainActor
+public struct UpdateLocalUserUseCase: UseCase {
+    public struct Input {
+        public let displayName: String
+
+        public init(displayName: String) {
+            self.displayName = displayName
+        }
+    }
+
+    private let userIdentityRepository: any UserIdentityRepository
+    private let hapticFeedbackProvider: any HapticFeedbackProviding
+
+    public init(
+        userIdentityRepository: any UserIdentityRepository,
+        hapticFeedbackProvider: any HapticFeedbackProviding = NoOpHapticFeedbackProvider()
+    ) {
+        self.userIdentityRepository = userIdentityRepository
+        self.hapticFeedbackProvider = hapticFeedbackProvider
+    }
+
+    public func execute(_ input: Input) throws -> UserIdentity {
+        guard let localUser = try userIdentityRepository.loadLocalUser() else {
+            throw ChildProfileValidationError.insufficientPermissions
+        }
+
+        let updatedUser = try localUser.updating(
+            displayName: input.displayName,
+            cloudKitUserRecordName: localUser.cloudKitUserRecordName
+        )
+        try userIdentityRepository.saveLocalUser(updatedUser)
+        hapticFeedbackProvider.play(.actionSucceeded)
+        return updatedUser
+    }
+}

--- a/Packages/BabyTrackerDomain/Tests/BabyTrackerDomainTests/UpdateLocalUserUseCaseTests.swift
+++ b/Packages/BabyTrackerDomain/Tests/BabyTrackerDomainTests/UpdateLocalUserUseCaseTests.swift
@@ -1,0 +1,65 @@
+import Foundation
+import Testing
+@testable import BabyTrackerDomain
+
+@MainActor
+struct UpdateLocalUserUseCaseTests {
+    @Test
+    func updatesSavedLocalUserDisplayName() throws {
+        let repository = InMemoryUserIdentityRepository()
+        let existingUser = try UserIdentity(
+            displayName: "Alex Parent",
+            cloudKitUserRecordName: "icloud-user"
+        )
+        try repository.saveLocalUser(existingUser)
+
+        let updatedUser = try UpdateLocalUserUseCase(
+            userIdentityRepository: repository
+        ).execute(.init(displayName: "Sam Parent"))
+
+        #expect(updatedUser.displayName == "Sam Parent")
+        #expect(updatedUser.cloudKitUserRecordName == "icloud-user")
+        #expect(try repository.loadLocalUser()?.displayName == "Sam Parent")
+    }
+
+    @Test
+    func throwsWhenNoLocalUserExists() {
+        let repository = InMemoryUserIdentityRepository()
+
+        #expect(throws: ChildProfileValidationError.insufficientPermissions) {
+            try UpdateLocalUserUseCase(
+                userIdentityRepository: repository
+            ).execute(.init(displayName: "Sam Parent"))
+        }
+    }
+}
+
+@MainActor
+private final class InMemoryUserIdentityRepository: UserIdentityRepository {
+    private var localUser: UserIdentity?
+    private var usersByID: [UUID: UserIdentity] = [:]
+
+    func loadLocalUser() throws -> UserIdentity? {
+        localUser
+    }
+
+    func saveLocalUser(_ user: UserIdentity) throws {
+        localUser = user
+        usersByID[user.id] = user
+    }
+
+    func loadUsers(for userIDs: [UUID]) throws -> [UserIdentity] {
+        userIDs.compactMap { usersByID[$0] }
+    }
+
+    func saveUser(_ user: UserIdentity) throws {
+        usersByID[user.id] = user
+    }
+
+    func removeLegacyPlaceholderCaregivers() throws {}
+
+    func resetAllData() throws {
+        localUser = nil
+        usersByID.removeAll()
+    }
+}

--- a/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/AppModel.swift
+++ b/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/AppModel.swift
@@ -315,6 +315,17 @@ public final class AppModel {
         }
     }
 
+    @discardableResult
+    public func updateLocalUserName(displayName: String) -> Bool {
+        perform {
+            _ = try UpdateLocalUserUseCase(
+                userIdentityRepository: userIdentityRepository,
+                hapticFeedbackProvider: hapticFeedbackProvider
+            )
+            .execute(.init(displayName: displayName))
+        }
+    }
+
     public func createChild(name: String, birthDate: Date?, imageData: Data? = nil) {
         let succeeded = perform {
             guard let localUser else { return }

--- a/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/HelpFAQContent.swift
+++ b/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/HelpFAQContent.swift
@@ -3,12 +3,12 @@ import Foundation
 public enum HelpFAQContent {
     public static let sections: [HelpFAQSection] = [
         HelpFAQSection(
-            title: "Summary and Ranges",
+            title: "Summary, Today, and Trends",
             items: [
                 HelpFAQItem(
                     id: "summary-range-picker",
-                    title: "What does the Summary range picker change?",
-                    answer: "The range picker filters the events used in the Summary tab. Today shows only today's logs, 7 Days and 30 Days show recent history, and All Time includes everything saved for the selected child."
+                    title: "How do Today and Trends work in Summary?",
+                    answer: "The Summary tab has two views. Today focuses on the current day, while Trends groups recent history into 7 Days, 30 Days, or All Time for the selected child."
                 ),
                 HelpFAQItem(
                     id: "summary-more-information",
@@ -18,7 +18,7 @@ public enum HelpFAQContent {
                 HelpFAQItem(
                     id: "summary-streaks-averages",
                     title: "How are streaks and averages calculated?",
-                    answer: "The logging streak counts consecutive days with at least one saved event. Averages use the events in the current selection only, so they will change when you pick a different range or a specific day."
+                    answer: "The logging streak counts consecutive days with at least one saved event. Trends averages use only the events inside the current range, so they change when you pick 7 Days, 30 Days, All Time, or a specific day in More Information."
                 ),
             ]
         ),
@@ -33,7 +33,7 @@ public enum HelpFAQContent {
                 HelpFAQItem(
                     id: "sleep",
                     title: "How should I read the sleep metrics?",
-                    answer: "Sleep totals, averages, and longest-block values come from completed sleep sessions in the selected period. Active sleep sessions are shown in the app, but they do not affect finished-summary averages until they end."
+                    answer: "Sleep totals, averages, and longest-block values come from completed sleep sessions in the selected period. Active sleep sessions still appear around the app, but they do not affect finished summary totals until they end."
                 ),
                 HelpFAQItem(
                     id: "nappies",
@@ -48,7 +48,7 @@ public enum HelpFAQContent {
                 HelpFAQItem(
                     id: "sharing",
                     title: "How does caregiver sharing work?",
-                    answer: "Sharing uses iCloud so another caregiver can work from the same child timeline. If sharing is unavailable, local data still stays on the device and you can review sync details from Profile > Sharing or iCloud Sync."
+                    answer: "Sharing uses iCloud so another caregiver can work from the same child timeline. If sharing is unavailable, local data still stays on the device and you can review sync details from Profile > Sharing & Caregivers or Profile > App Settings > Sync Status."
                 ),
                 HelpFAQItem(
                     id: "switching-children",
@@ -63,7 +63,7 @@ public enum HelpFAQContent {
                 HelpFAQItem(
                     id: "export-data",
                     title: "How do I export data?",
-                    answer: "Open Profile > Settings > Export Data to prepare a file you can share. Export gives you the recorded information for the selected child so you can keep a copy or bring it into another workflow."
+                    answer: "Open Profile > App Settings > Export Data to prepare a file you can share. Export gives you the recorded information for the selected child so you can keep a copy or bring it into another workflow."
                 ),
                 HelpFAQItem(
                     id: "clinician",

--- a/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/RelativeSyncTextFormatter.swift
+++ b/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/RelativeSyncTextFormatter.swift
@@ -1,0 +1,16 @@
+import Foundation
+
+public enum RelativeSyncTextFormatter {
+    public static func lastSyncedText(
+        for date: Date,
+        relativeTo referenceDate: Date
+    ) -> String {
+        guard date <= referenceDate else {
+            return "Last Synced: just now"
+        }
+
+        let formatter = RelativeDateTimeFormatter()
+        let relativeText = formatter.localizedString(for: date, relativeTo: referenceDate)
+        return "Last Synced: \(relativeText)"
+    }
+}

--- a/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/ChildHomeView.swift
+++ b/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/ChildHomeView.swift
@@ -257,8 +257,7 @@ public struct ChildHomeView: View {
         for date: Date,
         relativeTo referenceDate: Date
     ) -> String {
-        let formatter = RelativeDateTimeFormatter()
-        return "Last synced \(formatter.localizedString(for: date, relativeTo: referenceDate))"
+        RelativeSyncTextFormatter.lastSyncedText(for: date, relativeTo: referenceDate)
     }
 }
 

--- a/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/ChildProfileSyncView.swift
+++ b/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/ChildProfileSyncView.swift
@@ -42,8 +42,10 @@ public struct ChildProfileSyncView: View {
                 }
 
                 if let lastSyncAt = viewModel.cloudKitStatus.lastSyncAt {
-                    LabeledContent("Last Sync") {
-                        Text(lastSyncAt, format: .dateTime.month(.abbreviated).day().hour().minute())
+                    TimelineView(.everyMinute) { context in
+                        LabeledContent("Last Synced") {
+                            Text(RelativeSyncTextFormatter.lastSyncedText(for: lastSyncAt, relativeTo: context.date))
+                        }
                     }
                 }
 

--- a/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/ChildProfileView.swift
+++ b/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/ChildProfileView.swift
@@ -91,11 +91,19 @@ public struct ChildProfileView: View {
                     )
                 }
 
-                LabeledContent("Signed In As") {
-                    Text(viewModel.localUser?.displayName ?? "")
-                        .foregroundStyle(.secondary)
+                if let localUser = viewModel.localUser {
+                    NavigationLink {
+                        LocalUserNameEditView(initialDisplayName: localUser.displayName) { updatedName in
+                            model.updateLocalUserName(displayName: updatedName)
+                        }
+                    } label: {
+                        settingsRow(
+                            title: "Your Name",
+                            value: localUser.displayName,
+                            accessibilityIdentifier: "profile-local-user-name-row"
+                        )
+                    }
                 }
-                .accessibilityIdentifier("profile-signed-in-as-row")
             }
 
             if canSelectFromMultipleChildren || canCreateLocalChild || hasArchivedChildren {

--- a/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/EventHistoryView.swift
+++ b/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/EventHistoryView.swift
@@ -195,13 +195,36 @@ public struct EventHistoryView: View {
             .font(.footnote.weight(.bold))
             .foregroundStyle(.primary)
             .textCase(.none)
-            .padding(.horizontal, 10)
-            .padding(.vertical, 4)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .padding(.horizontal, 16)
+            .padding(.vertical, 10)
             .background(
-                Capsule()
-                    .fill(Color(.tertiarySystemFill))
+                RoundedRectangle(cornerRadius: 16, style: .continuous)
+                    .fill(Color(.secondarySystemGroupedBackground))
             )
-            .padding(.vertical, 4)
+            .overlay {
+                RoundedRectangle(cornerRadius: 16, style: .continuous)
+                    .stroke(Color(.separator).opacity(0.28), lineWidth: 1)
+            }
+            .padding(.top, 8)
+            .padding(.bottom, 2)
+    }
+}
+
+#Preview {
+    NavigationStack {
+        let model = ChildProfilePreviewFactory.makeModel()
+
+        EventHistoryView(
+            viewModel: EventHistoryViewModel(appModel: model),
+            canManageEvents: true,
+            openEvent: { _ in },
+            deleteEvent: { _ in },
+            pendingDeleteEvent: nil,
+            confirmDelete: {},
+            cancelDelete: {},
+            onRefresh: {}
+        )
     }
 }
 

--- a/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/IdentityOnboardingView.swift
+++ b/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/IdentityOnboardingView.swift
@@ -14,6 +14,8 @@ public struct IdentityOnboardingView: View {
     @State private var isShowingNotificationPermissionPrompt = false
     @State private var isHandlingNotificationPermissionFlow = false
     @State private var hasShownNotificationPermissionPrompt = false
+    @State private var isContentVisible = false
+    @State private var isExiting = false
 
     private static let introPages: [OnboardingIntroPage] = [
         OnboardingIntroPage(
@@ -112,6 +114,8 @@ public struct IdentityOnboardingView: View {
                 endPoint: .bottomTrailing
             )
             .ignoresSafeArea()
+            .opacity(isContentVisible ? 1 : 0)
+            .animation(reduceMotion ? nil : .easeOut(duration: 0.3), value: isContentVisible)
 
             VStack(spacing: 0) {
                 topBar
@@ -134,6 +138,10 @@ public struct IdentityOnboardingView: View {
                     .padding(.horizontal, 24)
                     .padding(.bottom, 24)
             }
+            .opacity(contentOpacity)
+            .scaleEffect(contentScale)
+            .offset(y: contentOffsetY)
+            .allowsHitTesting(isExiting == false)
 
             if isShowingNotificationPermissionPrompt {
                 Color.black.opacity(0.22)
@@ -152,7 +160,41 @@ public struct IdentityOnboardingView: View {
         .task {
             await refreshNotificationAuthorizationStatus()
         }
+        .onAppear {
+            guard reduceMotion == false else {
+                isContentVisible = true
+                return
+            }
+
+            withAnimation(.spring(response: 0.42, dampingFraction: 0.86)) {
+                isContentVisible = true
+            }
+        }
         .animation(reduceMotion ? nil : .easeInOut(duration: 0.2), value: isShowingNotificationPermissionPrompt)
+    }
+
+    private var contentOpacity: Double {
+        isContentVisible && isExiting == false ? 1 : 0
+    }
+
+    private var contentScale: CGFloat {
+        guard reduceMotion == false else {
+            return 1
+        }
+
+        return isExiting ? 0.96 : 1
+    }
+
+    private var contentOffsetY: CGFloat {
+        guard reduceMotion == false else {
+            return 0
+        }
+
+        if isContentVisible == false {
+            return 24
+        }
+
+        return isExiting ? -18 : 0
     }
 
     private var topBar: some View {
@@ -273,7 +315,9 @@ public struct IdentityOnboardingView: View {
             return
         }
 
-        model.dismissOnboarding()
+        performExit {
+            model.dismissOnboarding()
+        }
     }
 
     private func moveToNextIntroStep() {
@@ -300,7 +344,9 @@ public struct IdentityOnboardingView: View {
             return
         }
 
-        model.createLocalUser(displayName: trimmedName)
+        performExit {
+            model.createLocalUser(displayName: trimmedName)
+        }
     }
 
     private func requestNotificationAuthorization() {
@@ -324,6 +370,31 @@ public struct IdentityOnboardingView: View {
     private func refreshNotificationAuthorizationStatus() async {
         let settings = await UNUserNotificationCenter.current().notificationSettings()
         notificationAuthorizationStatus = settings.authorizationStatus
+    }
+
+    private func performExit(_ action: @escaping () -> Void) {
+        guard isExiting == false else {
+            return
+        }
+
+        guard reduceMotion == false else {
+            action()
+            return
+        }
+
+        isExiting = true
+        withAnimation(.easeInOut(duration: 0.28)) {
+            isContentVisible = false
+        }
+
+        Task { @MainActor in
+            try? await Task.sleep(for: .milliseconds(220))
+            guard !Task.isCancelled else {
+                return
+            }
+
+            action()
+        }
     }
 }
 

--- a/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/IdentityOnboardingView.swift
+++ b/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/IdentityOnboardingView.swift
@@ -14,7 +14,7 @@ public struct IdentityOnboardingView: View {
     @State private var isShowingNotificationPermissionPrompt = false
     @State private var isHandlingNotificationPermissionFlow = false
     @State private var hasShownNotificationPermissionPrompt = false
-    @State private var isContentVisible = false
+    @State private var viewOpacity = 0.0
     @State private var isExiting = false
 
     private static let introPages: [OnboardingIntroPage] = [
@@ -114,8 +114,6 @@ public struct IdentityOnboardingView: View {
                 endPoint: .bottomTrailing
             )
             .ignoresSafeArea()
-            .opacity(isContentVisible ? 1 : 0)
-            .animation(reduceMotion ? nil : .easeOut(duration: 0.3), value: isContentVisible)
 
             VStack(spacing: 0) {
                 topBar
@@ -138,9 +136,6 @@ public struct IdentityOnboardingView: View {
                     .padding(.horizontal, 24)
                     .padding(.bottom, 24)
             }
-            .opacity(contentOpacity)
-            .scaleEffect(contentScale)
-            .offset(y: contentOffsetY)
             .allowsHitTesting(isExiting == false)
 
             if isShowingNotificationPermissionPrompt {
@@ -162,39 +157,16 @@ public struct IdentityOnboardingView: View {
         }
         .onAppear {
             guard reduceMotion == false else {
-                isContentVisible = true
+                viewOpacity = 1
                 return
             }
 
-            withAnimation(.spring(response: 0.42, dampingFraction: 0.86)) {
-                isContentVisible = true
+            withAnimation(.easeIn(duration: 0.2)) {
+                viewOpacity = 1
             }
         }
+        .opacity(viewOpacity)
         .animation(reduceMotion ? nil : .easeInOut(duration: 0.2), value: isShowingNotificationPermissionPrompt)
-    }
-
-    private var contentOpacity: Double {
-        isContentVisible && isExiting == false ? 1 : 0
-    }
-
-    private var contentScale: CGFloat {
-        guard reduceMotion == false else {
-            return 1
-        }
-
-        return isExiting ? 0.96 : 1
-    }
-
-    private var contentOffsetY: CGFloat {
-        guard reduceMotion == false else {
-            return 0
-        }
-
-        if isContentVisible == false {
-            return 24
-        }
-
-        return isExiting ? -18 : 0
     }
 
     private var topBar: some View {
@@ -383,12 +355,12 @@ public struct IdentityOnboardingView: View {
         }
 
         isExiting = true
-        withAnimation(.easeInOut(duration: 0.28)) {
-            isContentVisible = false
+        withAnimation(.easeOut(duration: 0.18)) {
+            viewOpacity = 0
         }
 
         Task { @MainActor in
-            try? await Task.sleep(for: .milliseconds(220))
+            try? await Task.sleep(for: .milliseconds(180))
             guard !Task.isCancelled else {
                 return
             }

--- a/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/LocalUserNameEditView.swift
+++ b/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/LocalUserNameEditView.swift
@@ -1,0 +1,56 @@
+import SwiftUI
+
+public struct LocalUserNameEditView: View {
+    let initialDisplayName: String
+    let saveAction: (String) -> Bool
+
+    @Environment(\.dismiss) private var dismiss
+    @State private var displayName = ""
+
+    public init(
+        initialDisplayName: String,
+        saveAction: @escaping (String) -> Bool
+    ) {
+        self.initialDisplayName = initialDisplayName
+        self.saveAction = saveAction
+    }
+
+    public var body: some View {
+        Form {
+            Section {
+                Text("Update the name shown for the active caregiver throughout sharing, event history, and sync activity.")
+                    .font(.subheadline)
+                    .foregroundStyle(.secondary)
+            }
+
+            Section("Caregiver") {
+                TextField("Your name", text: $displayName)
+                    .textInputAutocapitalization(.words)
+                    .accessibilityIdentifier("local-user-name-field")
+            }
+        }
+        .navigationTitle("Your Name")
+        .navigationBarTitleDisplayMode(.inline)
+        .toolbar {
+            ToolbarItem(placement: .confirmationAction) {
+                Button("Save") {
+                    let didSave = saveAction(displayName)
+                    if didSave {
+                        dismiss()
+                    }
+                }
+                .disabled(displayName.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
+                .accessibilityIdentifier("save-local-user-name-button")
+            }
+        }
+        .onAppear {
+            displayName = initialDisplayName
+        }
+    }
+}
+
+#Preview {
+    NavigationStack {
+        LocalUserNameEditView(initialDisplayName: "Alex Parent") { _ in true }
+    }
+}

--- a/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/SummaryScreenView.swift
+++ b/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/SummaryScreenView.swift
@@ -64,9 +64,9 @@ public struct SummaryScreenView: View {
                 )
             } else {
                 VStack(alignment: .leading, spacing: 12) {
+                    sleepSectionCard(data: data)
                     bottleSectionCard(data: data)
                     breastSectionCard(data: data)
-                    sleepSectionCard(data: data)
                     nappySectionCard(data: data)
                     advancedSummaryLink
                     loggingStreakRow(data: data)
@@ -292,9 +292,9 @@ public struct SummaryScreenView: View {
                     message: "Try a broader range to see feeding, sleep, and nappy trends."
                 )
             } else {
+                sleepChartCard(data: data)
                 bottleChartCard(data: data)
                 breastChartCard(data: data)
-                sleepChartCard(data: data)
                 nappyChartCard(data: data)
             }
         }

--- a/docs/plans/075-requested-ui-settings-polish.md
+++ b/docs/plans/075-requested-ui-settings-polish.md
@@ -1,0 +1,19 @@
+# 075 Requested UI Settings Polish
+
+GitHub issue: #177
+
+## Goal
+
+Implement the requested UI and settings refinements across live activity handling, sync wording, event history headers, summary ordering, Help & FAQ content, onboarding transitions, and caregiver profile editing.
+
+## Plan
+
+1. Stop presenting the end sleep sheet when the app opens from the live activity, while still switching to the relevant child.
+2. Change the iCloud sync status copy to display `Last Synced: {relative time ago}` and avoid future-facing wording.
+3. Replace event history date pills with full-width section headers that align the title to the leading edge.
+4. Move Sleep to the top of the Today and Trends summary layouts and review the Help & FAQ copy so it matches the current app structure and terminology.
+5. Add entrance and exit transitions for onboarding so it appears and dismisses more smoothly.
+6. Add a profile/settings flow that lets the active caregiver update their display name after onboarding.
+7. Verify the affected behavior with focused tests and a project build, then mark the plan complete.
+
+- [ ] Complete

--- a/docs/plans/075-requested-ui-settings-polish.md
+++ b/docs/plans/075-requested-ui-settings-polish.md
@@ -16,4 +16,4 @@ Implement the requested UI and settings refinements across live activity handlin
 6. Add a profile/settings flow that lets the active caregiver update their display name after onboarding.
 7. Verify the affected behavior with focused tests and a project build, then mark the plan complete.
 
-- [ ] Complete
+- [x] Complete


### PR DESCRIPTION
## Summary
This PR implements the requested UI and settings polish across live activity handling, sync copy, event history styling, summary ordering, Help & FAQ content, onboarding transitions, and caregiver profile editing.

## What Changed
- stop opening the end sleep sheet when launching from the live activity
- update iCloud sync wording to `Last Synced: ...` and avoid future-facing copy
- replace event history date pills with full-width section headers
- move Sleep to the top of the Today and Trends summaries
- refresh Help & FAQ copy to match the current app structure and terminology
- add onboarding fade transitions
- add a profile flow to rename the active caregiver after onboarding
- simplify the onboarding dismissal to a full-screen fade after follow-up review

## Why
These changes align the app with the requested behavior and reduce friction in common flows like live activity entry, sync status reading, onboarding, and caregiver profile management.

## Impact
- live activity deep links no longer interrupt the user with the sleep end sheet
- sync status reads naturally as time since last sync
- event history headers are easier to scan
- Sleep metrics are more prominent in Today and Trends
- Help content reflects the app as it exists today
- caregivers can update their own display name without clearing app data
- onboarding uses a simpler fade transition for entry and exit

## Validation
- `xcodebuild -scheme 'Baby Tracker' -destination 'generic/platform=iOS Simulator' build`
- `xcodebuild -scheme 'Baby Tracker' -destination 'platform=iOS Simulator,name=iPhone 17,OS=26.2' test -only-testing:'Baby TrackerTests/RelativeSyncTextFormatterTests'`
- `xcodebuild -scheme 'Baby Tracker' -destination 'platform=iOS Simulator,name=iPhone 17,OS=26.2' test -only-testing:'Baby TrackerTests/HelpFAQContentTests'`

## Tracking
- Closes #177
- Plan: `docs/plans/075-requested-ui-settings-polish.md`