### PR TITLE
feat: interactive onboarding with feature demos and first-event logging

### DIFF
--- a/Baby Tracker/App/AppRootView.swift
+++ b/Baby Tracker/App/AppRootView.swift
@@ -43,6 +43,15 @@ struct AppRootView: View {
         // Reset the stack when the app moves between top-level flows so stale
         // detail screens do not remain visible above a new root route.
         .id("\(String(describing: model.route))-\(model.navigationResetToken)")
+        // The interactive onboarding is presented as a full-screen cover so it
+        // persists across the route changes that occur when the user creates
+        // their profile and first child during setup.
+        .fullScreenCover(isPresented: Binding(
+            get: { model.isInteractiveOnboardingActive },
+            set: { model.isInteractiveOnboardingActive = $0 }
+        )) {
+            InteractiveOnboardingView(model: model)
+        }
         .overlay(alignment: .top) {
             ZStack(alignment: .topTrailing) {
                 if let errorMessage = model.errorMessage {

--- a/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/AppModel.swift
+++ b/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/AppModel.swift
@@ -21,6 +21,10 @@ public final class AppModel {
     public private(set) var sleepSheetRequestToken: Int = 0
     public var selectedWorkspaceTab: ChildWorkspaceTab = .home
     public var shareSheetState: ShareSheetState?
+    /// True while the interactive onboarding flow (new-user setup) is visible.
+    /// Persists across route changes so the full-screen cover remains on screen
+    /// during the user/child creation steps.
+    public var isInteractiveOnboardingActive = false
     public private(set) var csvImportState: CSVImportState = .idle
     public private(set) var nestImportState: NestImportState = .idle
     public private(set) var dataExportState: DataExportState = .idle
@@ -908,6 +912,9 @@ public final class AppModel {
 
             guard let localUser else {
                 route = .identityOnboarding
+                if !isInteractiveOnboardingActive {
+                    isInteractiveOnboardingActive = true
+                }
                 activeChildren = []
                 archivedChildren = []
                 clearProfileData()

--- a/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/OnboardingDemoDataFactory.swift
+++ b/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/OnboardingDemoDataFactory.swift
@@ -1,0 +1,83 @@
+import BabyTrackerDomain
+import Foundation
+
+/// Provides static demo data for the interactive onboarding feature showcase pages.
+/// All data is fabricated and never persisted.
+@MainActor
+enum OnboardingDemoDataFactory {
+
+    static var summaryViewModel: SummaryViewModel {
+        SummaryScreenPreviewFactory.summaryViewModel
+    }
+
+    /// Seven days of plausible timeline strip columns centred on today,
+    /// suitable for the `TimelineWeekView` demo embed.
+    static var timelineStripColumns: [TimelineStripDayColumnViewState] {
+        let calendar = Calendar(identifier: .gregorian)
+        let today = calendar.startOfDay(for: Date())
+        let formatter = DateFormatter()
+        formatter.locale = Locale.current
+
+        return (-6...0).map { dayOffset in
+            let date = calendar.date(byAdding: .day, value: dayOffset, to: today) ?? today
+            formatter.dateFormat = "EEE"
+            let weekday = formatter.string(from: date)
+            formatter.dateFormat = "d"
+            let dayNumber = formatter.string(from: date)
+
+            return TimelineStripDayColumnViewState(
+                date: date,
+                shortWeekdayTitle: weekday,
+                dayNumberTitle: dayNumber,
+                isToday: dayOffset == 0,
+                slots: slots(forDayOffset: dayOffset)
+            )
+        }
+    }
+
+    // MARK: - Private
+
+    private static func slots(forDayOffset offset: Int) -> [BabyEventKind?] {
+        // 24 slots, one per hour (index 0 = midnight)
+        var result: [BabyEventKind?] = Array(repeating: nil, count: 24)
+
+        // Night sleep: midnight through early morning
+        for hour in 0...4 { result[hour] = .sleep }
+
+        // Morning routine varies slightly by day
+        let feedHour = (offset % 2 == 0) ? 6 : 7
+        result[feedHour] = .breastFeed
+        result[feedHour + 1] = .nappy
+
+        // Mid-morning nap
+        result[9] = .sleep
+        result[10] = .sleep
+
+        // Midday feed
+        result[11] = .bottleFeed
+        result[12] = .nappy
+
+        // Afternoon nap — slightly staggered to look natural
+        let napHour = 13 + abs(offset % 2)
+        result[napHour] = .sleep
+        result[napHour + 1] = .sleep
+
+        // Afternoon feed
+        result[15] = .bottleFeed
+
+        // Evening routine
+        result[17] = .nappy
+        result[18] = .breastFeed
+
+        // Bedtime
+        result[19] = .sleep
+        result[20] = .sleep
+
+        // Late night feed — only on some days to vary the pattern
+        if offset % 3 == 0 {
+            result[23] = .bottleFeed
+        }
+
+        return result
+    }
+}

--- a/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/InteractiveOnboardingView.swift
+++ b/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/InteractiveOnboardingView.swift
@@ -1,0 +1,494 @@
+import BabyTrackerDomain
+import BabyTrackerPersistence
+import BabyTrackerSync
+import SwiftUI
+import UserNotifications
+
+/// The interactive onboarding experience for new users.
+///
+/// Presented as a `fullScreenCover` from `AppRootView` whenever
+/// `model.isInteractiveOnboardingActive` is true (set by `AppModel.refresh()`
+/// the first time a device has no local user). Persists across route changes
+/// so the user/child creation steps do not dismiss the flow prematurely.
+public struct InteractiveOnboardingView: View {
+    let model: AppModel
+
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+
+    @State private var currentStepIndex = 0
+    @State private var caregiverName = ""
+    @State private var childName = ""
+    @State private var includesBirthDate = false
+    @State private var babyBirthDate = Date()
+    @State private var viewOpacity = 0.0
+    @State private var notificationAuthorizationStatus: UNAuthorizationStatus = .notDetermined
+    @State private var isShowingNotificationPermissionPrompt = false
+
+    private static let welcomePage = OnboardingIntroPage(
+        id: "welcome",
+        title: "When every hour blurs together",
+        message: "Feeds, nappies, and short stretches of sleep are hard to keep track of when you're running on empty.",
+        symbolNames: [
+            "clock.badge.questionmark.fill",
+            "drop.fill",
+            "moon.zzz.fill",
+        ],
+        highlights: [
+            OnboardingIntroHighlight(title: "Last feed", symbolName: "drop.fill"),
+            OnboardingIntroHighlight(title: "Last sleep", symbolName: "moon.zzz.fill"),
+        ]
+    )
+
+    private enum Step: Int {
+        case welcome = 0
+        case quickLogDemo
+        case timelineDemo
+        case chartsDemo
+        case caregiverName
+        case babySetup
+        case firstEvent
+        case appPreview
+
+        var isSkippableToSetup: Bool {
+            switch self {
+            case .welcome, .quickLogDemo, .timelineDemo, .chartsDemo:
+                return true
+            default:
+                return false
+            }
+        }
+    }
+
+    private var currentStep: Step {
+        Step(rawValue: currentStepIndex) ?? .welcome
+    }
+
+    private var trimmedCaregiverName: String {
+        caregiverName.trimmingCharacters(in: .whitespaces)
+    }
+
+    private var trimmedChildName: String {
+        childName.trimmingCharacters(in: .whitespaces)
+    }
+
+    public init(model: AppModel) {
+        self.model = model
+    }
+
+    init(model: AppModel, previewStepIndex: Int) {
+        self.model = model
+        _currentStepIndex = State(initialValue: previewStepIndex)
+    }
+
+    public var body: some View {
+        ZStack {
+            LinearGradient(
+                colors: [
+                    Color(.systemGroupedBackground),
+                    Color.accentColor.opacity(0.08),
+                    Color(.systemGroupedBackground),
+                ],
+                startPoint: .topLeading,
+                endPoint: .bottomTrailing
+            )
+            .ignoresSafeArea()
+
+            VStack(spacing: 0) {
+                topBar
+
+                stepContent
+                    .animation(reduceMotion ? nil : .easeInOut(duration: 0.25), value: currentStepIndex)
+
+                Spacer(minLength: 24)
+
+                footer
+                    .padding(.horizontal, 24)
+                    .padding(.bottom, 24)
+            }
+        }
+        .task {
+            await refreshNotificationStatus()
+        }
+        .onAppear {
+            guard !reduceMotion else {
+                viewOpacity = 1
+                return
+            }
+            withAnimation(.easeIn(duration: 0.2)) {
+                viewOpacity = 1
+            }
+        }
+        .opacity(viewOpacity)
+        .alert("Enable Notifications?", isPresented: $isShowingNotificationPermissionPrompt) {
+            Button("Enable Notifications", action: requestNotificationAuthorization)
+            Button("Not Now", role: .cancel, action: { advance() })
+        } message: {
+            Text("Get a heads-up when another caregiver logs an event so you stay in the loop.")
+        }
+    }
+
+    // MARK: - Top bar
+
+    private var topBar: some View {
+        HStack {
+            Text("Nest")
+                .font(.headline)
+                .foregroundStyle(.secondary)
+
+            Spacer()
+
+            // Skip to caregiver name step from demo pages
+            if currentStep.isSkippableToSetup {
+                Button("Skip") {
+                    move(to: Step.caregiverName.rawValue)
+                }
+                .font(.subheadline.weight(.semibold))
+            }
+        }
+        .padding(.horizontal, 24)
+        .padding(.top, 20)
+    }
+
+    // MARK: - Step content
+
+    @ViewBuilder
+    private var stepContent: some View {
+        switch currentStep {
+        case .welcome:
+            VStack(spacing: 24) {
+                TabView(selection: .constant(0)) {
+                    OnboardingIntroStepView(page: Self.welcomePage)
+                        .tag(0)
+                        .padding(.horizontal, 24)
+                }
+                .tabViewStyle(.page(indexDisplayMode: .never))
+
+                pageIndicator
+            }
+
+        case .quickLogDemo:
+            demoPage(
+                title: "Log in seconds",
+                message: "Tap one button, fill in the details, done. No fumbling around."
+            ) {
+                OnboardingQuickLogDemoView()
+                    .clipShape(RoundedRectangle(cornerRadius: 24, style: .continuous))
+                    .shadow(color: .black.opacity(0.06), radius: 12, y: 4)
+            }
+
+        case .timelineDemo:
+            demoPage(
+                title: "See the whole picture",
+                message: "The timeline fills in as you log, so you can see the rhythm of any day at a glance."
+            ) {
+                OnboardingTimelineDemoView()
+            }
+
+        case .chartsDemo:
+            demoPage(
+                title: "Spot the patterns",
+                message: "The Summary tab turns raw events into charts so you can see what's changing week by week."
+            ) {
+                OnboardingChartsDemoView()
+            }
+
+        case .caregiverName:
+            IdentityOnboardingNameStepView(
+                displayName: $caregiverName,
+                submitAction: submitCaregiverName
+            )
+
+        case .babySetup:
+            OnboardingAddBabyStepView(
+                childName: $childName,
+                includesBirthDate: $includesBirthDate,
+                birthDate: $babyBirthDate,
+                addAction: submitBabySetup,
+                skipAction: dismissOnboarding
+            )
+
+        case .firstEvent:
+            OnboardingFirstEventStepView(
+                model: model,
+                onEventSaved: { advance() },
+                skipAction: dismissOnboarding
+            )
+
+        case .appPreview:
+            VStack(alignment: .leading, spacing: 0) {
+                VStack(alignment: .leading, spacing: 12) {
+                    Text("Here's your app")
+                        .font(.largeTitle.weight(.bold))
+
+                    Text("Everything you just logged is already there.")
+                        .font(.title3)
+                        .foregroundStyle(.secondary)
+                }
+                .padding(.horizontal, 24)
+                .padding(.top, 32)
+                .padding(.bottom, 16)
+
+                OnboardingAppPreviewStepView(model: model)
+            }
+        }
+    }
+
+    // MARK: - Footer
+
+    @ViewBuilder
+    private var footer: some View {
+        switch currentStep {
+        case .welcome, .quickLogDemo, .timelineDemo, .chartsDemo:
+            Button(action: advance) {
+                Text("Continue")
+                    .font(.headline)
+                    .frame(maxWidth: .infinity)
+                    .padding(.vertical, 16)
+            }
+            .buttonStyle(.borderedProminent)
+
+        case .caregiverName:
+            Button(action: submitCaregiverName) {
+                Text("Get Started")
+                    .font(.headline)
+                    .frame(maxWidth: .infinity)
+                    .padding(.vertical, 16)
+            }
+            .buttonStyle(.borderedProminent)
+            .disabled(trimmedCaregiverName.isEmpty)
+
+        case .babySetup:
+            VStack(spacing: 12) {
+                Button(action: submitBabySetup) {
+                    Text("Add Baby")
+                        .font(.headline)
+                        .frame(maxWidth: .infinity)
+                        .padding(.vertical, 16)
+                }
+                .buttonStyle(.borderedProminent)
+                .disabled(trimmedChildName.isEmpty)
+
+                Button(action: dismissOnboarding) {
+                    Text("Skip for now")
+                        .font(.subheadline.weight(.semibold))
+                        .foregroundStyle(.secondary)
+                }
+                .buttonStyle(.plain)
+            }
+
+        case .firstEvent:
+            Button(action: dismissOnboarding) {
+                Text("Skip for now")
+                    .font(.subheadline.weight(.semibold))
+                    .foregroundStyle(.secondary)
+            }
+            .buttonStyle(.plain)
+
+        case .appPreview:
+            Button(action: dismissOnboarding) {
+                Text("Let's Go")
+                    .font(.headline)
+                    .frame(maxWidth: .infinity)
+                    .padding(.vertical, 16)
+            }
+            .buttonStyle(.borderedProminent)
+        }
+    }
+
+    // MARK: - Page indicator (shown on demo steps 0–3)
+
+    private var pageIndicator: some View {
+        HStack(spacing: 8) {
+            ForEach(0..<4) { index in
+                Capsule()
+                    .fill(index == currentStepIndex ? Color.accentColor : Color.secondary.opacity(0.18))
+                    .frame(width: index == currentStepIndex ? 28 : 10, height: 10)
+            }
+        }
+        .accessibilityElement(children: .ignore)
+        .accessibilityLabel("Onboarding step \(currentStepIndex + 1) of 4")
+    }
+
+    // MARK: - Demo page layout
+
+    @ViewBuilder
+    private func demoPage<Demo: View>(
+        title: String,
+        message: String,
+        @ViewBuilder demo: () -> Demo
+    ) -> some View {
+        VStack(spacing: 0) {
+            VStack(alignment: .leading, spacing: 12) {
+                Text(title)
+                    .font(.largeTitle.weight(.bold))
+                    .fixedSize(horizontal: false, vertical: true)
+
+                Text(message)
+                    .font(.title3)
+                    .foregroundStyle(.secondary)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .padding(.horizontal, 24)
+            .padding(.top, 32)
+            .padding(.bottom, 20)
+
+            demo()
+                .padding(.horizontal, 24)
+
+            pageIndicator
+                .padding(.top, 20)
+        }
+    }
+
+    // MARK: - Step actions
+
+    private func advance() {
+        move(to: currentStepIndex + 1)
+    }
+
+    private func move(to index: Int) {
+        guard !reduceMotion else {
+            currentStepIndex = index
+            return
+        }
+        withAnimation(.easeInOut(duration: 0.25)) {
+            currentStepIndex = index
+        }
+    }
+
+    private func submitCaregiverName() {
+        guard !trimmedCaregiverName.isEmpty else { return }
+        model.createLocalUser(displayName: trimmedCaregiverName)
+        // Offer notification permission before moving to baby setup
+        if notificationAuthorizationStatus == .notDetermined {
+            isShowingNotificationPermissionPrompt = true
+        } else {
+            advance()
+        }
+    }
+
+    private func submitBabySetup() {
+        guard !trimmedChildName.isEmpty else { return }
+        model.createChild(
+            name: trimmedChildName,
+            birthDate: includesBirthDate ? babyBirthDate : nil
+        )
+        advance()
+    }
+
+    private func dismissOnboarding() {
+        model.isInteractiveOnboardingActive = false
+    }
+
+    // MARK: - Notification permission
+
+    private func refreshNotificationStatus() async {
+        let settings = await UNUserNotificationCenter.current().notificationSettings()
+        notificationAuthorizationStatus = settings.authorizationStatus
+    }
+
+    private func requestNotificationAuthorization() {
+        model.requestNotificationAuthorizationIfNeeded()
+        advance()
+    }
+}
+
+// MARK: - Previews
+
+#Preview("Welcome") {
+    InteractiveOnboardingView(
+        model: InteractiveOnboardingPreviewFactory.makeModel(),
+        previewStepIndex: 0
+    )
+}
+
+#Preview("Quick Log Demo") {
+    InteractiveOnboardingView(
+        model: InteractiveOnboardingPreviewFactory.makeModel(),
+        previewStepIndex: 1
+    )
+}
+
+#Preview("Timeline Demo") {
+    InteractiveOnboardingView(
+        model: InteractiveOnboardingPreviewFactory.makeModel(),
+        previewStepIndex: 2
+    )
+}
+
+#Preview("Charts Demo") {
+    InteractiveOnboardingView(
+        model: InteractiveOnboardingPreviewFactory.makeModel(),
+        previewStepIndex: 3
+    )
+}
+
+#Preview("Caregiver Name") {
+    InteractiveOnboardingView(
+        model: InteractiveOnboardingPreviewFactory.makeModel(),
+        previewStepIndex: 4
+    )
+}
+
+#Preview("Baby Setup") {
+    InteractiveOnboardingView(
+        model: InteractiveOnboardingPreviewFactory.makeModel(),
+        previewStepIndex: 5
+    )
+}
+
+#Preview("First Event") {
+    InteractiveOnboardingView(
+        model: ChildProfilePreviewFactory.makeModel(),
+        previewStepIndex: 6
+    )
+}
+
+#Preview("App Preview") {
+    InteractiveOnboardingView(
+        model: ChildProfilePreviewFactory.makeModel(),
+        previewStepIndex: 7
+    )
+}
+
+private enum InteractiveOnboardingPreviewFactory {
+    @MainActor
+    static func makeModel() -> AppModel {
+        let suiteName = "InteractiveOnboardingPreview"
+        let userDefaults = UserDefaults(suiteName: suiteName) ?? .standard
+        userDefaults.removePersistentDomain(forName: suiteName)
+
+        let store = try! BabyTrackerModelStore(isStoredInMemoryOnly: true)
+        let childRepository = SwiftDataChildRepository(store: store)
+        let userIdentityRepository = SwiftDataUserIdentityRepository(store: store, userDefaults: userDefaults)
+        let membershipRepository = SwiftDataMembershipRepository(store: store)
+        let childSelectionStore = UserDefaultsChildSelectionStore(userDefaults: userDefaults)
+        let eventRepository = SwiftDataEventRepository(store: store)
+        let syncStateRepository = SwiftDataSyncStateRepository(store: store)
+        let recordMetadataRepository = SwiftDataCloudKitRecordMetadataRepository(store: store)
+        let syncEngine = CloudKitSyncEngine(
+            childRepository: childRepository,
+            userIdentityRepository: userIdentityRepository,
+            membershipRepository: membershipRepository,
+            eventRepository: eventRepository,
+            syncStateRepository: syncStateRepository,
+            recordMetadataRepository: recordMetadataRepository,
+            client: UnavailableCloudKitClient()
+        )
+        let model = AppModel(
+            childRepository: childRepository,
+            userIdentityRepository: userIdentityRepository,
+            membershipRepository: membershipRepository,
+            childSelectionStore: childSelectionStore,
+            eventRepository: eventRepository,
+            syncEngine: syncEngine,
+            liveActivityManager: NoOpFeedLiveActivityManager(),
+            liveActivityPreferenceStore: InMemoryLiveActivityPreferenceStore(),
+            localNotificationManager: NoOpLocalNotificationManager(),
+            hapticFeedbackProvider: NoOpHapticFeedbackProvider()
+        )
+        model.load(performLaunchSync: false)
+        return model
+    }
+}

