### PR TITLE
Open end sleep sheet when tapping Live Activity End Sleep button

### DIFF
--- a/Baby Tracker/App/AppRootView.swift
+++ b/Baby Tracker/App/AppRootView.swift
@@ -80,6 +80,7 @@ struct AppRootView: View {
             }
 
             model.selectChild(id: childID)
+            model.requestSleepSheetPresentation()
         }
         .safeAreaInset(edge: .bottom) {
             VStack(spacing: 8) {


### PR DESCRIPTION
## Summary
- Tapping the "End Sleep" button on the Live Activity now opens the app **and** immediately presents the end sleep sheet
- Only triggered by the `babytracker://sleep/end` deep link (i.e. the Live Activity button); no other code paths are affected

## How it works
`AppRootView.onOpenURL` already parsed the deep link and called `model.selectChild(id:)` to navigate to the right child. The fix adds a call to `model.requestSleepSheetPresentation()` immediately after.

`AppModel.refresh` (called inside `selectChild`) is synchronous, so `activeSleep` is populated before the sleep sheet request fires. `ChildWorkspaceTabView` observes `sleepSheetRequestToken` and calls `showSleepSheet()`, which opens the end sleep sheet because an active sleep is present.

## Test plan
- [ ] Start a sleep session so a Live Activity appears
- [ ] Tap the "End Sleep" button on the Live Activity (lock screen or Dynamic Island)
- [ ] Verify the app opens and the end sleep sheet is presented immediately
- [ ] Confirm tapping elsewhere on the Live Activity does **not** open the sheet