### PR TITLE
Add app version label to bottom of settings screen

### DIFF
--- a/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/AppSettingsView.swift
+++ b/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/AppSettingsView.swift
@@ -86,10 +86,33 @@ public struct AppSettingsView: View {
                     )
                 }
             }
+
+            Section {
+                HStack {
+                    Spacer()
+                    VStack(spacing: 4) {
+                        Text("App Version")
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                        Text(appVersion)
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                    }
+                    Spacer()
+                }
+                .frame(maxWidth: .infinity)
+                .accessibilityIdentifier("app-version-label")
+            }
         }
         .listStyle(.insetGrouped)
         .navigationTitle("App Settings")
         .navigationBarTitleDisplayMode(.inline)
+    }
+
+    private var appVersion: String {
+        let version = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "Unknown"
+        let build = Bundle.main.infoDictionary?["CFBundleVersion"] as? String ?? "Unknown"
+        return "\(version) (\(build))"
     }
 
     private func settingsRow(


### PR DESCRIPTION
- Display app version (short version + build number) at the bottom of the App Settings screen
- Format: "Version (Build)" e.g., "1.0 (42)"
- Styled with caption font and secondary color for subtle appearance
- Added accessibility identifier for testing

https://claude.ai/code/session_01NXRFApELMWmxeH4yDg7a8T