### PR TITLE
Fix owner not seeing accepted caregiver in Sharing & Caregivers view

### DIFF
--- a/Packages/BabyTrackerSync/Sources/BabyTrackerSync/CloudKitSyncEngine.swift
+++ b/Packages/BabyTrackerSync/Sources/BabyTrackerSync/CloudKitSyncEngine.swift
@@ -1164,18 +1164,8 @@ public final class CloudKitSyncEngine {
 
         try userIdentityRepository.saveUser(localUser)
         try membershipRepository.saveCloudKitMembership(membership)
-        logger.info("[4/5] ensureMembership — saved local membership id=\(membership.id, privacy: .public), marking upToDate immediately (received from CloudKit, not a local write)")
-        AppLogger.shared.log(.info, category: "CloudKitSync", "[4/5] ensureMembership — saved local membership id=\(membership.id), marking upToDate immediately")
-        try syncStateRepository.updateSyncState(
-            for: SyncRecordReference(
-                recordType: .membership,
-                recordID: membership.id,
-                childID: membership.childID
-            ),
-            state: .upToDate,
-            lastSyncedAt: .now,
-            lastSyncErrorCode: nil
-        )
+        logger.info("[4/5] ensureMembership — saved local membership id=\(membership.id, privacy: .public) as pendingSync so it is uploaded to CloudKit")
+        AppLogger.shared.log(.info, category: "CloudKitSync", "[4/5] ensureMembership — saved local membership id=\(membership.id) as pendingSync")
         let context = CloudKitChildContext(
             childID: childID,
             zoneID: zoneID,

--- a/docs/plans/079-fix-owner-missing-caregiver-in-sharing-view.md
+++ b/docs/plans/079-fix-owner-missing-caregiver-in-sharing-view.md
@@ -1,0 +1,36 @@
+# 079 — Fix: Owner doesn't see accepted caregiver in Sharing & Caregivers view
+
+## Goal
+
+After an owner invites a caregiver and the caregiver accepts the share, the owner's "Sharing & Caregivers" page must show the caregiver in the active caregivers section. Before this fix, the caregiver disappeared entirely from the owner's view after acceptance.
+
+## Problem
+
+When a caregiver accepts a CloudKit share, `ensureMembershipForAcceptedShare` creates a local `Membership` record with `role: .caregiver, status: .active`. The record was saved as `.pendingSync` via `saveCloudKitMembership`, but the code then immediately overrode that to `.upToDate`:
+
+```swift
+try syncStateRepository.updateSyncState(
+    for: SyncRecordReference(recordType: .membership, ...),
+    state: .upToDate,
+    ...
+)
+```
+
+The comment claimed this was "received from CloudKit, not a local write" — but the membership was created locally with a new UUID and was never in CloudKit. Marking it `.upToDate` prevented `refresh(reason: .localWrite)` (which runs immediately after) from uploading the membership to the shared CloudKit zone.
+
+Since the caregiver's membership was never in CloudKit, the owner's device never received it:
+
+1. The caregiver didn't appear in `activeCaregivers` (requires a membership with `role == .caregiver && status == .active` on the owner's device)
+2. After acceptance, `cachePendingInvites` filtered the caregiver out of `pendingShareInvites` too (because `acceptanceStatus == .accepted` is excluded once they accept)
+
+The caregiver disappeared from the owner's view entirely.
+
+## Fix
+
+Removed the premature `.upToDate` marking block (10 lines) from `ensureMembershipForAcceptedShare` in `CloudKitSyncEngine.swift`. The membership now remains `.pendingSync`, so the subsequent `refresh(reason: .localWrite)` uploads it to the shared CloudKit zone. The owner's private zone subscription receives the change and pulls the caregiver's membership, making them visible in `activeCaregivers`.
+
+## Files Changed
+
+- `Packages/BabyTrackerSync/Sources/BabyTrackerSync/CloudKitSyncEngine.swift`
+
+- [x] Complete


### PR DESCRIPTION
## Summary

- After a caregiver accepts a CloudKit share, the owner's "Sharing & Caregivers" page failed to show them — they disappeared entirely from the owner's view
- Root cause: `ensureMembershipForAcceptedShare` created the caregiver's local membership but immediately marked it `.upToDate`, preventing it from being uploaded to CloudKit
- Fix: remove the premature `.upToDate` override so the membership stays `.pendingSync` and is pushed to CloudKit by the `refresh(reason: .localWrite)` that runs right after

## Root Cause Detail

`ensureMembershipForAcceptedShare` creates a local `Membership` (role: `.caregiver`, status: `.active`) when a caregiver accepts a share. Despite a misleading comment saying "received from CloudKit, not a local write", this record was created locally with a new UUID and was never in CloudKit. Marking it `.upToDate` had two consequences:

1. The membership was never uploaded → owner's device never received it → caregiver missing from `activeCaregivers`
2. `cachePendingInvites` also excluded them from `pendingShareInvites` once `acceptanceStatus == .accepted` — so they vanished completely

## Test plan

- [ ] Owner invites a caregiver via the share sheet
- [ ] Caregiver accepts the share on their device
- [ ] Both devices sync (foreground refresh)
- [ ] Owner's "Sharing & Caregivers" page shows the caregiver in the active caregivers section
- [ ] Caregiver's page continues to show both Owner and themselves correctly

## References

- Plan: `docs/plans/079-fix-owner-missing-caregiver-in-sharing-view.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)