### PR TITLE
Fix sleep charts to include active sessions and distribute minutes by hour

### DIFF
--- a/Baby TrackerTests/TodaySummaryCalculatorTests.swift
+++ b/Baby TrackerTests/TodaySummaryCalculatorTests.swift
@@ -343,6 +343,150 @@ struct TodaySummaryCalculatorTests {
         #expect(data.averageSleepBlockMinutes == 60)
     }
 
+    // MARK: - Active sleep tests
+
+    @Test
+    func activeSleepIsIncludedInTotalSleepMinutes() throws {
+        var calendar = Calendar(identifier: .gregorian)
+        calendar.timeZone = TimeZone(secondsFromGMT: 0)!
+
+        let childID = UUID()
+        let userID = UUID()
+        let now = try #require(calendar.date(from: DateComponents(year: 2026, month: 4, day: 7, hour: 10)))
+        // Baby fell asleep at 8am and is still sleeping (active session)
+        let sleepStart = try #require(calendar.date(from: DateComponents(year: 2026, month: 4, day: 7, hour: 8)))
+
+        let events: [BabyEvent] = [
+            .sleep(try SleepEvent(
+                metadata: EventMetadata(childID: childID, occurredAt: sleepStart, createdAt: sleepStart, createdBy: userID),
+                startedAt: sleepStart,
+                endedAt: nil
+            )),
+        ]
+
+        let data = TodaySummaryCalculator.makeData(from: events, now: now, calendar: calendar)
+
+        // 2 hours of active sleep should count
+        #expect(data.totalSleepMinutes == 120)
+        // While sleeping, minutesSinceLastSleep should be nil
+        #expect(data.minutesSinceLastSleep == nil)
+    }
+
+    @Test
+    func activeSleepThatStartedYesterdayIsIncludedInMetrics() throws {
+        var calendar = Calendar(identifier: .gregorian)
+        calendar.timeZone = TimeZone(secondsFromGMT: 0)!
+
+        let childID = UUID()
+        let userID = UUID()
+        let now = try #require(calendar.date(from: DateComponents(year: 2026, month: 4, day: 7, hour: 2)))
+        // Baby fell asleep at 10pm yesterday and is still sleeping
+        let sleepStart = try #require(calendar.date(from: DateComponents(year: 2026, month: 4, day: 6, hour: 22)))
+
+        let events: [BabyEvent] = [
+            .sleep(try SleepEvent(
+                metadata: EventMetadata(childID: childID, occurredAt: sleepStart, createdAt: sleepStart, createdBy: userID),
+                startedAt: sleepStart,
+                endedAt: nil
+            )),
+        ]
+
+        let data = TodaySummaryCalculator.makeData(from: events, now: now, calendar: calendar)
+
+        // 4 hours total (10pm→2am) should be in the total
+        #expect(data.totalSleepMinutes == 240)
+        #expect(data.minutesSinceLastSleep == nil)
+    }
+
+    @Test
+    func sleepChartDistributesMinutesAcrossHours() throws {
+        var calendar = Calendar(identifier: .gregorian)
+        calendar.timeZone = TimeZone(secondsFromGMT: 0)!
+
+        let childID = UUID()
+        let userID = UUID()
+        let now = try #require(calendar.date(from: DateComponents(year: 2026, month: 4, day: 7, hour: 15)))
+        // 90-minute nap: 9:00am–10:30am
+        let sleepStart = try #require(calendar.date(from: DateComponents(year: 2026, month: 4, day: 7, hour: 9)))
+        let sleepEnd = try #require(calendar.date(from: DateComponents(year: 2026, month: 4, day: 7, hour: 10, minute: 30)))
+
+        let events: [BabyEvent] = [
+            .sleep(try SleepEvent(
+                metadata: EventMetadata(childID: childID, occurredAt: sleepEnd, createdAt: sleepEnd, createdBy: userID),
+                startedAt: sleepStart,
+                endedAt: sleepEnd
+            )),
+        ]
+
+        let data = TodaySummaryCalculator.makeData(from: events, now: now, calendar: calendar)
+        let today = data.chartData.sleep.todayCumulative
+
+        // Hour 9 gets 60 minutes (9:00–10:00), hour 10 gets 30 minutes (10:00–10:30)
+        // Cumulative: hour 9 = 60, hour 10 = 90, hour 11+ = 90
+        #expect(today[8] == 0)
+        #expect(today[9] == 60)
+        #expect(today[10] == 90)
+        #expect(today[14] == 90)
+    }
+
+    @Test
+    func activeSleepIsIncludedInSleepChart() throws {
+        var calendar = Calendar(identifier: .gregorian)
+        calendar.timeZone = TimeZone(secondsFromGMT: 0)!
+
+        let childID = UUID()
+        let userID = UUID()
+        let now = try #require(calendar.date(from: DateComponents(year: 2026, month: 4, day: 7, hour: 10, minute: 30)))
+        // Baby fell asleep at 9am and is still sleeping
+        let sleepStart = try #require(calendar.date(from: DateComponents(year: 2026, month: 4, day: 7, hour: 9)))
+
+        let events: [BabyEvent] = [
+            .sleep(try SleepEvent(
+                metadata: EventMetadata(childID: childID, occurredAt: sleepStart, createdAt: sleepStart, createdBy: userID),
+                startedAt: sleepStart,
+                endedAt: nil
+            )),
+        ]
+
+        let data = TodaySummaryCalculator.makeData(from: events, now: now, calendar: calendar)
+        let today = data.chartData.sleep.todayCumulative
+
+        // Hour 9: 60 min (9:00–10:00), hour 10: 30 min (10:00–10:30)
+        // Cumulative: hour 9 = 60, hour 10 = 90
+        #expect(today[9] == 60)
+        #expect(today[10] == 90)
+    }
+
+    @Test
+    func overnightActiveSleepAppearsInTodayChart() throws {
+        var calendar = Calendar(identifier: .gregorian)
+        calendar.timeZone = TimeZone(secondsFromGMT: 0)!
+
+        let childID = UUID()
+        let userID = UUID()
+        let now = try #require(calendar.date(from: DateComponents(year: 2026, month: 4, day: 7, hour: 2)))
+        // Baby fell asleep at 11pm yesterday
+        let sleepStart = try #require(calendar.date(from: DateComponents(year: 2026, month: 4, day: 6, hour: 23)))
+
+        let events: [BabyEvent] = [
+            .sleep(try SleepEvent(
+                metadata: EventMetadata(childID: childID, occurredAt: sleepStart, createdAt: sleepStart, createdBy: userID),
+                startedAt: sleepStart,
+                endedAt: nil
+            )),
+        ]
+
+        let data = TodaySummaryCalculator.makeData(from: events, now: now, calendar: calendar)
+        let today = data.chartData.sleep.todayCumulative
+
+        // Today's chart: midnight to 2am = 2 hours = 120 minutes
+        // Hour 0 (midnight–1am): 60 min, hour 1 (1am–2am): 60 min
+        #expect(today[0] == 60)
+        #expect(today[1] == 120)
+        // Hour 2 onwards: still 120 (nothing beyond now)
+        #expect(today[2] == 120)
+    }
+
     // MARK: - Existing tests
 
     @Test

