### PR TITLE
Fix owner still seeing caregiver as active after they leave

### DIFF
--- a/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/AppModel.swift
+++ b/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/AppModel.swift
@@ -523,8 +523,14 @@ public final class AppModel {
         guard let currentChild, let currentMembership,
               currentMembership.role == .caregiver && currentMembership.status == .active else { return }
         let childID = currentChild.id
+        let membership = currentMembership
         Task { @MainActor in
             do {
+                // Push .removed membership to CloudKit before leaving so the owner's
+                // device receives the status update and shows the caregiver in Past Access.
+                let removedMembership = try membership.removed()
+                try membershipRepository.saveMembership(removedMembership)
+                _ = await syncEngine.refreshAfterLocalWrite()
                 try await syncEngine.leaveShare(childID: childID)
                 try childRepository.purgeChildData(id: childID)
                 if childSelectionStore.loadSelectedChildID() == childID {

--- a/docs/plans/080-fix-caregiver-leave-missing-removed-status.md
+++ b/docs/plans/080-fix-caregiver-leave-missing-removed-status.md
@@ -1,0 +1,29 @@
+# 080 — Fix: Owner still sees caregiver as active after they leave
+
+## Goal
+
+When a caregiver leaves a shared child profile, the owner's "Sharing & Caregivers" page should move them to the "Past Access" section. Before this fix, the caregiver's membership record remained `.active` on the owner's device indefinitely after departure.
+
+## Problem
+
+`leaveChildShare` in `AppModel.swift` called `leaveShare` (which deletes the shared zone from CloudKit) and then `purgeChildData` (which wipes the caregiver's local data). Neither step updated the caregiver's membership record to `.removed` or pushed that update to CloudKit.
+
+The membership record in the owner's private CloudKit zone kept `status: .active`. On the owner's next sync, they would pull the unchanged record and continue to see the caregiver listed as an active caregiver.
+
+The owner had no indication the caregiver had left until they manually removed them using the "Remove" button.
+
+## Fix
+
+Before deleting the zone and purging local data, `leaveChildShare` now:
+
+1. Transitions the membership to `.removed` via `membership.removed()`
+2. Saves it locally via `membershipRepository.saveMembership` (marks it `.pendingSync`)
+3. Pushes it to CloudKit via `syncEngine.refreshAfterLocalWrite()`
+
+The push happens while the shared zone still exists, so the write succeeds. The owner's device receives the `.removed` record on their next sync and moves the caregiver to "Past Access".
+
+## Files Changed
+
+- `Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/AppModel.swift`
+
+- [x] Complete


### PR DESCRIPTION
## Summary

- When a caregiver left a shared child profile, the owner's "Sharing & Caregivers" page kept showing them as an active caregiver
- Root cause: `leaveChildShare` deleted the shared zone and purged local data, but never marked the membership `.removed` or pushed that to CloudKit
- Fix: push the `.removed` membership to CloudKit before deleting the zone, so the owner receives the update on their next sync

## Root Cause Detail

`leaveChildShare` called `leaveShare` then `purgeChildData`. Neither updated the membership record. The caregiver's `.active` membership persisted in the owner's private CloudKit zone, so every sync the owner pulled it and continued to see them as active.

## Fix

Three steps added before `leaveShare`:

1. `membership.removed()` — transitions status to `.removed`
2. `membershipRepository.saveMembership(removedMembership)` — saves locally, marks `.pendingSync`
3. `syncEngine.refreshAfterLocalWrite()` — pushes the record to CloudKit while the shared zone still exists

The owner's next sync pulls the `.removed` record and moves the caregiver to "Past Access".

## Test plan

- [ ] Caregiver taps "Leave Profile" on a shared child
- [ ] Owner's "Sharing & Caregivers" page moves the caregiver to "Past Access" after the next sync
- [ ] Caregiver's device cleanly removes all data for the child as before

## References

- Issue: #188
- Plan: `docs/plans/080-fix-caregiver-leave-missing-removed-status.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)