--- a/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/OnboardingAddBabyStepView.swift
+++ b/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/OnboardingAddBabyStepView.swift
@@ -1,0 +1,92 @@
+import SwiftUI
+
+/// The baby setup step in the interactive onboarding flow.
+/// Collects baby name and optional birth date before the user logs their first event.
+struct OnboardingAddBabyStepView: View {
+    @Binding var childName: String
+    @Binding var includesBirthDate: Bool
+    @Binding var birthDate: Date
+    let addAction: () -> Void
+    let skipAction: () -> Void
+
+    private var trimmedName: String {
+        childName.trimmingCharacters(in: .whitespaces)
+    }
+
+    var body: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: 24) {
+                VStack(alignment: .leading, spacing: 12) {
+                    Text("Now let's add your baby")
+                        .font(.largeTitle.weight(.bold))
+
+                    Text("You can always update this from the Profile tab.")
+                        .font(.title3)
+                        .foregroundStyle(.secondary)
+                        .fixedSize(horizontal: false, vertical: true)
+                }
+
+                VStack(alignment: .leading, spacing: 8) {
+                    Text("Baby's name")
+                        .font(.caption.weight(.semibold))
+                        .foregroundStyle(.secondary)
+                        .padding(.horizontal, 4)
+
+                    TextField("e.g. Olivia", text: $childName)
+                        .font(.title3)
+                        .textInputAutocapitalization(.words)
+                        .submitLabel(.done)
+                        .padding(16)
+                        .background(
+                            RoundedRectangle(cornerRadius: 18, style: .continuous)
+                                .fill(Color(.secondarySystemGroupedBackground))
+                        )
+                        .accessibilityIdentifier("onboarding-baby-name-field")
+                }
+
+                VStack(alignment: .leading, spacing: 12) {
+                    Toggle("Add birth date", isOn: $includesBirthDate)
+                        .font(.body.weight(.medium))
+
+                    if includesBirthDate {
+                        DatePicker(
+                            "Birth date",
+                            selection: $birthDate,
+                            in: ...Date(),
+                            displayedComponents: .date
+                        )
+                        .datePickerStyle(.compact)
+                        .labelsHidden()
+                        .transition(.opacity.combined(with: .move(edge: .top)))
+                    }
+                }
+                .animation(.easeInOut(duration: 0.2), value: includesBirthDate)
+                .padding(20)
+                .background(.thinMaterial, in: RoundedRectangle(cornerRadius: 24, style: .continuous))
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .padding(.horizontal, 24)
+            .padding(.top, 32)
+            .padding(.bottom, 8)
+        }
+        .scrollBounceBehavior(.basedOnSize)
+        .onSubmit {
+            guard !trimmedName.isEmpty else { return }
+            addAction()
+        }
+    }
+}
+
+#Preview {
+    @Previewable @State var name = ""
+    @Previewable @State var includesBirthDate = false
+    @Previewable @State var birthDate = Date()
+
+    OnboardingAddBabyStepView(
+        childName: $name,
+        includesBirthDate: $includesBirthDate,
+        birthDate: $birthDate,
+        addAction: {},
+        skipAction: {}
+    )
+}

