### PR TITLE
Extract refresh logic into three Domain UseCases

### DIFF
--- a/Baby TrackerTests/RefreshUseCasesDomainTests.swift
+++ b/Baby TrackerTests/RefreshUseCasesDomainTests.swift
@@ -1,0 +1,374 @@
+import BabyTrackerDomain
+import Foundation
+import Testing
+
+// MARK: - Local stubs (Domain protocol only, no Persistence dependency)
+
+@MainActor
+private final class StubMembershipRepository: MembershipRepository {
+    var membershipsByChildID: [UUID: [Membership]] = [:]
+
+    func loadMemberships(for childID: UUID) throws -> [Membership] {
+        membershipsByChildID[childID] ?? []
+    }
+
+    func saveMembership(_ membership: Membership) throws {
+        membershipsByChildID[membership.childID, default: []].append(membership)
+    }
+}
+
+@MainActor
+private final class StubEventRepository: EventRepository {
+    var eventsByChildID: [UUID: [BabyEvent]] = [:]
+    var activeSleepByChildID: [UUID: SleepEvent] = [:]
+
+    func saveEvent(_ event: BabyEvent) throws {
+        eventsByChildID[event.metadata.childID, default: []].append(event)
+    }
+
+    func loadEvent(id: UUID) throws -> BabyEvent? { nil }
+
+    func loadTimeline(for childID: UUID, includingDeleted: Bool) throws -> [BabyEvent] {
+        eventsByChildID[childID] ?? []
+    }
+
+    func loadEvents(for childID: UUID, on day: Date, calendar: Calendar, includingDeleted: Bool) throws -> [BabyEvent] {
+        eventsByChildID[childID] ?? []
+    }
+
+    func loadActiveSleepEvent(for childID: UUID) throws -> SleepEvent? {
+        activeSleepByChildID[childID]
+    }
+
+    func softDeleteEvent(id: UUID, deletedAt: Date, deletedBy: UUID) throws {}
+}
+
+@MainActor
+private final class StubUserIdentityRepository: UserIdentityRepository {
+    var usersByID: [UUID: UserIdentity] = [:]
+
+    func loadLocalUser() throws -> UserIdentity? { nil }
+    func saveLocalUser(_ user: UserIdentity) throws {}
+    func loadUsers(for userIDs: [UUID]) throws -> [UserIdentity] {
+        userIDs.compactMap { usersByID[$0] }
+    }
+    func saveUser(_ user: UserIdentity) throws { usersByID[user.id] = user }
+    func removeLegacyPlaceholderCaregivers() throws {}
+    func resetAllData() throws {}
+}
+
+// MARK: - LoadChildSummariesUseCase Tests
+
+@MainActor
+struct LoadChildSummariesUseCaseTests {
+    let userID = UUID()
+    let membershipRepo = StubMembershipRepository()
+
+    private func makeChild(createdAt: Date = .now) throws -> Child {
+        try Child(name: "Test Child", createdAt: createdAt, createdBy: userID)
+    }
+
+    @Test
+    func childWithActiveMembershipIsIncluded() throws {
+        let child = try makeChild()
+        membershipRepo.membershipsByChildID[child.id] = [
+            Membership.owner(childID: child.id, userID: userID)
+        ]
+
+        let result = try LoadChildSummariesUseCase(membershipRepository: membershipRepo)
+            .execute(.init(children: [child], userID: userID))
+
+        #expect(result.count == 1)
+        #expect(result[0].child.id == child.id)
+        #expect(result[0].membership.userID == userID)
+    }
+
+    @Test
+    func childWithNoMembershipsIsSkipped() throws {
+        let child = try makeChild()
+        // No memberships stored for this child
+
+        let result = try LoadChildSummariesUseCase(membershipRepository: membershipRepo)
+            .execute(.init(children: [child], userID: userID))
+
+        #expect(result.isEmpty)
+    }
+
+    @Test
+    func childWithRemovedMembershipIsSkipped() throws {
+        let child = try makeChild()
+        let invited = Membership.invitedCaregiver(childID: child.id, userID: userID)
+        let removed = try invited.removed()
+        membershipRepo.membershipsByChildID[child.id] = [removed]
+
+        let result = try LoadChildSummariesUseCase(membershipRepository: membershipRepo)
+            .execute(.init(children: [child], userID: userID))
+
+        #expect(result.isEmpty)
+    }
+
+    @Test
+    func childWithInvitedMembershipIsSkipped() throws {
+        let child = try makeChild()
+        membershipRepo.membershipsByChildID[child.id] = [
+            Membership.invitedCaregiver(childID: child.id, userID: userID)
+        ]
+
+        let result = try LoadChildSummariesUseCase(membershipRepository: membershipRepo)
+            .execute(.init(children: [child], userID: userID))
+
+        #expect(result.isEmpty)
+    }
+
+    @Test
+    func onlyChildrenWithActiveMembershipForLocalUserAreIncluded() throws {
+        let ownedChild = try makeChild()
+        let otherUserID = UUID()
+        let sharedChild = try Child(name: "Shared", createdBy: otherUserID)
+
+        membershipRepo.membershipsByChildID[ownedChild.id] = [
+            Membership.owner(childID: ownedChild.id, userID: userID)
+        ]
+        membershipRepo.membershipsByChildID[sharedChild.id] = [
+            Membership.owner(childID: sharedChild.id, userID: otherUserID)
+            // local user has no membership for sharedChild
+        ]
+
+        let result = try LoadChildSummariesUseCase(membershipRepository: membershipRepo)
+            .execute(.init(children: [ownedChild, sharedChild], userID: userID))
+
+        #expect(result.count == 1)
+        #expect(result[0].child.id == ownedChild.id)
+    }
+
+    @Test
+    func resultsAreSortedByCreatedAtAscending() throws {
+        let now = Date()
+        let older = try Child(name: "Older", createdAt: now.addingTimeInterval(-3600), createdBy: userID)
+        let newer = try Child(name: "Newer", createdAt: now, createdBy: userID)
+
+        for child in [newer, older] {
+            membershipRepo.membershipsByChildID[child.id] = [
+                Membership.owner(childID: child.id, userID: userID)
+            ]
+        }
+
+        let result = try LoadChildSummariesUseCase(membershipRepository: membershipRepo)
+            .execute(.init(children: [newer, older], userID: userID))
+
+        #expect(result.map(\.child.id) == [older.id, newer.id])
+    }
+
+    @Test
+    func emptyChildListReturnsEmptySummaries() throws {
+        let result = try LoadChildSummariesUseCase(membershipRepository: membershipRepo)
+            .execute(.init(children: [], userID: userID))
+
+        #expect(result.isEmpty)
+    }
+}
+
+// MARK: - ResolveChildWorkspaceUseCase Tests
+
+@MainActor
+struct ResolveChildWorkspaceUseCaseTests {
+    let userID = UUID()
+    let useCase = ResolveChildWorkspaceUseCase()
+
+    private func makeSummary(childID: UUID = UUID()) throws -> ChildSummary {
+        let child = try Child(name: "Child", createdBy: userID)
+        let membership = Membership.owner(childID: child.id, userID: userID)
+        return ChildSummary(child: child, membership: membership)
+    }
+
+    @Test
+    func noActiveChildrenResolvesToNoActiveChildren() throws {
+        let result = useCase.execute(.init(activeChildren: [], selectedChildID: nil))
+        #expect(result == .noActiveChildren)
+    }
+
+    @Test
+    func noActiveChildrenIgnoresSelectedID() throws {
+        let result = useCase.execute(.init(activeChildren: [], selectedChildID: UUID()))
+        #expect(result == .noActiveChildren)
+    }
+
+    @Test
+    func singleChildResolvesRegardlessOfSelectedID() throws {
+        let summary = try makeSummary()
+
+        let resultWithNilID = useCase.execute(.init(activeChildren: [summary], selectedChildID: nil))
+        let resultWithWrongID = useCase.execute(.init(activeChildren: [summary], selectedChildID: UUID()))
+        let resultWithMatchingID = useCase.execute(.init(activeChildren: [summary], selectedChildID: summary.child.id))
+
+        #expect(resultWithNilID == .resolved(summary))
+        #expect(resultWithWrongID == .resolved(summary))
+        #expect(resultWithMatchingID == .resolved(summary))
+    }
+
+    @Test
+    func multipleChildrenWithMatchingSelectedIDResolvesCorrectChild() throws {
+        let first = try makeSummary()
+        let second = try makeSummary()
+
+        let result = useCase.execute(.init(activeChildren: [first, second], selectedChildID: second.child.id))
+
+        #expect(result == .resolved(second))
+    }
+
+    @Test
+    func multipleChildrenWithNoSelectedIDNeedsChildSelection() throws {
+        let first = try makeSummary()
+        let second = try makeSummary()
+
+        let result = useCase.execute(.init(activeChildren: [first, second], selectedChildID: nil))
+
+        #expect(result == .needsChildSelection)
+    }
+
+    @Test
+    func multipleChildrenWithUnknownSelectedIDNeedsChildSelection() throws {
+        let first = try makeSummary()
+        let second = try makeSummary()
+
+        let result = useCase.execute(.init(activeChildren: [first, second], selectedChildID: UUID()))
+
+        #expect(result == .needsChildSelection)
+    }
+}
+
+// MARK: - LoadChildWorkspaceDataUseCase Tests
+
+@MainActor
+struct LoadChildWorkspaceDataUseCaseTests {
+    let userID = UUID()
+    let childID = UUID()
+    let eventRepo = StubEventRepository()
+    let membershipRepo = StubMembershipRepository()
+    let userIdentityRepo = StubUserIdentityRepository()
+
+    private func makeUseCase() -> LoadChildWorkspaceDataUseCase {
+        LoadChildWorkspaceDataUseCase(
+            eventRepository: eventRepo,
+            membershipRepository: membershipRepo,
+            userIdentityRepository: userIdentityRepo
+        )
+    }
+
+    @Test
+    func loadsEventsForChild() throws {
+        membershipRepo.membershipsByChildID[childID] = [
+            Membership.owner(childID: childID, userID: userID)
+        ]
+        let event = try BottleFeedEvent(
+            metadata: EventMetadata(childID: childID, occurredAt: .now, createdBy: userID),
+            amountMilliliters: 120
+        )
+        eventRepo.eventsByChildID[childID] = [.bottleFeed(event)]
+
+        let output = try makeUseCase().execute(.init(childID: childID, localUserID: userID))
+
+        #expect(output.events.count == 1)
+        #expect(output.events[0].id == event.id)
+    }
+
+    @Test
+    func loadsActiveSleepForChild() throws {
+        membershipRepo.membershipsByChildID[childID] = [
+            Membership.owner(childID: childID, userID: userID)
+        ]
+        let sleep = try SleepEvent(
+            metadata: EventMetadata(childID: childID, occurredAt: .now, createdBy: userID),
+            startedAt: .now
+        )
+        eventRepo.activeSleepByChildID[childID] = sleep
+
+        let output = try makeUseCase().execute(.init(childID: childID, localUserID: userID))
+
+        #expect(output.activeSleep?.id == sleep.id)
+    }
+
+    @Test
+    func noActiveSleepReturnsNil() throws {
+        membershipRepo.membershipsByChildID[childID] = [
+            Membership.owner(childID: childID, userID: userID)
+        ]
+
+        let output = try makeUseCase().execute(.init(childID: childID, localUserID: userID))
+
+        #expect(output.activeSleep == nil)
+    }
+
+    @Test
+    func resolvedMembershipBelongsToLocalUser() throws {
+        let ownerMembership = Membership.owner(childID: childID, userID: userID)
+        let otherUser = UUID()
+        let caregiverMembership = Membership(
+            childID: childID,
+            userID: otherUser,
+            role: .caregiver,
+            status: .active,
+            invitedAt: .now,
+            acceptedAt: .now
+        )
+        membershipRepo.membershipsByChildID[childID] = [ownerMembership, caregiverMembership]
+
+        let output = try makeUseCase().execute(.init(childID: childID, localUserID: userID))
+
+        #expect(output.currentMembership.userID == userID)
+        #expect(output.currentMembership.role == .owner)
+    }
+
+    @Test
+    func allMembershipsAreReturnedInOutput() throws {
+        let owner = Membership.owner(childID: childID, userID: userID)
+        let caregiver = Membership(
+            childID: childID,
+            userID: UUID(),
+            role: .caregiver,
+            status: .active,
+            invitedAt: .now,
+            acceptedAt: .now
+        )
+        membershipRepo.membershipsByChildID[childID] = [owner, caregiver]
+
+        let output = try makeUseCase().execute(.init(childID: childID, localUserID: userID))
+
+        #expect(output.memberships.count == 2)
+    }
+
+    @Test
+    func membershipUsersAreLoadedForAllMemberships() throws {
+        let otherUserID = UUID()
+        membershipRepo.membershipsByChildID[childID] = [
+            Membership.owner(childID: childID, userID: userID),
+            Membership(childID: childID, userID: otherUserID, role: .caregiver, status: .active, invitedAt: .now, acceptedAt: .now)
+        ]
+        let otherUser = try UserIdentity(id: otherUserID, displayName: "Caregiver")
+        userIdentityRepo.usersByID[otherUserID] = otherUser
+
+        let output = try makeUseCase().execute(.init(childID: childID, localUserID: userID))
+
+        #expect(output.membershipUsers.contains(where: { $0.id == otherUserID }))
+    }
+
+    @Test
+    func throwsWhenLocalUserHasNoMembership() throws {
+        membershipRepo.membershipsByChildID[childID] = []
+
+        #expect(throws: ChildProfileValidationError.invalidMembershipTransition(from: .removed, to: .active)) {
+            try makeUseCase().execute(.init(childID: childID, localUserID: userID))
+        }
+    }
+
+    @Test
+    func throwsWhenLocalUserMembershipIsRemoved() throws {
+        let invited = Membership.invitedCaregiver(childID: childID, userID: userID)
+        let removed = try invited.removed()
+        membershipRepo.membershipsByChildID[childID] = [removed]
+
+        #expect(throws: ChildProfileValidationError.invalidMembershipTransition(from: .removed, to: .active)) {
+            try makeUseCase().execute(.init(childID: childID, localUserID: userID))
+        }
+    }
+}