--- a/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/TodaySummaryCalculator.swift
+++ b/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/TodaySummaryCalculator.swift
@@ -53,27 +53,46 @@ public enum TodaySummaryCalculator {
             max(0, Int(now.timeIntervalSince($0) / 60))
         }
 
-        // Sleep
+        // Sleep - find active (in-progress) session from all events; it may have started before today
+        let activeSleep = allEvents.compactMap { event -> SleepEvent? in
+            guard case let .sleep(sleep) = event, sleep.endedAt == nil else { return nil }
+            return sleep
+        }.sorted { $0.startedAt > $1.startedAt }.first
+
         let completedSleeps = todayEvents.compactMap { event -> SleepEvent? in
             guard case let .sleep(sleep) = event, sleep.endedAt != nil else { return nil }
             return sleep
         }
-        let sleepDurations = completedSleeps.compactMap { sleepDurationMinutes(for: $0) }
-        let totalSleepMinutes = sleepDurations.reduce(0, +)
-        let longestSleepBlock = sleepDurations.max()
-        let shortestSleepBlock = sleepDurations.min()
-        let averageSleepBlock = average(of: sleepDurations)
 
-        // Time since last sleep
-        let lastSleepEndDate = completedSleeps.compactMap(\.endedAt).max()
-        let minutesSinceLastSleep = lastSleepEndDate.map {
-            max(0, Int(now.timeIntervalSince($0) / 60))
+        let completedDurations = completedSleeps.compactMap { sleepDurationMinutes(for: $0) }
+        let activeDuration = activeSleep.map { max(1, Int(now.timeIntervalSince($0.startedAt) / 60)) }
+        let allSleepDurations = completedDurations + (activeDuration.map { [$0] } ?? [])
+
+        let totalSleepMinutes = allSleepDurations.reduce(0, +)
+        let longestSleepBlock = allSleepDurations.max()
+        let shortestSleepBlock = allSleepDurations.min()
+        let averageSleepBlock = average(of: allSleepDurations)
+
+        // Time since last sleep - nil while actively sleeping
+        let minutesSinceLastSleep: Int?
+        if activeSleep != nil {
+            minutesSinceLastSleep = nil
+        } else {
+            let lastSleepEndDate = completedSleeps.compactMap(\.endedAt).max()
+            minutesSinceLastSleep = lastSleepEndDate.map {
+                max(0, Int(now.timeIntervalSince($0) / 60))
+            }
         }
 
         var daytimeSleepMinutes = 0
         var nighttimeSleepMinutes = 0
         for sleep in completedSleeps {
             let (daytime, nighttime) = splitSleepDuration(sleep, calendar: calendar)
+            daytimeSleepMinutes += daytime
+            nighttimeSleepMinutes += nighttime
+        }
+        if let active = activeSleep {
+            let (daytime, nighttime) = splitSleepDuration(active, effectiveEnd: now, calendar: calendar)
             daytimeSleepMinutes += daytime
             nighttimeSleepMinutes += nighttime
         }
@@ -196,8 +215,12 @@ public enum TodaySummaryCalculator {
                 historicalAmounts: historicalDays.map { breastHourlyAmounts(events: $0, calendar: calendar) }
             ),
             sleep: buildCumulativeSeries(
-                todayAmounts: sleepHourlyAmounts(events: todayEvents, calendar: calendar),
-                historicalAmounts: historicalDays.map { sleepHourlyAmounts(events: $0, calendar: calendar) }
+                todayAmounts: sleepHourlyAmounts(allEvents: allEvents, day: today, now: now, calendar: calendar),
+                historicalAmounts: (1...7).compactMap { offset -> [Int]? in
+                    guard let day = calendar.date(byAdding: .day, value: -offset, to: today),
+                          let dayEnd = calendar.date(byAdding: .day, value: 1, to: day) else { return nil }
+                    return sleepHourlyAmounts(allEvents: allEvents, day: day, now: dayEnd, calendar: calendar)
+                }
             ),
             nappy: buildCumulativeSeries(
                 todayAmounts: nappyHourlyAmounts(events: todayEvents, calendar: calendar),
@@ -314,15 +337,41 @@ public enum TodaySummaryCalculator {
         return amounts
     }
 
-    /// Returns a 24-element array where index h = minutes of completed sleep attributed to hour h (by endedAt).
-    private static func sleepHourlyAmounts(events: [BabyEvent], calendar: Calendar) -> [Int] {
+    /// Returns a 24-element array where index h = minutes of sleep overlapping hour h on `day`.
+    /// Minutes are distributed across each hour the sleep actually occupied, rather than
+    /// being attributed to the endedAt hour. Active sleep (endedAt == nil) is counted up to `now`.
+    /// Sleep that started before `day` (e.g. an overnight session) is also included.
+    private static func sleepHourlyAmounts(
+        allEvents: [BabyEvent],
+        day: Date,
+        now: Date,
+        calendar: Calendar
+    ) -> [Int] {
         var amounts = [Int](repeating: 0, count: 24)
-        for event in events {
-            guard case let .sleep(sleep) = event, let endedAt = sleep.endedAt else { continue }
-            let h = calendar.component(.hour, from: endedAt)
-            let minutes = max(1, Int(endedAt.timeIntervalSince(sleep.startedAt) / 60))
-            amounts[h] += minutes
+        guard let dayEnd = calendar.date(byAdding: .day, value: 1, to: day) else { return amounts }
+        let cap = min(now, dayEnd)
+
+        for event in allEvents {
+            guard case let .sleep(sleep) = event else { continue }
+            let effectiveEnd = sleep.endedAt ?? now
+
+            // Skip sessions that don't overlap with this day at all
+            guard effectiveEnd > day && sleep.startedAt < cap else { continue }
+
+            for h in 0..<24 {
+                guard let hourStart = calendar.date(byAdding: .hour, value: h, to: day),
+                      let hourEnd = calendar.date(byAdding: .hour, value: h + 1, to: day)
+                else { continue }
+
+                let overlapStart = max(sleep.startedAt, hourStart)
+                let overlapEnd = min(effectiveEnd, min(hourEnd, cap))
+
+                if overlapEnd > overlapStart {
+                    amounts[h] += max(0, Int(overlapEnd.timeIntervalSince(overlapStart) / 60))
+                }
+            }
         }
+
         return amounts
     }
 
@@ -349,12 +398,14 @@ public enum TodaySummaryCalculator {
         return max(1, Int(endedAt.timeIntervalSince(event.startedAt) / 60))
     }
 
-    /// Splits a completed sleep block into daytime (6am–10pm) and nighttime (10pm–6am) minutes.
+    /// Splits a sleep block into daytime (6am–10pm) and nighttime (10pm–6am) minutes.
+    /// Pass `effectiveEnd` for active (in-progress) sessions; otherwise `sleep.endedAt` is used.
     private static func splitSleepDuration(
         _ sleep: SleepEvent,
+        effectiveEnd: Date? = nil,
         calendar: Calendar
     ) -> (daytime: Int, nighttime: Int) {
-        guard let endedAt = sleep.endedAt else { return (0, 0) }
+        guard let endedAt = sleep.endedAt ?? effectiveEnd else { return (0, 0) }
 
         let totalMinutes = max(0, Int(endedAt.timeIntervalSince(sleep.startedAt) / 60))
         guard totalMinutes > 0 else { return (0, 0) }

--- a/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/TrendsSummaryCalculator.swift
+++ b/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/TrendsSummaryCalculator.swift
@@ -64,11 +64,7 @@ public enum TrendsSummaryCalculator {
         }
 
         let dailySleep = dates.map { date -> DailySleepData in
-            let dayEvents = eventsByDay[date] ?? []
-            let sleepMinutes = dayEvents.compactMap { event -> Int? in
-                guard case let .sleep(sleep) = event, let endedAt = sleep.endedAt else { return nil }
-                return max(1, Int(endedAt.timeIntervalSince(sleep.startedAt) / 60))
-            }.reduce(0, +)
+            let sleepMinutes = sleepMinutesForDay(date, from: rangeEvents, now: now, calendar: calendar)
             return DailySleepData(
                 date: date,
                 label: formatter(date),
@@ -193,6 +189,36 @@ public enum TrendsSummaryCalculator {
             fmt.setLocalizedDateFormatFromTemplate("MMM")
             return { date in fmt.string(from: date) }
         }
+    }
+
+    /// Returns the total minutes of sleep that overlapped with `day`, counting each minute
+    /// against the day it was actually slept rather than the day the session started or ended.
+    /// Active sessions (endedAt == nil) are counted up to `now`.
+    private static func sleepMinutesForDay(
+        _ day: Date,
+        from events: [BabyEvent],
+        now: Date,
+        calendar: Calendar
+    ) -> Int {
+        guard let dayEnd = calendar.date(byAdding: .day, value: 1, to: day) else { return 0 }
+        let cap = min(now, dayEnd)
+        var total = 0
+
+        for event in events {
+            guard case let .sleep(sleep) = event else { continue }
+            let effectiveEnd = sleep.endedAt ?? now
+
+            guard effectiveEnd > day && sleep.startedAt < cap else { continue }
+
+            let overlapStart = max(sleep.startedAt, day)
+            let overlapEnd = min(effectiveEnd, cap)
+
+            if overlapEnd > overlapStart {
+                total += max(0, Int(overlapEnd.timeIntervalSince(overlapStart) / 60))
+            }
+        }
+
+        return total
     }
 
     private static func average(of values: [Int]) -> Int? {


### PR DESCRIPTION
- Today chart: active (in-progress) sleep is now counted and shown in the
  cumulative sleep line chart; minutes are distributed to the hours the
  baby was actually sleeping rather than all being attributed to the
  endedAt hour. Overnight sessions that started before today also appear
  in today's chart for the hours they overlap with the current day.

- Today metrics: totalSleepMinutes, longest/shortest/average block,
  and daytime/nighttime splits now include the active sleep session
  (counted from startedAt to now). minutesSinceLastSleep is nil while
  the baby is actively sleeping.

- Trends chart: sleep minutes are now attributed to the day they were
  actually slept (by time overlap) rather than the day the session
  started. Active sessions are counted up to now, so today's bar
  grows in real time as the baby sleeps.

https://claude.ai/code/session_01QZNdL8iGecVR2GUD8m5ZdD