--- a/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/OnboardingAppPreviewStepView.swift
+++ b/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/OnboardingAppPreviewStepView.swift
@@ -1,0 +1,36 @@
+import SwiftUI
+
+/// A non-interactive embed of the real `ChildHomeView` shown after the user logs
+/// their first event. Demonstrates what the app looks like with live data.
+struct OnboardingAppPreviewStepView: View {
+    let model: AppModel
+
+    @State private var homeViewModel: HomeViewModel
+    @State private var childProfileViewModel: ChildProfileViewModel
+
+    init(model: AppModel) {
+        self.model = model
+        _homeViewModel = State(initialValue: HomeViewModel(appModel: model))
+        _childProfileViewModel = State(initialValue: ChildProfileViewModel(appModel: model))
+    }
+
+    var body: some View {
+        ChildHomeView(
+            model: model,
+            viewModel: homeViewModel,
+            childProfileViewModel: childProfileViewModel,
+            stopSleep: {},
+            quickLogBreastFeed: {},
+            quickLogBottleFeed: {},
+            quickLogSleep: {},
+            quickLogNappy: {}
+        )
+        .allowsHitTesting(false)
+    }
+}
+
+#Preview {
+    OnboardingAppPreviewStepView(
+        model: ChildProfilePreviewFactory.makeModel()
+    )
+}

