### PR TITLE
Remove timerStyle hidden-placeholder centering hack from live activity

### DIFF
--- a/Baby Tracker Live Activities/FeedLiveActivityContentView.swift
+++ b/Baby Tracker Live Activities/FeedLiveActivityContentView.swift
@@ -27,7 +27,7 @@ struct FeedLiveActivityContentView: View {
                     icon: symbolName(for: state.lastFeedKind),
                     color: eventAccentColor(for: .bottleFeed)
                 ) {
-                    Text(state.lastFeedAt, style: .timer).timerStyle()
+                    Text(state.lastFeedAt, style: .timer)
                 }
 
                 metricTile(
@@ -36,9 +36,9 @@ struct FeedLiveActivityContentView: View {
                     color: eventAccentColor(for: .sleep)
                 ) {
                     if let activeSleepStartedAt = state.activeSleepStartedAt {
-                        Text(activeSleepStartedAt, style: .timer).timerStyle()
+                        Text(activeSleepStartedAt, style: .timer)
                     } else if let lastSleepAt = state.lastSleepAt {
-                        Text(lastSleepAt, style: .timer).timerStyle()
+                        Text(lastSleepAt, style: .timer)
                     } else {
                         Text("—")
                     }
@@ -50,7 +50,7 @@ struct FeedLiveActivityContentView: View {
                     color: eventAccentColor(for: .nappy)
                 ) {
                     if let lastNappyAt = state.lastNappyAt {
-                        Text(lastNappyAt, style: .timer).timerStyle()
+                        Text(lastNappyAt, style: .timer)
                     } else {
                         Text("—")
                     }
@@ -152,18 +152,4 @@ struct FeedLiveActivityContentView: View {
         state: .previewActiveSleep,
         showsStopSleepAction: false
     )
-}
-
-extension Text {
-    func timerStyle() -> some View {
-        HStack(alignment: .center) {
-            Spacer()
-            Text("00:00:00")
-                .hidden()
-                .overlay {
-                    self
-                }
-            Spacer()
-        }
-    }
 }


### PR DESCRIPTION
The Spacer() sandwich + hidden Text("00:00:00") overlay was causing
misalignment between metric tiles — Spacers competed within the
equal-distribution HStack, and the "—" fallback tiles didn't use
the same approach. The metricTile frame(height: 24, alignment: .center)
and VStack(alignment: .center) already handle centering correctly.

https://claude.ai/code/session_01A3fEDveKa1ec1C1HHCh6si