--- a/Packages/BabyTrackerDomain/Sources/BabyTrackerDomain/ChildSummary.swift
+++ b/Packages/BabyTrackerDomain/Sources/BabyTrackerDomain/ChildSummary.swift
@@ -1,6 +1,6 @@
-import BabyTrackerDomain
 import Foundation
 
+/// A child profile paired with the local user's active membership for that child.
 public struct ChildSummary: Equatable, Identifiable, Sendable {
     public let child: Child
     public let membership: Membership

--- a/Packages/BabyTrackerDomain/Sources/BabyTrackerDomain/UseCases/LoadChildSummariesUseCase.swift
+++ b/Packages/BabyTrackerDomain/Sources/BabyTrackerDomain/UseCases/LoadChildSummariesUseCase.swift
@@ -1,0 +1,38 @@
+import Foundation
+
+/// Attaches the local user's active membership to each child, skipping children
+/// where no active membership exists. Results are sorted oldest-first by creation date.
+@MainActor
+public struct LoadChildSummariesUseCase: UseCase {
+    public struct Input {
+        public let children: [Child]
+        public let userID: UUID
+
+        public init(children: [Child], userID: UUID) {
+            self.children = children
+            self.userID = userID
+        }
+    }
+
+    private let membershipRepository: any MembershipRepository
+
+    public init(membershipRepository: any MembershipRepository) {
+        self.membershipRepository = membershipRepository
+    }
+
+    public func execute(_ input: Input) throws -> [ChildSummary] {
+        var summaries: [ChildSummary] = []
+
+        for child in input.children {
+            let memberships = try membershipRepository.loadMemberships(for: child.id)
+            guard let membership = memberships.first(where: {
+                $0.userID == input.userID && $0.status == .active
+            }) else {
+                continue
+            }
+            summaries.append(ChildSummary(child: child, membership: membership))
+        }
+
+        return summaries.sorted { $0.child.createdAt < $1.child.createdAt }
+    }
+}

--- a/Packages/BabyTrackerDomain/Sources/BabyTrackerDomain/UseCases/LoadChildWorkspaceDataUseCase.swift
+++ b/Packages/BabyTrackerDomain/Sources/BabyTrackerDomain/UseCases/LoadChildWorkspaceDataUseCase.swift
@@ -1,0 +1,62 @@
+import Foundation
+
+/// Loads all data required to display a child's workspace: the full event
+/// timeline, the active sleep session, the child's memberships, the user
+/// identities behind those memberships, and the local user's resolved
+/// membership. Throws if the local user no longer has an active membership
+/// for the child (e.g. the sync hasn't arrived yet after being removed).
+@MainActor
+public struct LoadChildWorkspaceDataUseCase: UseCase {
+    public struct Input {
+        public let childID: UUID
+        public let localUserID: UUID
+
+        public init(childID: UUID, localUserID: UUID) {
+            self.childID = childID
+            self.localUserID = localUserID
+        }
+    }
+
+    public struct Output {
+        public let events: [BabyEvent]
+        public let activeSleep: SleepEvent?
+        public let memberships: [Membership]
+        public let membershipUsers: [UserIdentity]
+        public let currentMembership: Membership
+    }
+
+    private let eventRepository: any EventRepository
+    private let membershipRepository: any MembershipRepository
+    private let userIdentityRepository: any UserIdentityRepository
+
+    public init(
+        eventRepository: any EventRepository,
+        membershipRepository: any MembershipRepository,
+        userIdentityRepository: any UserIdentityRepository
+    ) {
+        self.eventRepository = eventRepository
+        self.membershipRepository = membershipRepository
+        self.userIdentityRepository = userIdentityRepository
+    }
+
+    public func execute(_ input: Input) throws -> Output {
+        let events = try eventRepository.loadTimeline(for: input.childID, includingDeleted: false)
+        let activeSleep = try eventRepository.loadActiveSleepEvent(for: input.childID)
+        let memberships = try membershipRepository.loadMemberships(for: input.childID)
+        let membershipUsers = try userIdentityRepository.loadUsers(for: memberships.map(\.userID))
+
+        guard let currentMembership = memberships.first(where: {
+            $0.userID == input.localUserID && $0.status == .active
+        }) else {
+            throw ChildProfileValidationError.invalidMembershipTransition(from: .removed, to: .active)
+        }
+
+        return Output(
+            events: events,
+            activeSleep: activeSleep,
+            memberships: memberships,
+            membershipUsers: membershipUsers,
+            currentMembership: currentMembership
+        )
+    }
+}

--- a/Packages/BabyTrackerDomain/Sources/BabyTrackerDomain/UseCases/ResolveChildWorkspaceUseCase.swift
+++ b/Packages/BabyTrackerDomain/Sources/BabyTrackerDomain/UseCases/ResolveChildWorkspaceUseCase.swift
@@ -1,0 +1,44 @@
+import Foundation
+
+/// Decides which child workspace state to enter given the active children list
+/// and the user's previously-selected child ID. This is a pure computation —
+/// no repositories required.
+@MainActor
+public struct ResolveChildWorkspaceUseCase: UseCase {
+    public struct Input {
+        public let activeChildren: [ChildSummary]
+        public let selectedChildID: UUID?
+
+        public init(activeChildren: [ChildSummary], selectedChildID: UUID?) {
+            self.activeChildren = activeChildren
+            self.selectedChildID = selectedChildID
+        }
+    }
+
+    public enum Resolution: Equatable {
+        /// The user has no active children — show the empty state.
+        case noActiveChildren
+        /// There are multiple children but none matches the stored selection —
+        /// the user must pick one explicitly.
+        case needsChildSelection
+        /// A specific child was resolved. The associated value is the child to
+        /// show in the workspace.
+        case resolved(ChildSummary)
+    }
+
+    public init() {}
+
+    public func execute(_ input: Input) -> Resolution {
+        guard !input.activeChildren.isEmpty else {
+            return .noActiveChildren
+        }
+
+        let selected = input.activeChildren.first(where: { $0.child.id == input.selectedChildID })
+
+        if input.activeChildren.count > 1 && selected == nil {
+            return .needsChildSelection
+        }
+
+        return .resolved(selected ?? input.activeChildren[0])
+    }
+}

--- a/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/AppModel.swift
+++ b/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/AppModel.swift
@@ -765,24 +765,9 @@ public final class AppModel {
 
     public func sleepStartSuggestions() -> [(label: String, date: Date)] {
         guard let currentChild else { return [] }
-        let timeline = (try? eventRepository.loadTimeline(for: currentChild.id, includingDeleted: false)) ?? []
-
-        var suggestions: [(label: String, date: Date)] = []
-        let timeFormatter = Date.FormatStyle(date: .omitted, time: .shortened)
-
-        if case let .bottleFeed(feed) = timeline.first(where: { if case .bottleFeed = $0 { true } else { false } }) {
-            suggestions.append((label: "Last bottle at \(feed.metadata.occurredAt.formatted(timeFormatter))", date: feed.metadata.occurredAt))
-        }
-
-        if case let .breastFeed(feed) = timeline.first(where: { if case .breastFeed = $0 { true } else { false } }) {
-            suggestions.append((label: "Last feed at \(feed.metadata.occurredAt.formatted(timeFormatter))", date: feed.metadata.occurredAt))
-        }
-
-        if case let .nappy(nappy) = timeline.first(where: { if case .nappy = $0 { true } else { false } }) {
-            suggestions.append((label: "Last nappy at \(nappy.metadata.occurredAt.formatted(timeFormatter))", date: nappy.metadata.occurredAt))
-        }
-
-        return suggestions
+        let suggestions = (try? GetSleepStartSuggestionsUseCase(eventRepository: eventRepository)
+            .execute(.init(childID: currentChild.id))) ?? []
+        return suggestions.map { (label: $0.label, date: $0.date) }
     }
 
     @discardableResult
@@ -909,103 +894,97 @@ public final class AppModel {
                 return
             }
 
-            activeChildren = try loadChildSummaries(
+            let loadSummaries = LoadChildSummariesUseCase(membershipRepository: membershipRepository)
+            activeChildren = try loadSummaries.execute(.init(
                 children: childRepository.loadActiveChildren(for: localUser.id),
                 userID: localUser.id
-            )
-            archivedChildren = try loadChildSummaries(
+            ))
+            archivedChildren = try loadSummaries.execute(.init(
                 children: childRepository.loadArchivedChildren(for: localUser.id),
                 userID: localUser.id
-            )
+            ))
             logger.info("refresh — localUserID: \(localUser.id, privacy: .public), active: \(self.activeChildren.count, privacy: .public), archived: \(self.archivedChildren.count, privacy: .public)")
             AppLogger.shared.log(.info, category: "AppModel", "refresh — active: \(self.activeChildren.count), archived: \(self.archivedChildren.count)")
 
-            guard !activeChildren.isEmpty else {
+            let effectiveSelectedChildID = selectedChildID ?? childSelectionStore.loadSelectedChildID()
+            let resolution = ResolveChildWorkspaceUseCase().execute(.init(
+                activeChildren: activeChildren,
+                selectedChildID: effectiveSelectedChildID
+            ))
+
+            switch resolution {
+            case .noActiveChildren:
                 route = .noChildren
                 clearProfileData()
                 liveActivityManager.synchronize(with: nil)
                 return
-            }
-
-            let effectiveSelectedChildID = selectedChildID ?? childSelectionStore.loadSelectedChildID()
-            let selectedSummary = activeChildren.first(where: { summary in
-                summary.child.id == effectiveSelectedChildID
-            })
-
-            if activeChildren.count > 1 && selectedSummary == nil {
+            case .needsChildSelection:
                 route = .childPicker
                 clearProfileData()
                 liveActivityManager.synchronize(with: nil)
                 return
-            }
+            case .resolved(let currentSummary):
+                childSelectionStore.saveSelectedChildID(currentSummary.child.id)
+                synchronizeTimelineSelection(for: currentSummary.child.id)
 
-            let currentSummary = selectedSummary ?? activeChildren[0]
-            childSelectionStore.saveSelectedChildID(currentSummary.child.id)
-            synchronizeTimelineSelection(for: currentSummary.child.id)
+                let workspaceData = try LoadChildWorkspaceDataUseCase(
+                    eventRepository: eventRepository,
+                    membershipRepository: membershipRepository,
+                    userIdentityRepository: userIdentityRepository
+                ).execute(.init(childID: currentSummary.child.id, localUserID: localUser.id))
 
-            let visibleEvents = try loadVisibleEvents(for: currentSummary.child.id)
-            let builtTimelinePages = try loadTimelinePages(
-                child: currentSummary.child,
-                for: currentSummary.child.id,
-                days: timelineVisibleDays(for: timelineSelectedDay)
-            )
-            let currentActiveSleep = try eventRepository.loadActiveSleepEvent(for: currentSummary.child.id)
-            let childMemberships = try membershipRepository.loadMemberships(for: currentSummary.child.id)
-            let userIDs = childMemberships.map(\.userID)
-            let users = try userIdentityRepository.loadUsers(for: userIDs)
+                let builtTimelinePages = try loadTimelinePages(
+                    child: currentSummary.child,
+                    for: currentSummary.child.id,
+                    days: timelineVisibleDays(for: timelineSelectedDay)
+                )
+                let status = CloudKitStatusViewState(summary: syncEngine.statusSummary)
+                let pendingCounts = (try? syncEngine.loadPendingChangeCounts()) ?? [:]
+                let builtPendingChanges: [PendingChangeSummaryItem] = [
+                    (.breastFeedEvent, "figure.seated.side.air.upper", "Breast feeds"),
+                    (.bottleFeedEvent, "waterbottle.fill",             "Bottle feeds"),
+                    (.sleepEvent,      "moon.zzz.fill",                "Sleep sessions"),
+                    (.nappyEvent,      "checklist.checked",            "Nappy changes"),
+                    (.membership,      "person.2.fill",                "Sharing info"),
+                    (.child,           "person.fill",                  "Profile data"),
+                ].compactMap { (type, icon, label) in
+                    guard let count = pendingCounts[type], count > 0 else { return nil }
+                    return PendingChangeSummaryItem(icon: icon, label: label, count: count)
+                }
+                let builtPendingInvites = syncEngine.pendingInvites(for: currentSummary.child.id).map { invite in
+                    PendingShareInviteViewState(
+                        id: invite.id,
+                        displayName: invite.displayName,
+                        statusLabel: invite.acceptanceStatus == .pending ? "Pending invitation" : "Invited"
+                    )
+                }
+                let stripDataset = buildTimelineStripDatasetUseCase.execute(
+                    events: workspaceData.events,
+                    calendar: calendar
+                )
 
-            guard let resolvedMembership = childMemberships.first(where: { m in
-                m.userID == localUser.id && m.status == .active
-            }) else {
-                throw ChildProfileValidationError.invalidMembershipTransition(from: .removed, to: .active)
-            }
+                // Set flat observable properties — triggers ViewModel recomputation
+                events = workspaceData.events
+                currentChild = currentSummary.child
+                currentMembership = workspaceData.currentMembership
+                activeSleep = workspaceData.activeSleep
+                timelinePages = builtTimelinePages
+                timelineStripColumns = buildTimelineStripColumns(from: stripDataset)
+                cloudKitStatus = status
+                memberships = workspaceData.memberships
+                membershipUsers = workspaceData.membershipUsers
+                pendingChanges = builtPendingChanges
+                pendingShareInvites = builtPendingInvites
 
-            let status = CloudKitStatusViewState(summary: syncEngine.statusSummary)
-            let pendingCounts = (try? syncEngine.loadPendingChangeCounts()) ?? [:]
-            let builtPendingChanges: [PendingChangeSummaryItem] = [
-                (.breastFeedEvent, "figure.seated.side.air.upper", "Breast feeds"),
-                (.bottleFeedEvent, "waterbottle.fill",             "Bottle feeds"),
-                (.sleepEvent,      "moon.zzz.fill",                "Sleep sessions"),
-                (.nappyEvent,      "checklist.checked",            "Nappy changes"),
-                (.membership,      "person.2.fill",                "Sharing info"),
-                (.child,           "person.fill",                  "Profile data"),
-            ].compactMap { (type, icon, label) in
-                guard let count = pendingCounts[type], count > 0 else { return nil }
-                return PendingChangeSummaryItem(icon: icon, label: label, count: count)
-            }
-            let builtPendingInvites = syncEngine.pendingInvites(for: currentSummary.child.id).map { invite in
-                PendingShareInviteViewState(
-                    id: invite.id,
-                    displayName: invite.displayName,
-                    statusLabel: invite.acceptanceStatus == .pending ? "Pending invitation" : "Invited"
+                route = .childProfile
+                UpdateFeedLiveActivityUseCase.execute(
+                    events: workspaceData.events,
+                    child: currentSummary.child,
+                    activeSleep: workspaceData.activeSleep,
+                    isLiveActivityEnabled: isLiveActivityEnabled,
+                    liveActivityManager: liveActivityManager
                 )
             }
-            let stripDataset = buildTimelineStripDatasetUseCase.execute(
-                events: visibleEvents,
-                calendar: calendar
-            )
-
-            // Set flat observable properties — triggers ViewModel recomputation
-            events = visibleEvents
-            currentChild = currentSummary.child
-            currentMembership = resolvedMembership
-            activeSleep = currentActiveSleep
-            timelinePages = builtTimelinePages
-            timelineStripColumns = buildTimelineStripColumns(from: stripDataset)
-            cloudKitStatus = status
-            memberships = childMemberships
-            membershipUsers = users
-            pendingChanges = builtPendingChanges
-            pendingShareInvites = builtPendingInvites
-
-            route = .childProfile
-            UpdateFeedLiveActivityUseCase.execute(
-                events: visibleEvents,
-                child: currentSummary.child,
-                activeSleep: currentActiveSleep,
-                isLiveActivityEnabled: isLiveActivityEnabled,
-                liveActivityManager: liveActivityManager
-            )
         } catch {
             AppLogger.shared.log(.error, category: "AppModel", "refresh failed: \(error)")
             setErrorMessage(resolveErrorMessage(for: error))
@@ -1031,43 +1010,6 @@ public final class AppModel {
         pendingChanges = []
         pendingShareInvites = []
         timelineChildID = nil
-    }
-
-    private func loadChildSummaries(
-        children: [Child],
-        userID: UUID
-    ) throws -> [ChildSummary] {
-        var summaries: [ChildSummary] = []
-
-        for child in children {
-            let memberships = try membershipRepository.loadMemberships(for: child.id)
-            guard let membership = memberships.first(where: { membership in
-                membership.userID == userID && membership.status == .active
-            }) else {
-                let statuses = memberships
-                    .filter { $0.userID == userID }
-                    .map { "\($0.status)" }
-                    .joined(separator: ", ")
-                let allRoles = memberships
-                    .map { "userID=\($0.userID == userID ? "self" : "other") role=\($0.role) status=\($0.status)" }
-                    .joined(separator: "; ")
-                logger.warning(
-                    "loadChildSummaries — skipping child '\(child.name, privacy: .private)': no active membership for local user. Self statuses: [\(statuses, privacy: .public)]. All memberships: [\(allRoles, privacy: .public)]"
-                )
-                AppLogger.shared.log(.warning, category: "AppModel", "loadChildSummaries — skipping child: no active membership for local user. Self statuses: [\(statuses)]. All memberships: [\(allRoles)]")
-                continue
-            }
-
-            summaries.append(ChildSummary(child: child, membership: membership))
-        }
-
-        return summaries.sorted { left, right in
-            left.child.createdAt < right.child.createdAt
-        }
-    }
-
-    private func loadVisibleEvents(for childID: UUID) throws -> [BabyEvent] {
-        try eventRepository.loadTimeline(for: childID, includingDeleted: false)
     }
 
     private func loadTimelinePages(


### PR DESCRIPTION
Breaks AppModel.refresh into focused, independently-testable units:

- LoadChildSummariesUseCase: attaches the local user's active membership
  to each child, skipping children with no active membership and sorting
  oldest-first. Replaces the private AppModel.loadChildSummaries method.

- ResolveChildWorkspaceUseCase: pure function that decides between
  .noActiveChildren / .needsChildSelection / .resolved given the active
  child list and a stored selection. No repository dependencies.

- LoadChildWorkspaceDataUseCase: loads events, active sleep, memberships,
  and membership users for the resolved child, and validates the local
  user still holds an active membership (throws otherwise).

Also moves ChildSummary to Domain (it is a business concept — a Child
paired with the local user's Membership — with no presentation
dependencies), and replaces the inline re-implementation in
sleepStartSuggestions() with a delegation to the existing
GetSleepStartSuggestionsUseCase.

Adds RefreshUseCasesDomainTests.swift with 21 focused Domain-layer tests
covering all three use cases using local stub repositories.

https://claude.ai/code/session_01A1cT2RNsRCJCcQFtvkYktv