--- a/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/OnboardingChartsDemoView.swift
+++ b/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/OnboardingChartsDemoView.swift
@@ -1,0 +1,23 @@
+import SwiftUI
+
+/// A scaled, clipped, non-interactive embed of `SummaryScreenView` using static preview data.
+/// Used as the demo embed on the "Spot the patterns" onboarding page.
+struct OnboardingChartsDemoView: View {
+    @State private var viewModel = OnboardingDemoDataFactory.summaryViewModel
+    private let naturalHeight: CGFloat = 560
+
+    var body: some View {
+        SummaryScreenView(viewModel: viewModel)
+            .frame(height: naturalHeight)
+            .scaleEffect(0.72, anchor: .top)
+            .frame(height: naturalHeight * 0.72)
+            .clipped()
+            .clipShape(RoundedRectangle(cornerRadius: 24, style: .continuous))
+            .allowsHitTesting(false)
+    }
+}
+
+#Preview {
+    OnboardingChartsDemoView()
+        .padding(.horizontal, 24)
+}

--- a/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/OnboardingFirstEventStepView.swift
+++ b/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/OnboardingFirstEventStepView.swift
@@ -1,0 +1,191 @@
+import BabyTrackerDomain
+import SwiftUI
+
+/// The first-event logging step in the interactive onboarding flow.
+/// Presents the real quick-log editor sheets so the user can log an event before
+/// entering the main app. On a successful save the `onEventSaved` callback fires.
+struct OnboardingFirstEventStepView: View {
+    let model: AppModel
+    let onEventSaved: () -> Void
+    let skipAction: () -> Void
+
+    @State private var activeEventSheet: ChildEventSheet?
+    @State private var firstEventSaved = false
+
+    private var childName: String {
+        model.currentChild?.name ?? "your baby"
+    }
+
+    var body: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: 24) {
+                VStack(alignment: .leading, spacing: 12) {
+                    Text("Log your first event")
+                        .font(.largeTitle.weight(.bold))
+
+                    Text("Try it now — pick whichever happened most recently.")
+                        .font(.title3)
+                        .foregroundStyle(.secondary)
+                        .fixedSize(horizontal: false, vertical: true)
+                }
+
+                VStack(spacing: 12) {
+                    HStack(spacing: 12) {
+                        quickLogButton("Breast Feed", kind: .breastFeed) {
+                            activeEventSheet = .quickLogBreastFeed
+                        }
+                        quickLogButton("Bottle Feed", kind: .bottleFeed) {
+                            activeEventSheet = .quickLogBottleFeed
+                        }
+                    }
+
+                    HStack(spacing: 12) {
+                        quickLogButton("Start Sleep", kind: .sleep) {
+                            activeEventSheet = .startSleep(suggestions: [])
+                        }
+                        quickLogButton("Nappy", kind: .nappy) {
+                            activeEventSheet = .quickLogNappy(.mixed)
+                        }
+                    }
+                }
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .padding(.horizontal, 24)
+            .padding(.top, 32)
+            .padding(.bottom, 8)
+        }
+        .scrollBounceBehavior(.basedOnSize)
+        .sheet(item: $activeEventSheet, onDismiss: { activeEventSheet = nil }) { sheet in
+            eventSheet(for: sheet)
+        }
+        .onChange(of: firstEventSaved) { _, saved in
+            if saved { onEventSaved() }
+        }
+    }
+
+    private func quickLogButton(
+        _ title: String,
+        kind: BabyEventKind,
+        action: @escaping () -> Void
+    ) -> some View {
+        Button(action: action) {
+            Label(title, systemImage: BabyEventStyle.systemImage(for: kind))
+                .font(.headline)
+                .frame(maxWidth: .infinity, minHeight: 56, alignment: .leading)
+                .padding(.horizontal, 14)
+                .foregroundStyle(BabyEventStyle.buttonForegroundColor(for: kind))
+                .background(
+                    RoundedRectangle(cornerRadius: 18, style: .continuous)
+                        .fill(BabyEventStyle.buttonFillColor(for: kind))
+                )
+        }
+        .buttonStyle(.plain)
+    }
+
+    @ViewBuilder
+    private func eventSheet(for sheet: ChildEventSheet) -> some View {
+        switch sheet {
+        case .quickLogBreastFeed:
+            BreastFeedEditorSheetView(
+                navigationTitle: "Breast Feed",
+                primaryActionTitle: "Save",
+                childName: childName,
+                initialDurationMinutes: 15,
+                initialEndTime: Date(),
+                initialSide: nil
+            ) { durationMinutes, endTime, side, leftDurationSeconds, rightDurationSeconds in
+                let didSave = model.logBreastFeed(
+                    durationMinutes: durationMinutes,
+                    endTime: endTime,
+                    side: side,
+                    leftDurationSeconds: leftDurationSeconds,
+                    rightDurationSeconds: rightDurationSeconds
+                )
+                if didSave {
+                    activeEventSheet = nil
+                    firstEventSaved = true
+                }
+                return didSave
+            }
+
+        case .quickLogBottleFeed:
+            BottleFeedEditorSheetView(
+                navigationTitle: "Bottle Feed",
+                primaryActionTitle: "Save",
+                childName: childName,
+                preferredVolumeUnit: model.currentChild?.preferredFeedVolumeUnit ?? .milliliters,
+                initialAmountMilliliters: 120,
+                initialOccurredAt: Date(),
+                initialMilkType: .formula
+            ) { amountMilliliters, occurredAt, milkType in
+                let didSave = model.logBottleFeed(
+                    amountMilliliters: amountMilliliters,
+                    occurredAt: occurredAt,
+                    milkType: milkType
+                )
+                if didSave {
+                    activeEventSheet = nil
+                    firstEventSaved = true
+                }
+                return didSave
+            }
+
+        case let .startSleep(suggestions):
+            SleepEditorSheetView(
+                mode: .start,
+                childName: childName,
+                initialStartedAt: Date(),
+                initialEndedAt: nil,
+                startSuggestions: suggestions
+            ) { startedAt, endedAt in
+                let didSave: Bool
+                if let endedAt {
+                    didSave = model.logSleep(startedAt: startedAt, endedAt: endedAt)
+                } else {
+                    didSave = model.startSleep(startedAt: startedAt)
+                }
+                if didSave {
+                    activeEventSheet = nil
+                    firstEventSaved = true
+                }
+                return didSave
+            }
+
+        case let .quickLogNappy(type):
+            NappyEditorSheetView(
+                navigationTitle: "Nappy",
+                primaryActionTitle: "Save",
+                childName: childName,
+                initialType: type,
+                initialOccurredAt: Date(),
+                initialPeeVolume: nil,
+                initialPooVolume: nil,
+                initialPooColor: nil
+            ) { updatedType, occurredAt, peeVolume, pooVolume, pooColor in
+                let didSave = model.logNappy(
+                    type: updatedType,
+                    occurredAt: occurredAt,
+                    peeVolume: peeVolume,
+                    pooVolume: pooVolume,
+                    pooColor: pooColor
+                )
+                if didSave {
+                    activeEventSheet = nil
+                    firstEventSaved = true
+                }
+                return didSave
+            }
+
+        default:
+            EmptyView()
+        }
+    }
+}
+
+#Preview {
+    OnboardingFirstEventStepView(
+        model: ChildProfilePreviewFactory.makeModel(),
+        onEventSaved: {},
+        skipAction: {}
+    )
+}

