### PR TITLE
Force-recreate live activity on app launch and after sync events

### DIFF
--- a/Baby Tracker/App/FeedLiveActivityManager.swift
+++ b/Baby Tracker/App/FeedLiveActivityManager.swift
@@ -15,6 +15,26 @@ final class FeedLiveActivityManager: FeedLiveActivityManaging {
         }
     }
 
+    func forceSync(with snapshot: FeedLiveActivitySnapshot?) {
+        synchronizationTask?.cancel()
+        synchronizationTask = Task { @MainActor [weak self] in
+            guard let self else { return }
+            await Self.endAllActivities()
+            self.activeActivityID = nil
+            guard let snapshot else { return }
+            do {
+                let activity = try Activity.request(
+                    attributes: FeedLiveActivityAttributes(childID: snapshot.childID),
+                    content: self.content(for: snapshot),
+                    pushType: nil
+                )
+                self.activeActivityID = activity.id
+            } catch {
+                self.activeActivityID = nil
+            }
+        }
+    }
+
     private func reconcile(_ snapshot: FeedLiveActivitySnapshot?) async {
         let activities = Activity<FeedLiveActivityAttributes>.activities
 

--- a/Baby TrackerTests/AppModelTests.swift
+++ b/Baby TrackerTests/AppModelTests.swift
@@ -1879,6 +1879,7 @@ extension AppModelTests {
     @MainActor
     private final class LiveActivityManagerSpy: FeedLiveActivityManaging {
         private(set) var snapshots: [FeedLiveActivitySnapshot?] = []
+        private(set) var forceSyncSnapshots: [FeedLiveActivitySnapshot?] = []
 
         var latestSnapshot: FeedLiveActivitySnapshot? {
             snapshots.last ?? nil
@@ -1886,6 +1887,10 @@ extension AppModelTests {
 
         func synchronize(with snapshot: FeedLiveActivitySnapshot?) {
             snapshots.append(snapshot)
+        }
+
+        func forceSync(with snapshot: FeedLiveActivitySnapshot?) {
+            forceSyncSnapshots.append(snapshot)
         }
     }
 

--- a/Baby TrackerTests/AppModelTests.swift
+++ b/Baby TrackerTests/AppModelTests.swift
@@ -1880,17 +1880,20 @@ extension AppModelTests {
     private final class LiveActivityManagerSpy: FeedLiveActivityManaging {
         private(set) var snapshots: [FeedLiveActivitySnapshot?] = []
         private(set) var forceSyncSnapshots: [FeedLiveActivitySnapshot?] = []
+        private var _currentSnapshot: FeedLiveActivitySnapshot?
 
         var latestSnapshot: FeedLiveActivitySnapshot? {
-            snapshots.last ?? nil
+            _currentSnapshot
         }
 
         func synchronize(with snapshot: FeedLiveActivitySnapshot?) {
             snapshots.append(snapshot)
+            _currentSnapshot = snapshot
         }
 
         func forceSync(with snapshot: FeedLiveActivitySnapshot?) {
             forceSyncSnapshots.append(snapshot)
+            _currentSnapshot = snapshot
         }
     }
 

--- a/Baby TrackerTests/UpdateFeedLiveActivityUseCaseTests.swift
+++ b/Baby TrackerTests/UpdateFeedLiveActivityUseCaseTests.swift
@@ -91,6 +91,7 @@ struct UpdateFeedLiveActivityUseCaseTests {
 @MainActor
 private final class LiveActivityManagerSpy: FeedLiveActivityManaging {
     private(set) var snapshots: [FeedLiveActivitySnapshot?] = []
+    private(set) var forceSyncSnapshots: [FeedLiveActivitySnapshot?] = []
 
     var latestSnapshot: FeedLiveActivitySnapshot? {
         snapshots.last ?? nil
@@ -98,5 +99,9 @@ private final class LiveActivityManagerSpy: FeedLiveActivityManaging {
 
     func synchronize(with snapshot: FeedLiveActivitySnapshot?) {
         snapshots.append(snapshot)
+    }
+
+    func forceSync(with snapshot: FeedLiveActivitySnapshot?) {
+        forceSyncSnapshots.append(snapshot)
     }
 }

--- a/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/AppModel.swift
+++ b/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/AppModel.swift
@@ -110,7 +110,7 @@ public final class AppModel {
     }
 
     public func load(performLaunchSync: Bool = true) {
-        refresh(selecting: nil)
+        refresh(selecting: nil, forceRecreate: true)
 
         guard performLaunchSync else {
             return
@@ -198,7 +198,7 @@ public final class AppModel {
     public func refreshAfterRemoteNotification() async -> SyncStatusSummary {
         let summary = await syncEngine.refreshAfterRemoteNotification()
         await scheduleRemoteSyncNotificationIfNeeded()
-        refresh(selecting: childSelectionStore.loadSelectedChildID())
+        refresh(selecting: childSelectionStore.loadSelectedChildID(), forceRecreate: true)
         return summary
     }
 
@@ -896,7 +896,7 @@ public final class AppModel {
         appReviewRequester.requestReview()
     }
 
-    private func refresh(selecting selectedChildID: UUID?) {
+    private func refresh(selecting selectedChildID: UUID?, forceRecreate: Bool = false) {
         do {
             localUser = try userIdentityRepository.loadLocalUser()
 
@@ -1004,7 +1004,8 @@ public final class AppModel {
                 child: currentSummary.child,
                 activeSleep: currentActiveSleep,
                 isLiveActivityEnabled: isLiveActivityEnabled,
-                liveActivityManager: liveActivityManager
+                liveActivityManager: liveActivityManager,
+                forceRecreate: forceRecreate
             )
         } catch {
             AppLogger.shared.log(.error, category: "AppModel", "refresh failed: \(error)")
@@ -1786,7 +1787,7 @@ public final class AppModel {
     ) async {
         setSyncIndicator(.syncing)
         let summary = await operation()
-        refresh(selecting: childSelectionStore.loadSelectedChildID())
+        refresh(selecting: childSelectionStore.loadSelectedChildID(), forceRecreate: true)
         updateSyncIndicator(using: summary)
     }
 

--- a/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/FeedLiveActivityManaging.swift
+++ b/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/FeedLiveActivityManaging.swift
@@ -3,4 +3,7 @@ import Foundation
 @MainActor
 public protocol FeedLiveActivityManaging: AnyObject {
     func synchronize(with snapshot: FeedLiveActivitySnapshot?)
+    /// Ends any existing activity and starts a completely fresh one from the given snapshot.
+    /// Use this on app launch and after sync events to avoid stale activity state.
+    func forceSync(with snapshot: FeedLiveActivitySnapshot?)
 }

--- a/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/NoOpFeedLiveActivityManager.swift
+++ b/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/NoOpFeedLiveActivityManager.swift
@@ -7,4 +7,8 @@ public final class NoOpFeedLiveActivityManager: FeedLiveActivityManaging {
     public func synchronize(with snapshot: FeedLiveActivitySnapshot?) {
         _ = snapshot
     }
+
+    public func forceSync(with snapshot: FeedLiveActivitySnapshot?) {
+        _ = snapshot
+    }
 }

--- a/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/UseCases/UpdateFeedLiveActivityUseCase.swift
+++ b/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/UseCases/UpdateFeedLiveActivityUseCase.swift
@@ -8,7 +8,8 @@ public enum UpdateFeedLiveActivityUseCase {
         child: Child?,
         activeSleep: SleepEvent?,
         isLiveActivityEnabled: Bool,
-        liveActivityManager: any FeedLiveActivityManaging
+        liveActivityManager: any FeedLiveActivityManaging,
+        forceRecreate: Bool = false
     ) {
         guard isLiveActivityEnabled, let child else {
             liveActivityManager.synchronize(with: nil)
@@ -20,6 +21,10 @@ public enum UpdateFeedLiveActivityUseCase {
             child: child,
             activeSleep: activeSleep
         )
-        liveActivityManager.synchronize(with: snapshot)
+        if forceRecreate {
+            liveActivityManager.forceSync(with: snapshot)
+        } else {
+            liveActivityManager.synchronize(with: snapshot)
+        }
     }
 }


### PR DESCRIPTION
Previously, refresh operations only updated the existing live activity in
place, which could leave it showing stale data. Now, app launch, foreground
transitions, and CloudKit sync completions all end the existing activity and
request a fresh one — the same behaviour as toggling the Live Activities
setting off and back on.

https://claude.ai/code/session_01JYLKGGP6dz2NiiPKYLxKsd