### PR TITLE
Increase live activity UI height with better spacing and padding

### DIFF
--- a/Baby Tracker Live Activities/FeedLiveActivityContentView.swift
+++ b/Baby Tracker Live Activities/FeedLiveActivityContentView.swift
@@ -15,13 +15,13 @@ struct FeedLiveActivityContentView: View {
     }
 
     var body: some View {
-        VStack(alignment: .center, spacing: 4) {
+        VStack(alignment: .center, spacing: 12) {
             Text(state.childName)
                 .font(.headline)
                 .lineLimit(1)
                 .minimumScaleFactor(0.85)
 
-            HStack(alignment: .center, spacing: 4) {
+            HStack(alignment: .center, spacing: 8) {
                 metricTile(
                     title: "Feed",
                     icon: symbolName(for: state.lastFeedKind),
@@ -68,7 +68,7 @@ struct FeedLiveActivityContentView: View {
             }
         }
         .padding(.horizontal, 16)
-        .padding(.vertical, 4)
+        .padding(.vertical, 12)
         .frame(maxWidth: .infinity, alignment: .center)
     }
 
@@ -86,7 +86,7 @@ struct FeedLiveActivityContentView: View {
         color: Color,
         @ViewBuilder value: () -> some View
     ) -> some View {
-        VStack(alignment: .center, spacing: 3) {
+        VStack(alignment: .center, spacing: 6) {
             HStack(alignment: .center, spacing: 4) {
                 Image(systemName: icon)
                     .frame(width: 14)

--- a/Baby Tracker Live Activities/FeedLiveActivityWidget.swift
+++ b/Baby Tracker Live Activities/FeedLiveActivityWidget.swift
@@ -7,7 +7,7 @@ import WidgetKit
 struct FeedLiveActivityWidget: Widget {
     var body: some WidgetConfiguration {
         ActivityConfiguration(for: FeedLiveActivityAttributes.self) { context in
-            FeedLiveActivityContentView(state: context.state)
+            FeedLiveActivityContentView(state: context.state, showsStopSleepAction: false)
                 .activityBackgroundTint(Color(red: 0.12, green: 0.15, blue: 0.24))
                 .activitySystemActionForegroundColor(.white)
                 .widgetURL(FeedLiveActivityDeepLink.endSleepURL(childID: context.state.childID))

--- a/Baby Tracker Live Activities/FeedLiveActivityWidget.swift
+++ b/Baby Tracker Live Activities/FeedLiveActivityWidget.swift
@@ -7,7 +7,7 @@ import WidgetKit
 struct FeedLiveActivityWidget: Widget {
     var body: some WidgetConfiguration {
         ActivityConfiguration(for: FeedLiveActivityAttributes.self) { context in
-            FeedLiveActivityContentView(state: context.state, showsStopSleepAction: false)
+            FeedLiveActivityContentView(state: context.state)
                 .activityBackgroundTint(Color(red: 0.12, green: 0.15, blue: 0.24))
                 .activitySystemActionForegroundColor(.white)
                 .widgetURL(FeedLiveActivityDeepLink.endSleepURL(childID: context.state.childID))
@@ -18,18 +18,6 @@ struct FeedLiveActivityWidget: Widget {
                         state: context.state,
                         showsStopSleepAction: false
                     )
-                }
-
-                DynamicIslandExpandedRegion(.bottom) {
-                    if let stopSleepURL = FeedLiveActivityDeepLink.endSleepURL(childID: context.state.childID),
-                       context.state.activeSleepStartedAt != nil {
-                        Link(destination: stopSleepURL) {
-                            Label("Stop Sleep", systemImage: "stop.fill")
-                                .font(.caption.weight(.semibold))
-                                .frame(maxWidth: .infinity)
-                        }
-                        .buttonStyle(.borderedProminent)
-                    }
                 }
             } compactLeading: {
                 compactLeadingView(for: context.state)


### PR DESCRIPTION
- Increase vertical padding from 4 to 12 points
- Increase VStack spacing from 4 to 12 points
- Increase HStack spacing from 4 to 8 points
- Increase metric tile internal spacing from 3 to 6 points

This gives the live activity UI more breathing room and makes it feel less compact.