--- a/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/OnboardingQuickLogDemoView.swift
+++ b/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/OnboardingQuickLogDemoView.swift
@@ -1,0 +1,46 @@
+import BabyTrackerDomain
+import SwiftUI
+
+/// A static, non-interactive replica of the Quick Log grid shown on the Home tab.
+/// Used as the demo embed on the "Log in seconds" onboarding page.
+struct OnboardingQuickLogDemoView: View {
+    var body: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            Text("Quick Log")
+                .font(.headline)
+                .padding(.horizontal, 16)
+
+            VStack(spacing: 12) {
+                HStack(spacing: 12) {
+                    demoButton("Breast Feed", kind: .breastFeed)
+                    demoButton("Bottle Feed", kind: .bottleFeed)
+                }
+
+                HStack(spacing: 12) {
+                    demoButton("Start Sleep", kind: .sleep)
+                    demoButton("Nappy", kind: .nappy)
+                }
+            }
+            .padding(.horizontal, 16)
+        }
+        .padding(.vertical, 12)
+        .background(Color(.systemGroupedBackground))
+    }
+
+    private func demoButton(_ title: String, kind: BabyEventKind) -> some View {
+        Label(title, systemImage: BabyEventStyle.systemImage(for: kind))
+            .font(.headline)
+            .frame(maxWidth: .infinity, minHeight: 56, alignment: .leading)
+            .padding(.horizontal, 14)
+            .foregroundStyle(BabyEventStyle.buttonForegroundColor(for: kind))
+            .background(
+                RoundedRectangle(cornerRadius: 18, style: .continuous)
+                    .fill(BabyEventStyle.buttonFillColor(for: kind))
+            )
+    }
+}
+
+#Preview {
+    OnboardingQuickLogDemoView()
+        .frame(width: 320)
+}

