### PR TITLE
Fix Now button losing accent color on event logging screens

### DIFF
--- a/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/BottleFeedEditorSheetView.swift
+++ b/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/BottleFeedEditorSheetView.swift
@@ -59,7 +59,7 @@ public struct BottleFeedEditorSheetView: View {
                 LoggingSummaryView(sentence: summarySentence)
 
                 Section("When was the feed?") {
-                    QuickTimeSelectorView(selection: $occurredAt, initialPreset: initialTimePreset)
+                    QuickTimeSelectorView(selection: $occurredAt, initialPreset: initialTimePreset, buttonColor: Self.eventColor)
                         .accessibilityIdentifier("bottle-feed-time-selector")
                 }
 

--- a/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/BreastFeedEditorSheetView.swift
+++ b/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/BreastFeedEditorSheetView.swift
@@ -201,7 +201,7 @@ public struct BreastFeedEditorSheetView: View {
     private var manualModeContent: some View {
         Group {
             Section("When was the feed?") {
-                QuickTimeSelectorView(selection: $endTime, initialPreset: initialTimePreset)
+                QuickTimeSelectorView(selection: $endTime, initialPreset: initialTimePreset, buttonColor: Self.eventColor)
                     .accessibilityIdentifier("breast-feed-time-selector")
             }
 

--- a/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/NappyEditorSheetView.swift
+++ b/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/NappyEditorSheetView.swift
@@ -47,7 +47,7 @@ public struct NappyEditorSheetView: View {
                 LoggingSummaryView(sentence: summarySentence)
 
                 Section("When was the Nappy?") {
-                    QuickTimeSelectorView(selection: $occurredAt, initialPreset: initialTimePreset)
+                    QuickTimeSelectorView(selection: $occurredAt, initialPreset: initialTimePreset, buttonColor: Self.eventColor)
                         .accessibilityIdentifier("nappy-time-selector")
                 }
 

--- a/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/QuickTimeSelectorView.swift
+++ b/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/QuickTimeSelectorView.swift
@@ -11,11 +11,13 @@ public struct QuickTimeSelectorView: View {
         GridItem(.flexible(), spacing: 8),
         GridItem(.flexible(), spacing: 8),
     ]
+    private let buttonColor: Color
 
-    public init(selection: Binding<Date>, initialPreset: TimePreset = .now) {
+    public init(selection: Binding<Date>, initialPreset: TimePreset = .now, buttonColor: Color = .accentColor) {
         _selection = selection
         _selectedPreset = State(initialValue: initialPreset)
         _showCustomPicker = State(initialValue: initialPreset == .custom)
+        self.buttonColor = buttonColor
     }
 
     public var body: some View {
@@ -37,7 +39,7 @@ public struct QuickTimeSelectorView: View {
                             .padding(.vertical, 10)
                             .background(
                                 RoundedRectangle(cornerRadius: 12, style: .continuous)
-                                    .fill(selectedPreset == preset ? Color.accentColor : Color(.tertiarySystemGroupedBackground))
+                                    .fill(selectedPreset == preset ? buttonColor : Color(.tertiarySystemGroupedBackground))
                             )
                             .foregroundStyle(selectedPreset == preset ? Color.white : Color.primary)
                     }

--- a/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/SleepEditorSheetView.swift
+++ b/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/SleepEditorSheetView.swift
@@ -115,7 +115,7 @@ public struct SleepEditorSheetView: View {
                 if !startSuggestions.isEmpty {
                     suggestionButtons
                 }
-                QuickTimeSelectorView(selection: $startedAt)
+                QuickTimeSelectorView(selection: $startedAt, buttonColor: Self.eventColor)
                     .accessibilityIdentifier("sleep-start-time-selector")
             }
 
@@ -129,7 +129,7 @@ public struct SleepEditorSheetView: View {
                     durationSeparatorRow
                 }
                 Section("When did sleep end?") {
-                    QuickTimeSelectorView(selection: $endedAt, initialPreset: endTimeInitialPreset)
+                    QuickTimeSelectorView(selection: $endedAt, initialPreset: endTimeInitialPreset, buttonColor: Self.eventColor)
                         .accessibilityIdentifier("sleep-end-time-selector")
                 }
             }
@@ -155,7 +155,7 @@ public struct SleepEditorSheetView: View {
             }
 
             Section("When did sleep end?") {
-                QuickTimeSelectorView(selection: $endedAt, initialPreset: endTimeInitialPreset)
+                QuickTimeSelectorView(selection: $endedAt, initialPreset: endTimeInitialPreset, buttonColor: Self.eventColor)
                     .accessibilityIdentifier("sleep-end-time-selector")
             }
         }
@@ -180,7 +180,7 @@ public struct SleepEditorSheetView: View {
             }
 
             Section("When did sleep end?") {
-                QuickTimeSelectorView(selection: $endedAt, initialPreset: endTimeInitialPreset)
+                QuickTimeSelectorView(selection: $endedAt, initialPreset: endTimeInitialPreset, buttonColor: Self.eventColor)
                     .accessibilityIdentifier("sleep-end-time-selector")
             }
         }


### PR DESCRIPTION
The "Now" button (and other time preset buttons) in QuickTimeSelectorView
were losing their accent color and reverting to system blue because the
view was using Color.accentColor, which defaults to blue when the
AccentColor.colorset is empty.

Now QuickTimeSelectorView accepts an optional buttonColor parameter,
allowing each event editor (Sleep, BreastFeed, BottleFeed, Nappy) to
pass its event-specific color. This ensures the buttons maintain their
intended accent colors throughout the event logging flow.

https://claude.ai/code/session_011X5YESSuu8tqmBrkmYrnUW