--- a/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/OnboardingTimelineDemoView.swift
+++ b/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/OnboardingTimelineDemoView.swift
@@ -1,0 +1,26 @@
+import SwiftUI
+
+/// A scaled, clipped, non-interactive embed of `TimelineWeekView` using static demo data.
+/// Used as the demo embed on the "See the whole picture" onboarding page.
+struct OnboardingTimelineDemoView: View {
+    private let naturalHeight: CGFloat = 380
+
+    var body: some View {
+        TimelineWeekView(
+            columns: OnboardingDemoDataFactory.timelineStripColumns,
+            selectedDay: .now,
+            showDay: { _ in }
+        )
+        .frame(height: naturalHeight)
+        .scaleEffect(0.75, anchor: .top)
+        .frame(height: naturalHeight * 0.75)
+        .clipped()
+        .clipShape(RoundedRectangle(cornerRadius: 24, style: .continuous))
+        .allowsHitTesting(false)
+    }
+}
+
+#Preview {
+    OnboardingTimelineDemoView()
+        .padding(.horizontal, 24)
+}

--- a/docs/plans/081-interactive-onboarding.md
+++ b/docs/plans/081-interactive-onboarding.md
@@ -1,0 +1,70 @@
+# 080 — Interactive Onboarding Experience
+
+## Goal
+
+Replace the static 4-page intro onboarding with a rich, interactive multi-step experience that:
+- Showcases the app's core features through inline demo views
+- Integrates baby setup directly into the onboarding
+- Guides the user through logging their first real event
+- Shows what the app looks like with live data before entering the main UI
+
+## Problem
+
+The existing `IdentityOnboardingView` shows 4 static, text-only intro pages followed by a caregiver name entry. After completing it, users land on a separate "no children" screen to add their baby. There is no guided first-event logging, no feature demos with real data, and no sense of what the app looks like populated.
+
+## Approach
+
+A new `InteractiveOnboardingView` is presented as a `fullScreenCover` from `AppRootView` whenever `model.isInteractiveOnboardingActive` is true. Using a full-screen cover rather than a route-based view means the onboarding survives the route changes that occur when `createLocalUser` and `createChild` are called mid-flow (which would otherwise transition the route away from `.identityOnboarding`).
+
+`AppModel.refresh()` sets `isInteractiveOnboardingActive = true` the first time it finds no local user, triggering the interactive onboarding on first launch. The replay-from-settings path (`showOnboarding()` from Profile) is unaffected — it sets `route = .identityOnboarding` with a local user already present, so `isInteractiveOnboardingActive` is never set and `IdentityOnboardingView` shows as before.
+
+### 8-step flow
+
+| Step | Name | What it shows |
+|------|------|---------------|
+| 0 | Welcome | Existing `OnboardingIntroStepView` with the pain-points page |
+| 1 | Quick Log Demo | `OnboardingQuickLogDemoView` — static replica of the 4 quick-log buttons |
+| 2 | Timeline Demo | `OnboardingTimelineDemoView` — scaled `TimelineWeekView` with demo data |
+| 3 | Charts Demo | `OnboardingChartsDemoView` — scaled `SummaryScreenView` with preview data |
+| 4 | Caregiver Name | `IdentityOnboardingNameStepView` (reused unchanged) |
+| 5 | Baby Setup | `OnboardingAddBabyStepView` — name + optional birthdate form |
+| 6 | First Event | `OnboardingFirstEventStepView` — real interactive quick-log buttons + editor sheets |
+| 7 | App Preview | `OnboardingAppPreviewStepView` — non-interactive `ChildHomeView` with live data |
+
+Steps 0–3 have a "Skip" button in the top bar that jumps to step 4 (caregiver name). Steps 5, 6 have a "Skip for now" link in the footer that exits the onboarding. Step 7 has "Let's Go" which dismisses the cover.
+
+At step 4, `model.createLocalUser()` is called — route changes to `.noChildren` but the full-screen cover stays visible.
+At step 5, `model.createChild()` is called — route changes to `.childProfile`.
+At step 6, the real event editors are presented and events are saved to the live database.
+At step 7, the real `ChildHomeView` renders with the just-logged event visible.
+
+Demo views use static data from `OnboardingDemoDataFactory` (timeline) and `SummaryScreenPreviewFactory` (charts). All demo views have `allowsHitTesting(false)`.
+
+## Files changed
+
+**New files (all in `Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/`):**
+- `Views/InteractiveOnboardingView.swift` — root container
+- `Views/OnboardingAddBabyStepView.swift` — step 5 baby form
+- `Views/OnboardingFirstEventStepView.swift` — step 6 first event logging
+- `Views/OnboardingAppPreviewStepView.swift` — step 7 live Home screen embed
+- `Views/OnboardingQuickLogDemoView.swift` — step 1 Quick Log demo
+- `Views/OnboardingTimelineDemoView.swift` — step 2 Timeline demo
+- `Views/OnboardingChartsDemoView.swift` — step 3 Charts demo
+- `OnboardingDemoDataFactory.swift` — static demo data factory
+
+**Modified files:**
+- `AppModel.swift` — added `isInteractiveOnboardingActive` property; set it in `refresh()` when `localUser == nil`
+- `Baby Tracker/App/AppRootView.swift` — added `fullScreenCover` driven by `isInteractiveOnboardingActive`
+
+**Unchanged:**
+- `IdentityOnboardingView.swift` — still used for settings replay path, no changes
+
+## Verification
+
+1. **First launch:** Delete app data / fresh install → interactive onboarding shows, all 8 steps work end-to-end, "Let's Go" lands on Home tab with logged event visible.
+2. **Skip paths:** Skip on steps 0–3 jumps to name entry. "Skip for now" on step 5 lands on noChildren screen. "Skip for now" on step 6 lands on Home tab.
+3. **Settings replay:** Profile → Replay Onboarding → legacy 4-page static flow shows.
+4. **Second child:** Add second child from Profile → noChildren → ChildCreationView path unaffected.
+5. **Tests pass:** `xcodebuild test` succeeds.
+
+- [x] Complete


### PR DESCRIPTION
## Summary

- Replaces the static 4-page intro onboarding with an 8-step interactive experience
- New users see inline demos of Quick Log, Timeline, and Summary charts before they set up their profile
- Baby setup (name + optional birthdate) is now integrated directly into the onboarding flow
- Users log their first real event during onboarding and see the live Home screen before entering the main app
- The existing settings replay path (`IdentityOnboardingView`) is unchanged

## How it works

The new `InteractiveOnboardingView` is presented as a `fullScreenCover` from `AppRootView`, driven by a new `AppModel.isInteractiveOnboardingActive` flag. Using a cover rather than a route-based view means the onboarding survives the route changes that occur when `createLocalUser` and `createChild` are called mid-flow. The flag is set automatically in `AppModel.refresh()` the first time a device has no local user, and cleared when the user completes or exits the flow.

## Test plan

- [ ] Fresh install (or delete app data): interactive onboarding shows, walk all 8 steps end-to-end, confirm "Let's Go" lands on Home tab with logged event
- [ ] Skip button on steps 0–3 jumps directly to name entry
- [ ] "Skip for now" on baby setup (step 5) lands on noChildren screen
- [ ] "Skip for now" on first event (step 6) lands on Home tab
- [ ] Profile → Replay Onboarding still shows the legacy 4-page static flow
- [ ] Adding a second child from Profile still works (noChildren → ChildCreationView)
- [ ] Build succeeds and test suite passes

## References

- Plan: `docs/plans/081-interactive-onboarding.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)