### PR TITLE
feat: add interactive onboarding with feature demos and first-event logging

### DIFF
--- a/Baby Tracker/App/AppRootView.swift
+++ b/Baby Tracker/App/AppRootView.swift
@@ -43,6 +43,15 @@ struct AppRootView: View {
         // Reset the stack when the app moves between top-level flows so stale
         // detail screens do not remain visible above a new root route.
         .id("\(String(describing: model.route))-\(model.navigationResetToken)")
+        // The interactive onboarding is presented as a full-screen cover so it
+        // persists across the route changes that occur when the user creates
+        // their profile and first child during setup.
+        .fullScreenCover(isPresented: Binding(
+            get: { model.isInteractiveOnboardingActive },
+            set: { model.isInteractiveOnboardingActive = $0 }
+        )) {
+            InteractiveOnboardingView(model: model)
+        }
         .overlay(alignment: .top) {
             ZStack(alignment: .topTrailing) {
                 if let errorMessage = model.errorMessage {

--- a/Packages/BabyTrackerFeature/Package.swift
+++ b/Packages/BabyTrackerFeature/Package.swift
@@ -15,6 +15,7 @@ let package = Package(
     ],
     dependencies: [
         .package(path: "../BabyTrackerDomain"),
+        .package(path: "../BabyTrackerLiveActivities"),
         .package(path: "../BabyTrackerPersistence"),
         .package(path: "../BabyTrackerSync"),
     ],
@@ -23,6 +24,7 @@ let package = Package(
             name: "BabyTrackerFeature",
             dependencies: [
                 .product(name: "BabyTrackerDomain", package: "BabyTrackerDomain"),
+                .product(name: "BabyTrackerLiveActivities", package: "BabyTrackerLiveActivities"),
                 .product(name: "BabyTrackerPersistence", package: "BabyTrackerPersistence"),
                 .product(name: "BabyTrackerSync", package: "BabyTrackerSync"),
             ]

--- a/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/AppModel.swift
+++ b/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/AppModel.swift
@@ -1901,9 +1901,16 @@ public final class AppModel {
 public extension AppModel {
     /// Creates a throw-away, fully in-memory model for previewing the interactive
     /// onboarding without touching the user's real stored data.
+    ///
+    /// SwiftData uses an in-memory store (no disk writes). CloudKit is blocked via
+    /// `UnavailableCloudKitClient`. UserDefaults uses a fixed isolated suite that is
+    /// wiped before each demo session so no stale entries accumulate on disk.
     @MainActor
     static func makeInMemoryDemoModel() -> AppModel {
-        let suiteName = "InMemoryDemoModel-\(UUID().uuidString)"
+        // Use a fixed suite name and clear it before each run so demo sessions
+        // never accumulate stale plist entries in the app's Preferences directory.
+        let suiteName = "com.adappt.BabyTracker.onboardingPreview"
+        UserDefaults.standard.removePersistentDomain(forName: suiteName)
         let userDefaults = UserDefaults(suiteName: suiteName) ?? .standard
         let store = try! BabyTrackerModelStore(isStoredInMemoryOnly: true)
         let childRepository = SwiftDataChildRepository(store: store)

--- a/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/AppModel.swift
+++ b/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/AppModel.swift
@@ -1895,3 +1895,48 @@ public final class AppModel {
         hapticFeedbackProvider.play(event)
     }
 }
+
+// MARK: - In-memory demo factory
+
+public extension AppModel {
+    /// Creates a throw-away, fully in-memory model for previewing the interactive
+    /// onboarding without touching the user's real stored data.
+    @MainActor
+    static func makeInMemoryDemoModel() -> AppModel {
+        let suiteName = "InMemoryDemoModel-\(UUID().uuidString)"
+        let userDefaults = UserDefaults(suiteName: suiteName) ?? .standard
+        let store = try! BabyTrackerModelStore(isStoredInMemoryOnly: true)
+        let childRepository = SwiftDataChildRepository(store: store)
+        let userIdentityRepository = SwiftDataUserIdentityRepository(store: store, userDefaults: userDefaults)
+        let membershipRepository = SwiftDataMembershipRepository(store: store)
+        let childSelectionStore = UserDefaultsChildSelectionStore(userDefaults: userDefaults)
+        let eventRepository = SwiftDataEventRepository(store: store)
+        let syncStateRepository = SwiftDataSyncStateRepository(store: store)
+        let recordMetadataRepository = SwiftDataCloudKitRecordMetadataRepository(store: store)
+        let syncEngine = CloudKitSyncEngine(
+            childRepository: childRepository,
+            userIdentityRepository: userIdentityRepository,
+            membershipRepository: membershipRepository,
+            eventRepository: eventRepository,
+            syncStateRepository: syncStateRepository,
+            recordMetadataRepository: recordMetadataRepository,
+            client: UnavailableCloudKitClient()
+        )
+        let model = AppModel(
+            childRepository: childRepository,
+            userIdentityRepository: userIdentityRepository,
+            membershipRepository: membershipRepository,
+            childSelectionStore: childSelectionStore,
+            eventRepository: eventRepository,
+            syncEngine: syncEngine,
+            liveActivityManager: NoOpFeedLiveActivityManager(),
+            liveActivityPreferenceStore: InMemoryLiveActivityPreferenceStore(),
+            localNotificationManager: NoOpLocalNotificationManager(),
+            hapticFeedbackProvider: NoOpHapticFeedbackProvider()
+        )
+        // load() triggers refresh() which finds no local user and sets
+        // isInteractiveOnboardingActive = true, starting the onboarding flow.
+        model.load(performLaunchSync: false)
+        return model
+    }
+}

--- a/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/AppModel.swift
+++ b/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/AppModel.swift
@@ -21,6 +21,10 @@ public final class AppModel {
     public private(set) var sleepSheetRequestToken: Int = 0
     public var selectedWorkspaceTab: ChildWorkspaceTab = .home
     public var shareSheetState: ShareSheetState?
+    /// True while the interactive onboarding flow (new-user setup) is visible.
+    /// Persists across route changes so the full-screen cover remains on screen
+    /// during the user/child creation steps.
+    public var isInteractiveOnboardingActive = false
     public private(set) var csvImportState: CSVImportState = .idle
     public private(set) var nestImportState: NestImportState = .idle
     public private(set) var dataExportState: DataExportState = .idle
@@ -908,6 +912,9 @@ public final class AppModel {
 
             guard let localUser else {
                 route = .identityOnboarding
+                if !isInteractiveOnboardingActive {
+                    isInteractiveOnboardingActive = true
+                }
                 activeChildren = []
                 archivedChildren = []
                 clearProfileData()

--- a/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/OnboardingDemoDataFactory.swift
+++ b/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/OnboardingDemoDataFactory.swift
@@ -1,0 +1,83 @@
+import BabyTrackerDomain
+import Foundation
+
+/// Provides static demo data for the interactive onboarding feature showcase pages.
+/// All data is fabricated and never persisted.
+@MainActor
+enum OnboardingDemoDataFactory {
+
+    static var summaryViewModel: SummaryViewModel {
+        SummaryScreenPreviewFactory.summaryViewModel
+    }
+
+    /// Seven days of plausible timeline strip columns centred on today,
+    /// suitable for the `TimelineWeekView` demo embed.
+    static var timelineStripColumns: [TimelineStripDayColumnViewState] {
+        let calendar = Calendar(identifier: .gregorian)
+        let today = calendar.startOfDay(for: Date())
+        let formatter = DateFormatter()
+        formatter.locale = Locale.current
+
+        return (-6...0).map { dayOffset in
+            let date = calendar.date(byAdding: .day, value: dayOffset, to: today) ?? today
+            formatter.dateFormat = "EEE"
+            let weekday = formatter.string(from: date)
+            formatter.dateFormat = "d"
+            let dayNumber = formatter.string(from: date)
+
+            return TimelineStripDayColumnViewState(
+                date: date,
+                shortWeekdayTitle: weekday,
+                dayNumberTitle: dayNumber,
+                isToday: dayOffset == 0,
+                slots: slots(forDayOffset: dayOffset)
+            )
+        }
+    }
+
+    // MARK: - Private
+
+    private static func slots(forDayOffset offset: Int) -> [BabyEventKind?] {
+        // 24 slots, one per hour (index 0 = midnight)
+        var result: [BabyEventKind?] = Array(repeating: nil, count: 24)
+
+        // Night sleep: midnight through early morning
+        for hour in 0...4 { result[hour] = .sleep }
+
+        // Morning routine varies slightly by day
+        let feedHour = (offset % 2 == 0) ? 6 : 7
+        result[feedHour] = .breastFeed
+        result[feedHour + 1] = .nappy
+
+        // Mid-morning nap
+        result[9] = .sleep
+        result[10] = .sleep
+
+        // Midday feed
+        result[11] = .bottleFeed
+        result[12] = .nappy
+
+        // Afternoon nap — slightly staggered to look natural
+        let napHour = 13 + abs(offset % 2)
+        result[napHour] = .sleep
+        result[napHour + 1] = .sleep
+
+        // Afternoon feed
+        result[15] = .bottleFeed
+
+        // Evening routine
+        result[17] = .nappy
+        result[18] = .breastFeed
+
+        // Bedtime
+        result[19] = .sleep
+        result[20] = .sleep
+
+        // Late night feed — only on some days to vary the pattern
+        if offset % 3 == 0 {
+            result[23] = .bottleFeed
+        }
+
+        return result
+    }
+}

--- a/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/AnimatedSymbolSceneView.swift
+++ b/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/AnimatedSymbolSceneView.swift
@@ -4,6 +4,7 @@ struct AnimatedSymbolSceneView: View {
     let symbolNames: [String]
 
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
+    @Environment(\.colorScheme) private var colorScheme
     @ScaledMetric(relativeTo: .largeTitle) private var symbolSize = 56
 
     @State private var currentSymbolIndex = 0
@@ -25,18 +26,18 @@ struct AnimatedSymbolSceneView: View {
                 )
 
             Circle()
-                .fill(Color.white.opacity(0.4))
+                .fill(glowColor)
                 .frame(width: 116, height: 116)
-                .blur(radius: 18)
+                .blur(radius: glowBlurRadius)
                 .offset(x: -48, y: -34)
 
             Image(systemName: currentSymbolName)
                 .font(.system(size: symbolSize, weight: .semibold))
-                .symbolRenderingMode(.hierarchical)
-                .foregroundStyle(Color.accentColor)
+                .symbolRenderingMode(.palette)
+                .foregroundStyle(symbolPrimaryColor, symbolSecondaryColor)
                 .contentTransition(.symbolEffect(.replace.downUp.wholeSymbol))
                 .symbolEffect(.bounce.down.byLayer, value: symbolAnimationTrigger)
-                .shadow(color: Color.accentColor.opacity(0.18), radius: 12, y: 6)
+                .shadow(color: symbolShadowColor, radius: 12, y: 6)
         }
         .frame(maxWidth: .infinity)
         .frame(height: 196)
@@ -83,6 +84,33 @@ struct AnimatedSymbolSceneView: View {
         }
 
         return symbolNames[currentSymbolIndex]
+    }
+
+    private var glowColor: Color {
+        switch colorScheme {
+        case .dark:
+            return Color.accentColor.opacity(0.16)
+        case .light:
+            return Color.white.opacity(0.4)
+        @unknown default:
+            return Color.white.opacity(0.4)
+        }
+    }
+
+    private var glowBlurRadius: CGFloat {
+        colorScheme == .dark ? 26 : 18
+    }
+
+    private var symbolPrimaryColor: Color {
+        colorScheme == .dark ? .white : Color.accentColor
+    }
+
+    private var symbolSecondaryColor: Color {
+        Color.accentColor
+    }
+
+    private var symbolShadowColor: Color {
+        colorScheme == .dark ? Color.accentColor.opacity(0.28) : Color.accentColor.opacity(0.18)
     }
 }
 

--- a/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/AppSettingsView.swift
+++ b/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/AppSettingsView.swift
@@ -4,6 +4,7 @@ import SwiftUI
 public struct AppSettingsView: View {
     let model: AppModel
     let viewModel: ChildProfileViewModel
+    @State private var demoOnboardingModel: AppModel?
 
     public init(
         model: AppModel,
@@ -72,6 +73,17 @@ public struct AppSettingsView: View {
                     )
                 }
                 .foregroundStyle(.primary)
+
+                Button {
+                    demoOnboardingModel = AppModel.makeInMemoryDemoModel()
+                } label: {
+                    settingsRow(
+                        title: "Preview New Onboarding",
+                        value: nil,
+                        accessibilityIdentifier: "app-settings-preview-onboarding-row"
+                    )
+                }
+                .foregroundStyle(.primary)
             }
 
             Section("Account Reset") {
@@ -107,6 +119,14 @@ public struct AppSettingsView: View {
         .listStyle(.insetGrouped)
         .navigationTitle("App Settings")
         .navigationBarTitleDisplayMode(.inline)
+        .fullScreenCover(isPresented: Binding(
+            get: { demoOnboardingModel?.isInteractiveOnboardingActive ?? false },
+            set: { isActive in if !isActive { demoOnboardingModel = nil } }
+        )) {
+            if let dm = demoOnboardingModel {
+                InteractiveOnboardingView(model: dm)
+            }
+        }
     }
 
     private var appVersion: String {

--- a/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/IdentityOnboardingNameStepView.swift
+++ b/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/IdentityOnboardingNameStepView.swift
@@ -7,6 +7,12 @@ struct IdentityOnboardingNameStepView: View {
     var body: some View {
         ScrollView {
             VStack(alignment: .leading, spacing: 24) {
+                AnimatedSymbolSceneView(symbolNames: [
+                    "person.crop.circle.fill",
+                    "heart.fill",
+                    "figure.and.child.holdinghands",
+                ])
+
                 VStack(alignment: .leading, spacing: 12) {
                     Text("Let’s set up your profile")
                         .font(.largeTitle.weight(.bold))

--- a/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/InteractiveOnboardingView.swift
+++ b/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/InteractiveOnboardingView.swift
@@ -159,23 +159,17 @@ public struct InteractiveOnboardingView: View {
     private var stepContent: some View {
         switch currentStep {
         case .welcome:
-            VStack(spacing: 24) {
-                TabView(selection: .constant(0)) {
-                    OnboardingIntroStepView(page: Self.welcomePage)
-                        .tag(0)
-                        .padding(.horizontal, 24)
-                }
-                .tabViewStyle(.page(indexDisplayMode: .never))
-
-                pageIndicator
+            TabView(selection: .constant(0)) {
+                OnboardingIntroStepView(page: Self.welcomePage)
+                    .tag(0)
+                    .padding(.horizontal, 24)
             }
+            .tabViewStyle(.page(indexDisplayMode: .never))
 
         case .quickLogDemo:
             OnboardingDemoPageContainer(
                 title: "Log in seconds",
-                message: "Tap one button, fill in the details, done. No fumbling around.",
-                pageIndex: currentStepIndex,
-                totalDemoPages: 4
+                message: "Tap one button, fill in the details, done. No fumbling around."
             ) {
                 OnboardingQuickLogDemoView()
                     .clipShape(RoundedRectangle(cornerRadius: 24, style: .continuous))
@@ -185,9 +179,7 @@ public struct InteractiveOnboardingView: View {
         case .timelineDemo:
             OnboardingDemoPageContainer(
                 title: "See the whole picture",
-                message: "The timeline fills in as you log, so you can see the rhythm of any day at a glance.",
-                pageIndex: currentStepIndex,
-                totalDemoPages: 4
+                message: "The timeline fills in as you log, so you can see the rhythm of any day at a glance."
             ) {
                 OnboardingTimelineDemoView()
             }
@@ -195,9 +187,7 @@ public struct InteractiveOnboardingView: View {
         case .chartsDemo:
             OnboardingDemoPageContainer(
                 title: "Spot the patterns",
-                message: "The Summary tab turns raw events into charts so you can see what's changing week by week.",
-                pageIndex: currentStepIndex,
-                totalDemoPages: 4
+                message: "The Summary tab turns raw events into charts so you can see what's changing week by week."
             ) {
                 OnboardingChartsDemoView()
             }
@@ -235,13 +225,16 @@ public struct InteractiveOnboardingView: View {
     private var footer: some View {
         switch currentStep {
         case .welcome, .quickLogDemo, .timelineDemo, .chartsDemo:
-            Button(action: advance) {
-                Text("Continue")
-                    .font(.headline)
-                    .frame(maxWidth: .infinity)
-                    .padding(.vertical, 16)
+            VStack(spacing: 16) {
+                pageIndicator
+                Button(action: advance) {
+                    Text("Continue")
+                        .font(.headline)
+                        .frame(maxWidth: .infinity)
+                        .padding(.vertical, 16)
+                }
+                .buttonStyle(.borderedProminent)
             }
-            .buttonStyle(.borderedProminent)
 
         case .caregiverName:
             Button(action: submitCaregiverName) {

--- a/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/InteractiveOnboardingView.swift
+++ b/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/InteractiveOnboardingView.swift
@@ -2,6 +2,7 @@ import BabyTrackerDomain
 import BabyTrackerPersistence
 import BabyTrackerSync
 import SwiftUI
+import UIKit
 import UserNotifications
 
 /// The interactive onboarding experience for new users.
@@ -14,6 +15,7 @@ public struct InteractiveOnboardingView: View {
     let model: AppModel
 
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
+    @Environment(\.openURL) private var openURL
 
     @State private var currentStepIndex = 0
     @State private var isGoingBack = false
@@ -23,7 +25,7 @@ public struct InteractiveOnboardingView: View {
     @State private var babyBirthDate = Date()
     @State private var viewOpacity = 0.0
     @State private var notificationAuthorizationStatus: UNAuthorizationStatus = .notDetermined
-    @State private var isShowingNotificationPermissionPrompt = false
+    @State private var activeNotificationAlert: NotificationAlert?
 
     private static let welcomePage = OnboardingIntroPage(
         id: "welcome",
@@ -58,6 +60,18 @@ public struct InteractiveOnboardingView: View {
                 return true
             default:
                 return false
+            }
+        }
+    }
+
+    private enum NotificationAlert: Identifiable {
+        case prePrompt
+        case denied
+
+        var id: Int {
+            switch self {
+            case .prePrompt: return 0
+            case .denied: return 1
             }
         }
     }
@@ -135,11 +149,23 @@ public struct InteractiveOnboardingView: View {
                 }
         )
         .opacity(viewOpacity)
-        .alert("Enable Notifications?", isPresented: $isShowingNotificationPermissionPrompt) {
-            Button("Continue", action: requestNotificationAuthorization)
-            Button("Not Now", role: .cancel, action: continueWithoutNotificationPermission)
-        } message: {
-            Text("We'll show the system prompt next so Nest can send helpful alerts.")
+        .alert(item: $activeNotificationAlert) { alert in
+            switch alert {
+            case .prePrompt:
+                Alert(
+                    title: Text("Enable Notifications?"),
+                    message: Text("We'll show the system prompt next so Nest can send helpful alerts."),
+                    primaryButton: .default(Text("Continue"), action: requestNotificationAuthorization),
+                    secondaryButton: .cancel(Text("Not Now"), action: continueWithoutNotificationPermission)
+                )
+            case .denied:
+                Alert(
+                    title: Text("Notifications Are Off"),
+                    message: Text("To enable alerts, update notification permissions for Nest in Settings."),
+                    primaryButton: .default(Text("Open Settings"), action: openSettingsForNotifications),
+                    secondaryButton: .cancel(Text("Not Now"), action: continueWithoutNotificationPermission)
+                )
+            }
         }
     }
 
@@ -153,7 +179,6 @@ public struct InteractiveOnboardingView: View {
 
             Spacer()
 
-            // Skip to caregiver name step from demo pages
             if currentStep.isSkippableToSetup {
                 Button("Skip") {
                     move(to: Step.caregiverName.rawValue)
@@ -395,14 +420,25 @@ public struct InteractiveOnboardingView: View {
         switch notificationAuthorizationStatus {
         case .authorized, .provisional, .ephemeral:
             advance()
-        case .notDetermined, .denied:
-            isShowingNotificationPermissionPrompt = true
+        case .notDetermined:
+            activeNotificationAlert = .prePrompt
+        case .denied:
+            activeNotificationAlert = .denied
         @unknown default:
-            isShowingNotificationPermissionPrompt = true
+            activeNotificationAlert = .prePrompt
         }
     }
 
     private func continueWithoutNotificationPermission() {
+        advance()
+    }
+
+    private func openSettingsForNotifications() {
+        guard let url = URL(string: UIApplication.openSettingsURLString) else {
+            advance()
+            return
+        }
+        openURL(url)
         advance()
     }
 }

--- a/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/InteractiveOnboardingView.swift
+++ b/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/InteractiveOnboardingView.swift
@@ -1,0 +1,494 @@
+import BabyTrackerDomain
+import BabyTrackerPersistence
+import BabyTrackerSync
+import SwiftUI
+import UserNotifications
+
+/// The interactive onboarding experience for new users.
+///
+/// Presented as a `fullScreenCover` from `AppRootView` whenever
+/// `model.isInteractiveOnboardingActive` is true (set by `AppModel.refresh()`
+/// the first time a device has no local user). Persists across route changes
+/// so the user/child creation steps do not dismiss the flow prematurely.
+public struct InteractiveOnboardingView: View {
+    let model: AppModel
+
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+
+    @State private var currentStepIndex = 0
+    @State private var caregiverName = ""
+    @State private var childName = ""
+    @State private var includesBirthDate = false
+    @State private var babyBirthDate = Date()
+    @State private var viewOpacity = 0.0
+    @State private var notificationAuthorizationStatus: UNAuthorizationStatus = .notDetermined
+    @State private var isShowingNotificationPermissionPrompt = false
+
+    private static let welcomePage = OnboardingIntroPage(
+        id: "welcome",
+        title: "When every hour blurs together",
+        message: "Feeds, nappies, and short stretches of sleep are hard to keep track of when you're running on empty.",
+        symbolNames: [
+            "clock.badge.questionmark.fill",
+            "drop.fill",
+            "moon.zzz.fill",
+        ],
+        highlights: [
+            OnboardingIntroHighlight(title: "Last feed", symbolName: "drop.fill"),
+            OnboardingIntroHighlight(title: "Last sleep", symbolName: "moon.zzz.fill"),
+        ]
+    )
+
+    private enum Step: Int {
+        case welcome = 0
+        case quickLogDemo
+        case timelineDemo
+        case chartsDemo
+        case caregiverName
+        case babySetup
+        case firstEvent
+        case appPreview
+
+        var isSkippableToSetup: Bool {
+            switch self {
+            case .welcome, .quickLogDemo, .timelineDemo, .chartsDemo:
+                return true
+            default:
+                return false
+            }
+        }
+    }
+
+    private var currentStep: Step {
+        Step(rawValue: currentStepIndex) ?? .welcome
+    }
+
+    private var trimmedCaregiverName: String {
+        caregiverName.trimmingCharacters(in: .whitespaces)
+    }
+
+    private var trimmedChildName: String {
+        childName.trimmingCharacters(in: .whitespaces)
+    }
+
+    public init(model: AppModel) {
+        self.model = model
+    }
+
+    init(model: AppModel, previewStepIndex: Int) {
+        self.model = model
+        _currentStepIndex = State(initialValue: previewStepIndex)
+    }
+
+    public var body: some View {
+        ZStack {
+            LinearGradient(
+                colors: [
+                    Color(.systemGroupedBackground),
+                    Color.accentColor.opacity(0.08),
+                    Color(.systemGroupedBackground),
+                ],
+                startPoint: .topLeading,
+                endPoint: .bottomTrailing
+            )
+            .ignoresSafeArea()
+
+            VStack(spacing: 0) {
+                topBar
+
+                stepContent
+                    .animation(reduceMotion ? nil : .easeInOut(duration: 0.25), value: currentStepIndex)
+
+                Spacer(minLength: 24)
+
+                footer
+                    .padding(.horizontal, 24)
+                    .padding(.bottom, 24)
+            }
+        }
+        .task {
+            await refreshNotificationStatus()
+        }
+        .onAppear {
+            guard !reduceMotion else {
+                viewOpacity = 1
+                return
+            }
+            withAnimation(.easeIn(duration: 0.2)) {
+                viewOpacity = 1
+            }
+        }
+        .opacity(viewOpacity)
+        .alert("Enable Notifications?", isPresented: $isShowingNotificationPermissionPrompt) {
+            Button("Enable Notifications", action: requestNotificationAuthorization)
+            Button("Not Now", role: .cancel, action: { advance() })
+        } message: {
+            Text("Get a heads-up when another caregiver logs an event so you stay in the loop.")
+        }
+    }
+
+    // MARK: - Top bar
+
+    private var topBar: some View {
+        HStack {
+            Text("Nest")
+                .font(.headline)
+                .foregroundStyle(.secondary)
+
+            Spacer()
+
+            // Skip to caregiver name step from demo pages
+            if currentStep.isSkippableToSetup {
+                Button("Skip") {
+                    move(to: Step.caregiverName.rawValue)
+                }
+                .font(.subheadline.weight(.semibold))
+            }
+        }
+        .padding(.horizontal, 24)
+        .padding(.top, 20)
+    }
+
+    // MARK: - Step content
+
+    @ViewBuilder
+    private var stepContent: some View {
+        switch currentStep {
+        case .welcome:
+            VStack(spacing: 24) {
+                TabView(selection: .constant(0)) {
+                    OnboardingIntroStepView(page: Self.welcomePage)
+                        .tag(0)
+                        .padding(.horizontal, 24)
+                }
+                .tabViewStyle(.page(indexDisplayMode: .never))
+
+                pageIndicator
+            }
+
+        case .quickLogDemo:
+            demoPage(
+                title: "Log in seconds",
+                message: "Tap one button, fill in the details, done. No fumbling around."
+            ) {
+                OnboardingQuickLogDemoView()
+                    .clipShape(RoundedRectangle(cornerRadius: 24, style: .continuous))
+                    .shadow(color: .black.opacity(0.06), radius: 12, y: 4)
+            }
+
+        case .timelineDemo:
+            demoPage(
+                title: "See the whole picture",
+                message: "The timeline fills in as you log, so you can see the rhythm of any day at a glance."
+            ) {
+                OnboardingTimelineDemoView()
+            }
+
+        case .chartsDemo:
+            demoPage(
+                title: "Spot the patterns",
+                message: "The Summary tab turns raw events into charts so you can see what's changing week by week."
+            ) {
+                OnboardingChartsDemoView()
+            }
+
+        case .caregiverName:
+            IdentityOnboardingNameStepView(
+                displayName: $caregiverName,
+                submitAction: submitCaregiverName
+            )
+
+        case .babySetup:
+            OnboardingAddBabyStepView(
+                childName: $childName,
+                includesBirthDate: $includesBirthDate,
+                birthDate: $babyBirthDate,
+                addAction: submitBabySetup,
+                skipAction: dismissOnboarding
+            )
+
+        case .firstEvent:
+            OnboardingFirstEventStepView(
+                model: model,
+                onEventSaved: { advance() },
+                skipAction: dismissOnboarding
+            )
+
+        case .appPreview:
+            VStack(alignment: .leading, spacing: 0) {
+                VStack(alignment: .leading, spacing: 12) {
+                    Text("Here's your app")
+                        .font(.largeTitle.weight(.bold))
+
+                    Text("Everything you just logged is already there.")
+                        .font(.title3)
+                        .foregroundStyle(.secondary)
+                }
+                .padding(.horizontal, 24)
+                .padding(.top, 32)
+                .padding(.bottom, 16)
+
+                OnboardingAppPreviewStepView(model: model)
+            }
+        }
+    }
+
+    // MARK: - Footer
+
+    @ViewBuilder
+    private var footer: some View {
+        switch currentStep {
+        case .welcome, .quickLogDemo, .timelineDemo, .chartsDemo:
+            Button(action: advance) {
+                Text("Continue")
+                    .font(.headline)
+                    .frame(maxWidth: .infinity)
+                    .padding(.vertical, 16)
+            }
+            .buttonStyle(.borderedProminent)
+
+        case .caregiverName:
+            Button(action: submitCaregiverName) {
+                Text("Get Started")
+                    .font(.headline)
+                    .frame(maxWidth: .infinity)
+                    .padding(.vertical, 16)
+            }
+            .buttonStyle(.borderedProminent)
+            .disabled(trimmedCaregiverName.isEmpty)
+
+        case .babySetup:
+            VStack(spacing: 12) {
+                Button(action: submitBabySetup) {
+                    Text("Add Baby")
+                        .font(.headline)
+                        .frame(maxWidth: .infinity)
+                        .padding(.vertical, 16)
+                }
+                .buttonStyle(.borderedProminent)
+                .disabled(trimmedChildName.isEmpty)
+
+                Button(action: dismissOnboarding) {
+                    Text("Skip for now")
+                        .font(.subheadline.weight(.semibold))
+                        .foregroundStyle(.secondary)
+                }
+                .buttonStyle(.plain)
+            }
+
+        case .firstEvent:
+            Button(action: dismissOnboarding) {
+                Text("Skip for now")
+                    .font(.subheadline.weight(.semibold))
+                    .foregroundStyle(.secondary)
+            }
+            .buttonStyle(.plain)
+
+        case .appPreview:
+            Button(action: dismissOnboarding) {
+                Text("Let's Go")
+                    .font(.headline)
+                    .frame(maxWidth: .infinity)
+                    .padding(.vertical, 16)
+            }
+            .buttonStyle(.borderedProminent)
+        }
+    }
+
+    // MARK: - Page indicator (shown on demo steps 0–3)
+
+    private var pageIndicator: some View {
+        HStack(spacing: 8) {
+            ForEach(0..<4) { index in
+                Capsule()
+                    .fill(index == currentStepIndex ? Color.accentColor : Color.secondary.opacity(0.18))
+                    .frame(width: index == currentStepIndex ? 28 : 10, height: 10)
+            }
+        }
+        .accessibilityElement(children: .ignore)
+        .accessibilityLabel("Onboarding step \(currentStepIndex + 1) of 4")
+    }
+
+    // MARK: - Demo page layout
+
+    @ViewBuilder
+    private func demoPage<Demo: View>(
+        title: String,
+        message: String,
+        @ViewBuilder demo: () -> Demo
+    ) -> some View {
+        VStack(spacing: 0) {
+            VStack(alignment: .leading, spacing: 12) {
+                Text(title)
+                    .font(.largeTitle.weight(.bold))
+                    .fixedSize(horizontal: false, vertical: true)
+
+                Text(message)
+                    .font(.title3)
+                    .foregroundStyle(.secondary)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .padding(.horizontal, 24)
+            .padding(.top, 32)
+            .padding(.bottom, 20)
+
+            demo()
+                .padding(.horizontal, 24)
+
+            pageIndicator
+                .padding(.top, 20)
+        }
+    }
+
+    // MARK: - Step actions
+
+    private func advance() {
+        move(to: currentStepIndex + 1)
+    }
+
+    private func move(to index: Int) {
+        guard !reduceMotion else {
+            currentStepIndex = index
+            return
+        }
+        withAnimation(.easeInOut(duration: 0.25)) {
+            currentStepIndex = index
+        }
+    }
+
+    private func submitCaregiverName() {
+        guard !trimmedCaregiverName.isEmpty else { return }
+        model.createLocalUser(displayName: trimmedCaregiverName)
+        // Offer notification permission before moving to baby setup
+        if notificationAuthorizationStatus == .notDetermined {
+            isShowingNotificationPermissionPrompt = true
+        } else {
+            advance()
+        }
+    }
+
+    private func submitBabySetup() {
+        guard !trimmedChildName.isEmpty else { return }
+        model.createChild(
+            name: trimmedChildName,
+            birthDate: includesBirthDate ? babyBirthDate : nil
+        )
+        advance()
+    }
+
+    private func dismissOnboarding() {
+        model.isInteractiveOnboardingActive = false
+    }
+
+    // MARK: - Notification permission
+
+    private func refreshNotificationStatus() async {
+        let settings = await UNUserNotificationCenter.current().notificationSettings()
+        notificationAuthorizationStatus = settings.authorizationStatus
+    }
+
+    private func requestNotificationAuthorization() {
+        model.requestNotificationAuthorizationIfNeeded()
+        advance()
+    }
+}
+
+// MARK: - Previews
+
+#Preview("Welcome") {
+    InteractiveOnboardingView(
+        model: InteractiveOnboardingPreviewFactory.makeModel(),
+        previewStepIndex: 0
+    )
+}
+
+#Preview("Quick Log Demo") {
+    InteractiveOnboardingView(
+        model: InteractiveOnboardingPreviewFactory.makeModel(),
+        previewStepIndex: 1
+    )
+}
+
+#Preview("Timeline Demo") {
+    InteractiveOnboardingView(
+        model: InteractiveOnboardingPreviewFactory.makeModel(),
+        previewStepIndex: 2
+    )
+}
+
+#Preview("Charts Demo") {
+    InteractiveOnboardingView(
+        model: InteractiveOnboardingPreviewFactory.makeModel(),
+        previewStepIndex: 3
+    )
+}
+
+#Preview("Caregiver Name") {
+    InteractiveOnboardingView(
+        model: InteractiveOnboardingPreviewFactory.makeModel(),
+        previewStepIndex: 4
+    )
+}
+
+#Preview("Baby Setup") {
+    InteractiveOnboardingView(
+        model: InteractiveOnboardingPreviewFactory.makeModel(),
+        previewStepIndex: 5
+    )
+}
+
+#Preview("First Event") {
+    InteractiveOnboardingView(
+        model: ChildProfilePreviewFactory.makeModel(),
+        previewStepIndex: 6
+    )
+}
+
+#Preview("App Preview") {
+    InteractiveOnboardingView(
+        model: ChildProfilePreviewFactory.makeModel(),
+        previewStepIndex: 7
+    )
+}
+
+private enum InteractiveOnboardingPreviewFactory {
+    @MainActor
+    static func makeModel() -> AppModel {
+        let suiteName = "InteractiveOnboardingPreview"
+        let userDefaults = UserDefaults(suiteName: suiteName) ?? .standard
+        userDefaults.removePersistentDomain(forName: suiteName)
+
+        let store = try! BabyTrackerModelStore(isStoredInMemoryOnly: true)
+        let childRepository = SwiftDataChildRepository(store: store)
+        let userIdentityRepository = SwiftDataUserIdentityRepository(store: store, userDefaults: userDefaults)
+        let membershipRepository = SwiftDataMembershipRepository(store: store)
+        let childSelectionStore = UserDefaultsChildSelectionStore(userDefaults: userDefaults)
+        let eventRepository = SwiftDataEventRepository(store: store)
+        let syncStateRepository = SwiftDataSyncStateRepository(store: store)
+        let recordMetadataRepository = SwiftDataCloudKitRecordMetadataRepository(store: store)
+        let syncEngine = CloudKitSyncEngine(
+            childRepository: childRepository,
+            userIdentityRepository: userIdentityRepository,
+            membershipRepository: membershipRepository,
+            eventRepository: eventRepository,
+            syncStateRepository: syncStateRepository,
+            recordMetadataRepository: recordMetadataRepository,
+            client: UnavailableCloudKitClient()
+        )
+        let model = AppModel(
+            childRepository: childRepository,
+            userIdentityRepository: userIdentityRepository,
+            membershipRepository: membershipRepository,
+            childSelectionStore: childSelectionStore,
+            eventRepository: eventRepository,
+            syncEngine: syncEngine,
+            liveActivityManager: NoOpFeedLiveActivityManager(),
+            liveActivityPreferenceStore: InMemoryLiveActivityPreferenceStore(),
+            localNotificationManager: NoOpLocalNotificationManager(),
+            hapticFeedbackProvider: NoOpHapticFeedbackProvider()
+        )
+        model.load(performLaunchSync: false)
+        return model
+    }
+}

--- a/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/InteractiveOnboardingView.swift
+++ b/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/InteractiveOnboardingView.swift
@@ -46,6 +46,7 @@ public struct InteractiveOnboardingView: View {
         case timelineDemo
         case chartsDemo
         case liveActivityDemo
+        case notificationsDemo
         case caregiverName
         case babySetup
         case firstEvent
@@ -53,7 +54,7 @@ public struct InteractiveOnboardingView: View {
 
         var isSkippableToSetup: Bool {
             switch self {
-            case .welcome, .quickLogDemo, .timelineDemo, .chartsDemo, .liveActivityDemo:
+            case .welcome, .quickLogDemo, .timelineDemo, .chartsDemo, .liveActivityDemo, .notificationsDemo:
                 return true
             default:
                 return false
@@ -135,10 +136,10 @@ public struct InteractiveOnboardingView: View {
         )
         .opacity(viewOpacity)
         .alert("Enable Notifications?", isPresented: $isShowingNotificationPermissionPrompt) {
-            Button("Enable Notifications", action: requestNotificationAuthorization)
-            Button("Not Now", role: .cancel, action: { advance() })
+            Button("Continue", action: requestNotificationAuthorization)
+            Button("Not Now", role: .cancel, action: continueWithoutNotificationPermission)
         } message: {
-            Text("Get a heads-up when another caregiver logs an event so you stay in the loop.")
+            Text("We'll show the system prompt next so Nest can send helpful alerts.")
         }
     }
 
@@ -211,6 +212,14 @@ public struct InteractiveOnboardingView: View {
                 OnboardingLiveActivityDemoView()
             }
 
+        case .notificationsDemo:
+            OnboardingDemoPageContainer(
+                title: "Get helpful alerts",
+                message: "Know when feeds, sleep, and changes are logged, even when you're away from the app."
+            ) {
+                OnboardingNotificationsDemoView()
+            }
+
         case .caregiverName:
             IdentityOnboardingNameStepView(
                 displayName: $caregiverName,
@@ -247,6 +256,18 @@ public struct InteractiveOnboardingView: View {
             VStack(spacing: 16) {
                 pageIndicator
                 Button(action: advance) {
+                    Text("Continue")
+                        .font(.headline)
+                        .frame(maxWidth: .infinity)
+                        .padding(.vertical, 16)
+                }
+                .buttonStyle(.borderedProminent)
+            }
+
+        case .notificationsDemo:
+            VStack(spacing: 16) {
+                pageIndicator
+                Button(action: handleNotificationsDemoContinue) {
                     Text("Continue")
                         .font(.headline)
                         .frame(maxWidth: .infinity)
@@ -303,18 +324,18 @@ public struct InteractiveOnboardingView: View {
         }
     }
 
-    // MARK: - Page indicator (shown on demo steps 0–4)
+    // MARK: - Page indicator (shown on demo steps 0–5)
 
     private var pageIndicator: some View {
         HStack(spacing: 8) {
-            ForEach(0..<5) { index in
+            ForEach(0..<6) { index in
                 Capsule()
                     .fill(index == currentStepIndex ? Color.accentColor : Color.secondary.opacity(0.18))
                     .frame(width: index == currentStepIndex ? 28 : 10, height: 10)
             }
         }
         .accessibilityElement(children: .ignore)
-        .accessibilityLabel("Onboarding step \(currentStepIndex + 1) of 5")
+        .accessibilityLabel("Onboarding step \(currentStepIndex + 1) of 6")
     }
 
     // MARK: - Step actions
@@ -342,12 +363,7 @@ public struct InteractiveOnboardingView: View {
     private func submitCaregiverName() {
         guard !trimmedCaregiverName.isEmpty else { return }
         model.createLocalUser(displayName: trimmedCaregiverName)
-        // Offer notification permission before moving to baby setup
-        if notificationAuthorizationStatus == .notDetermined {
-            isShowingNotificationPermissionPrompt = true
-        } else {
-            advance()
-        }
+        advance()
     }
 
     private func submitBabySetup() {
@@ -372,6 +388,21 @@ public struct InteractiveOnboardingView: View {
 
     private func requestNotificationAuthorization() {
         model.requestNotificationAuthorizationIfNeeded()
+        advance()
+    }
+
+    private func handleNotificationsDemoContinue() {
+        switch notificationAuthorizationStatus {
+        case .authorized, .provisional, .ephemeral:
+            advance()
+        case .notDetermined, .denied:
+            isShowingNotificationPermissionPrompt = true
+        @unknown default:
+            isShowingNotificationPermissionPrompt = true
+        }
+    }
+
+    private func continueWithoutNotificationPermission() {
         advance()
     }
 }
@@ -413,31 +444,38 @@ public struct InteractiveOnboardingView: View {
     )
 }
 
-#Preview("Caregiver Name") {
+#Preview("Notifications Demo") {
     InteractiveOnboardingView(
         model: InteractiveOnboardingPreviewFactory.makeModel(),
         previewStepIndex: 5
     )
 }
 
-#Preview("Baby Setup") {
+#Preview("Caregiver Name") {
     InteractiveOnboardingView(
         model: InteractiveOnboardingPreviewFactory.makeModel(),
         previewStepIndex: 6
     )
 }
 
+#Preview("Baby Setup") {
+    InteractiveOnboardingView(
+        model: InteractiveOnboardingPreviewFactory.makeModel(),
+        previewStepIndex: 7
+    )
+}
+
 #Preview("First Event") {
     InteractiveOnboardingView(
         model: ChildProfilePreviewFactory.makeModel(),
-        previewStepIndex: 7
+        previewStepIndex: 8
     )
 }
 
 #Preview("App Preview") {
     InteractiveOnboardingView(
         model: ChildProfilePreviewFactory.makeModel(),
-        previewStepIndex: 8
+        previewStepIndex: 9
     )
 }
 

--- a/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/InteractiveOnboardingView.swift
+++ b/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/InteractiveOnboardingView.swift
@@ -97,7 +97,11 @@ public struct InteractiveOnboardingView: View {
                 topBar
 
                 stepContent
-                    .animation(reduceMotion ? nil : .easeInOut(duration: 0.25), value: currentStepIndex)
+                    .id(currentStepIndex)
+                    .transition(reduceMotion ? .opacity : .asymmetric(
+                        insertion: .move(edge: .trailing).combined(with: .opacity),
+                        removal: .move(edge: .leading).combined(with: .opacity)
+                    ))
 
                 Spacer(minLength: 24)
 
@@ -167,9 +171,11 @@ public struct InteractiveOnboardingView: View {
             }
 
         case .quickLogDemo:
-            demoPage(
+            OnboardingDemoPageContainer(
                 title: "Log in seconds",
-                message: "Tap one button, fill in the details, done. No fumbling around."
+                message: "Tap one button, fill in the details, done. No fumbling around.",
+                pageIndex: currentStepIndex,
+                totalDemoPages: 4
             ) {
                 OnboardingQuickLogDemoView()
                     .clipShape(RoundedRectangle(cornerRadius: 24, style: .continuous))
@@ -177,17 +183,21 @@ public struct InteractiveOnboardingView: View {
             }
 
         case .timelineDemo:
-            demoPage(
+            OnboardingDemoPageContainer(
                 title: "See the whole picture",
-                message: "The timeline fills in as you log, so you can see the rhythm of any day at a glance."
+                message: "The timeline fills in as you log, so you can see the rhythm of any day at a glance.",
+                pageIndex: currentStepIndex,
+                totalDemoPages: 4
             ) {
                 OnboardingTimelineDemoView()
             }
 
         case .chartsDemo:
-            demoPage(
+            OnboardingDemoPageContainer(
                 title: "Spot the patterns",
-                message: "The Summary tab turns raw events into charts so you can see what's changing week by week."
+                message: "The Summary tab turns raw events into charts so you can see what's changing week by week.",
+                pageIndex: currentStepIndex,
+                totalDemoPages: 4
             ) {
                 OnboardingChartsDemoView()
             }
@@ -215,21 +225,7 @@ public struct InteractiveOnboardingView: View {
             )
 
         case .appPreview:
-            VStack(alignment: .leading, spacing: 0) {
-                VStack(alignment: .leading, spacing: 12) {
-                    Text("Here's your app")
-                        .font(.largeTitle.weight(.bold))
-
-                    Text("Everything you just logged is already there.")
-                        .font(.title3)
-                        .foregroundStyle(.secondary)
-                }
-                .padding(.horizontal, 24)
-                .padding(.top, 32)
-                .padding(.bottom, 16)
-
-                OnboardingAppPreviewStepView(model: model)
-            }
+            OnboardingAppPreviewStepView(model: model)
         }
     }
 
@@ -309,38 +305,6 @@ public struct InteractiveOnboardingView: View {
         .accessibilityLabel("Onboarding step \(currentStepIndex + 1) of 4")
     }
 
-    // MARK: - Demo page layout
-
-    @ViewBuilder
-    private func demoPage<Demo: View>(
-        title: String,
-        message: String,
-        @ViewBuilder demo: () -> Demo
-    ) -> some View {
-        VStack(spacing: 0) {
-            VStack(alignment: .leading, spacing: 12) {
-                Text(title)
-                    .font(.largeTitle.weight(.bold))
-                    .fixedSize(horizontal: false, vertical: true)
-
-                Text(message)
-                    .font(.title3)
-                    .foregroundStyle(.secondary)
-                    .fixedSize(horizontal: false, vertical: true)
-            }
-            .frame(maxWidth: .infinity, alignment: .leading)
-            .padding(.horizontal, 24)
-            .padding(.top, 32)
-            .padding(.bottom, 20)
-
-            demo()
-                .padding(.horizontal, 24)
-
-            pageIndicator
-                .padding(.top, 20)
-        }
-    }
-
     // MARK: - Step actions
 
     private func advance() {
@@ -352,7 +316,7 @@ public struct InteractiveOnboardingView: View {
             currentStepIndex = index
             return
         }
-        withAnimation(.easeInOut(duration: 0.25)) {
+        withAnimation(.spring(response: 0.42, dampingFraction: 0.88)) {
             currentStepIndex = index
         }
     }

--- a/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/InteractiveOnboardingView.swift
+++ b/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/InteractiveOnboardingView.swift
@@ -16,6 +16,7 @@ public struct InteractiveOnboardingView: View {
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
 
     @State private var currentStepIndex = 0
+    @State private var isGoingBack = false
     @State private var caregiverName = ""
     @State private var childName = ""
     @State private var includesBirthDate = false
@@ -99,8 +100,8 @@ public struct InteractiveOnboardingView: View {
                 stepContent
                     .id(currentStepIndex)
                     .transition(reduceMotion ? .opacity : .asymmetric(
-                        insertion: .move(edge: .trailing).combined(with: .opacity),
-                        removal: .move(edge: .leading).combined(with: .opacity)
+                        insertion: .move(edge: isGoingBack ? .leading : .trailing).combined(with: .opacity),
+                        removal: .move(edge: isGoingBack ? .trailing : .leading).combined(with: .opacity)
                     ))
 
                 Spacer(minLength: 24)
@@ -122,6 +123,15 @@ public struct InteractiveOnboardingView: View {
                 viewOpacity = 1
             }
         }
+        .gesture(
+            DragGesture()
+                .onEnded { value in
+                    let isRightSwipe = value.translation.width > 60
+                    let isHorizontal = abs(value.translation.width) > abs(value.translation.height)
+                    guard isRightSwipe && isHorizontal && currentStepIndex > 0 else { return }
+                    goBack()
+                }
+        )
         .opacity(viewOpacity)
         .alert("Enable Notifications?", isPresented: $isShowingNotificationPermissionPrompt) {
             Button("Enable Notifications", action: requestNotificationAuthorization)
@@ -304,7 +314,13 @@ public struct InteractiveOnboardingView: View {
         move(to: currentStepIndex + 1)
     }
 
+    private func goBack() {
+        guard currentStepIndex > 0 else { return }
+        move(to: currentStepIndex - 1)
+    }
+
     private func move(to index: Int) {
+        isGoingBack = index < currentStepIndex
         guard !reduceMotion else {
             currentStepIndex = index
             return

--- a/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/InteractiveOnboardingView.swift
+++ b/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/InteractiveOnboardingView.swift
@@ -45,6 +45,7 @@ public struct InteractiveOnboardingView: View {
         case quickLogDemo
         case timelineDemo
         case chartsDemo
+        case liveActivityDemo
         case caregiverName
         case babySetup
         case firstEvent
@@ -52,7 +53,7 @@ public struct InteractiveOnboardingView: View {
 
         var isSkippableToSetup: Bool {
             switch self {
-            case .welcome, .quickLogDemo, .timelineDemo, .chartsDemo:
+            case .welcome, .quickLogDemo, .timelineDemo, .chartsDemo, .liveActivityDemo:
                 return true
             default:
                 return false
@@ -202,6 +203,14 @@ public struct InteractiveOnboardingView: View {
                 OnboardingChartsDemoView()
             }
 
+        case .liveActivityDemo:
+            OnboardingDemoPageContainer(
+                title: "Stay updated from your Lock Screen",
+                message: "See the latest feed, sleep, and nappy timings without unlocking your phone."
+            ) {
+                OnboardingLiveActivityDemoView()
+            }
+
         case .caregiverName:
             IdentityOnboardingNameStepView(
                 displayName: $caregiverName,
@@ -234,7 +243,7 @@ public struct InteractiveOnboardingView: View {
     @ViewBuilder
     private var footer: some View {
         switch currentStep {
-        case .welcome, .quickLogDemo, .timelineDemo, .chartsDemo:
+        case .welcome, .quickLogDemo, .timelineDemo, .chartsDemo, .liveActivityDemo:
             VStack(spacing: 16) {
                 pageIndicator
                 Button(action: advance) {
@@ -294,18 +303,18 @@ public struct InteractiveOnboardingView: View {
         }
     }
 
-    // MARK: - Page indicator (shown on demo steps 0–3)
+    // MARK: - Page indicator (shown on demo steps 0–4)
 
     private var pageIndicator: some View {
         HStack(spacing: 8) {
-            ForEach(0..<4) { index in
+            ForEach(0..<5) { index in
                 Capsule()
                     .fill(index == currentStepIndex ? Color.accentColor : Color.secondary.opacity(0.18))
                     .frame(width: index == currentStepIndex ? 28 : 10, height: 10)
             }
         }
         .accessibilityElement(children: .ignore)
-        .accessibilityLabel("Onboarding step \(currentStepIndex + 1) of 4")
+        .accessibilityLabel("Onboarding step \(currentStepIndex + 1) of 5")
     }
 
     // MARK: - Step actions
@@ -397,31 +406,38 @@ public struct InteractiveOnboardingView: View {
     )
 }
 
-#Preview("Caregiver Name") {
+#Preview("Live Activity Demo") {
     InteractiveOnboardingView(
         model: InteractiveOnboardingPreviewFactory.makeModel(),
         previewStepIndex: 4
     )
 }
 
-#Preview("Baby Setup") {
+#Preview("Caregiver Name") {
     InteractiveOnboardingView(
         model: InteractiveOnboardingPreviewFactory.makeModel(),
         previewStepIndex: 5
     )
 }
 
+#Preview("Baby Setup") {
+    InteractiveOnboardingView(
+        model: InteractiveOnboardingPreviewFactory.makeModel(),
+        previewStepIndex: 6
+    )
+}
+
 #Preview("First Event") {
     InteractiveOnboardingView(
         model: ChildProfilePreviewFactory.makeModel(),
-        previewStepIndex: 6
+        previewStepIndex: 7
     )
 }
 
 #Preview("App Preview") {
     InteractiveOnboardingView(
         model: ChildProfilePreviewFactory.makeModel(),
-        previewStepIndex: 7
+        previewStepIndex: 8
     )
 }
 

--- a/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/OnboardingAddBabyStepView.swift
+++ b/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/OnboardingAddBabyStepView.swift
@@ -19,6 +19,12 @@ struct OnboardingAddBabyStepView: View {
     var body: some View {
         ScrollView {
             VStack(alignment: .leading, spacing: 24) {
+                AnimatedSymbolSceneView(symbolNames: [
+                    "teddybear.fill",
+                    "moon.zzz.fill",
+                    "heart.fill",
+                ])
+
                 VStack(alignment: .leading, spacing: 12) {
                     Text("Now let's add your baby")
                         .font(.largeTitle.weight(.bold))

--- a/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/OnboardingAddBabyStepView.swift
+++ b/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/OnboardingAddBabyStepView.swift
@@ -9,6 +9,9 @@ struct OnboardingAddBabyStepView: View {
     let addAction: () -> Void
     let skipAction: () -> Void
 
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+    @State private var appearedMask: [Bool] = [false, false, false, false]
+
     private var trimmedName: String {
         childName.trimmingCharacters(in: .whitespaces)
     }
@@ -19,11 +22,15 @@ struct OnboardingAddBabyStepView: View {
                 VStack(alignment: .leading, spacing: 12) {
                     Text("Now let's add your baby")
                         .font(.largeTitle.weight(.bold))
+                        .opacity(appearedMask[0] ? 1 : 0)
+                        .offset(y: appearedMask[0] ? 0 : 18)
 
                     Text("You can always update this from the Profile tab.")
                         .font(.title3)
                         .foregroundStyle(.secondary)
                         .fixedSize(horizontal: false, vertical: true)
+                        .opacity(appearedMask[1] ? 1 : 0)
+                        .offset(y: appearedMask[1] ? 0 : 14)
                 }
 
                 VStack(alignment: .leading, spacing: 8) {
@@ -43,6 +50,8 @@ struct OnboardingAddBabyStepView: View {
                         )
                         .accessibilityIdentifier("onboarding-baby-name-field")
                 }
+                .opacity(appearedMask[2] ? 1 : 0)
+                .offset(y: appearedMask[2] ? 0 : 14)
 
                 VStack(alignment: .leading, spacing: 12) {
                     Toggle("Add birth date", isOn: $includesBirthDate)
@@ -63,6 +72,8 @@ struct OnboardingAddBabyStepView: View {
                 .animation(.easeInOut(duration: 0.2), value: includesBirthDate)
                 .padding(20)
                 .background(.thinMaterial, in: RoundedRectangle(cornerRadius: 24, style: .continuous))
+                .opacity(appearedMask[3] ? 1 : 0)
+                .offset(y: appearedMask[3] ? 0 : 14)
             }
             .frame(maxWidth: .infinity, alignment: .leading)
             .padding(.horizontal, 24)
@@ -70,9 +81,25 @@ struct OnboardingAddBabyStepView: View {
             .padding(.bottom, 8)
         }
         .scrollBounceBehavior(.basedOnSize)
+        .onAppear {
+            staggerIn()
+        }
         .onSubmit {
             guard !trimmedName.isEmpty else { return }
             addAction()
+        }
+    }
+
+    private func staggerIn() {
+        if reduceMotion {
+            appearedMask = Array(repeating: true, count: appearedMask.count)
+            return
+        }
+        for index in 0..<appearedMask.count {
+            let delay = Double(index) * 0.09
+            withAnimation(.spring(response: 0.5, dampingFraction: 0.82).delay(delay)) {
+                appearedMask[index] = true
+            }
         }
     }
 }

--- a/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/OnboardingAddBabyStepView.swift
+++ b/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/OnboardingAddBabyStepView.swift
@@ -1,0 +1,92 @@
+import SwiftUI
+
+/// The baby setup step in the interactive onboarding flow.
+/// Collects baby name and optional birth date before the user logs their first event.
+struct OnboardingAddBabyStepView: View {
+    @Binding var childName: String
+    @Binding var includesBirthDate: Bool
+    @Binding var birthDate: Date
+    let addAction: () -> Void
+    let skipAction: () -> Void
+
+    private var trimmedName: String {
+        childName.trimmingCharacters(in: .whitespaces)
+    }
+
+    var body: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: 24) {
+                VStack(alignment: .leading, spacing: 12) {
+                    Text("Now let's add your baby")
+                        .font(.largeTitle.weight(.bold))
+
+                    Text("You can always update this from the Profile tab.")
+                        .font(.title3)
+                        .foregroundStyle(.secondary)
+                        .fixedSize(horizontal: false, vertical: true)
+                }
+
+                VStack(alignment: .leading, spacing: 8) {
+                    Text("Baby's name")
+                        .font(.caption.weight(.semibold))
+                        .foregroundStyle(.secondary)
+                        .padding(.horizontal, 4)
+
+                    TextField("e.g. Olivia", text: $childName)
+                        .font(.title3)
+                        .textInputAutocapitalization(.words)
+                        .submitLabel(.done)
+                        .padding(16)
+                        .background(
+                            RoundedRectangle(cornerRadius: 18, style: .continuous)
+                                .fill(Color(.secondarySystemGroupedBackground))
+                        )
+                        .accessibilityIdentifier("onboarding-baby-name-field")
+                }
+
+                VStack(alignment: .leading, spacing: 12) {
+                    Toggle("Add birth date", isOn: $includesBirthDate)
+                        .font(.body.weight(.medium))
+
+                    if includesBirthDate {
+                        DatePicker(
+                            "Birth date",
+                            selection: $birthDate,
+                            in: ...Date(),
+                            displayedComponents: .date
+                        )
+                        .datePickerStyle(.compact)
+                        .labelsHidden()
+                        .transition(.opacity.combined(with: .move(edge: .top)))
+                    }
+                }
+                .animation(.easeInOut(duration: 0.2), value: includesBirthDate)
+                .padding(20)
+                .background(.thinMaterial, in: RoundedRectangle(cornerRadius: 24, style: .continuous))
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .padding(.horizontal, 24)
+            .padding(.top, 32)
+            .padding(.bottom, 8)
+        }
+        .scrollBounceBehavior(.basedOnSize)
+        .onSubmit {
+            guard !trimmedName.isEmpty else { return }
+            addAction()
+        }
+    }
+}
+
+#Preview {
+    @Previewable @State var name = ""
+    @Previewable @State var includesBirthDate = false
+    @Previewable @State var birthDate = Date()
+
+    OnboardingAddBabyStepView(
+        childName: $name,
+        includesBirthDate: $includesBirthDate,
+        birthDate: $birthDate,
+        addAction: {},
+        skipAction: {}
+    )
+}

--- a/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/OnboardingAppPreviewStepView.swift
+++ b/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/OnboardingAppPreviewStepView.swift
@@ -1,79 +1,210 @@
+import BabyTrackerDomain
 import SwiftUI
 
-/// A non-interactive embed of the real `ChildHomeView` shown after the user logs
-/// their first event. Demonstrates what the app looks like with live data.
+/// The final step of the interactive onboarding flow.
 ///
-/// Title and subtitle stagger in first, then the app preview slides up with a
-/// slight delay so the text has a moment to settle before the UI appears.
+/// Shows a personalised welcome with the caregiver's first name and baby's name,
+/// a summary card for the event they just logged (with a live timer for active
+/// sleep), and a brief "Welcome to Nest" note. Each element animates in one by
+/// one after the page slide-in settles.
 struct OnboardingAppPreviewStepView: View {
     let model: AppModel
 
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
-    @State private var homeViewModel: HomeViewModel
-    @State private var childProfileViewModel: ChildProfileViewModel
-    @State private var titleAppeared = false
-    @State private var subtitleAppeared = false
-    @State private var previewAppeared = false
+    @State private var appearedMask: [Bool] = [false, false, false]
 
-    init(model: AppModel) {
-        self.model = model
-        _homeViewModel = State(initialValue: HomeViewModel(appModel: model))
-        _childProfileViewModel = State(initialValue: ChildProfileViewModel(appModel: model))
+    private var firstName: String {
+        let full = model.localUser?.displayName ?? ""
+        return full.components(separatedBy: " ").first ?? full
+    }
+
+    private var babyName: String {
+        model.currentChild?.name ?? "your baby"
+    }
+
+    private var latestEvent: BabyEvent? {
+        model.events.max(by: { $0.metadata.occurredAt < $1.metadata.occurredAt })
     }
 
     var body: some View {
-        VStack(alignment: .leading, spacing: 0) {
-            VStack(alignment: .leading, spacing: 12) {
-                Text("Here's your app")
-                    .font(.largeTitle.weight(.bold))
-                    .opacity(titleAppeared ? 1 : 0)
-                    .offset(y: titleAppeared ? 0 : 18)
+        ScrollView {
+            VStack(alignment: .leading, spacing: 28) {
+                // Welcome heading
+                VStack(alignment: .leading, spacing: 10) {
+                    Text("Welcome, \(firstName)!")
+                        .font(.largeTitle.weight(.bold))
 
-                Text("Everything you just logged is already there.")
-                    .font(.title3)
-                    .foregroundStyle(.secondary)
-                    .fixedSize(horizontal: false, vertical: true)
-                    .opacity(subtitleAppeared ? 1 : 0)
-                    .offset(y: subtitleAppeared ? 0 : 14)
+                    Text("Congratulations on \(babyName).")
+                        .font(.title3)
+                        .foregroundStyle(.secondary)
+                        .fixedSize(horizontal: false, vertical: true)
+                }
+                .opacity(appearedMask[0] ? 1 : 0)
+                .offset(y: appearedMask[0] ? 0 : 18)
+
+                // Event summary card
+                if let event = latestEvent {
+                    eventCard(for: event)
+                        .opacity(appearedMask[1] ? 1 : 0)
+                        .offset(y: appearedMask[1] ? 0 : 16)
+                }
+
+                // Welcome to Nest
+                welcomeCard
+                    .opacity(appearedMask[2] ? 1 : 0)
+                    .offset(y: appearedMask[2] ? 0 : 14)
             }
+            .frame(maxWidth: .infinity, alignment: .leading)
             .padding(.horizontal, 24)
             .padding(.top, 32)
-            .padding(.bottom, 16)
-
-            ChildHomeView(
-                model: model,
-                viewModel: homeViewModel,
-                childProfileViewModel: childProfileViewModel,
-                stopSleep: {},
-                quickLogBreastFeed: {},
-                quickLogBottleFeed: {},
-                quickLogSleep: {},
-                quickLogNappy: {}
-            )
-            .allowsHitTesting(false)
-            .opacity(previewAppeared ? 1 : 0)
-            .offset(y: previewAppeared ? 0 : 24)
+            .padding(.bottom, 8)
         }
+        .scrollBounceBehavior(.basedOnSize)
         .onAppear {
             animateIn()
         }
     }
 
+    // MARK: - Event card
+
+    private func eventCard(for event: BabyEvent) -> some View {
+        VStack(alignment: .leading, spacing: 12) {
+            Label(eventTypeName(for: event) + " logged", systemImage: BabyEventStyle.systemImage(for: event.kind))
+                .font(.headline)
+                .foregroundStyle(BabyEventStyle.accentColor(for: event.kind))
+
+            eventDetailView(for: event)
+                .font(.subheadline)
+                .foregroundStyle(.secondary)
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding(20)
+        .background(.thinMaterial, in: RoundedRectangle(cornerRadius: 20, style: .continuous))
+    }
+
+    @ViewBuilder
+    private func eventDetailView(for event: BabyEvent) -> some View {
+        switch event {
+        case let .breastFeed(e):
+            Text(breastFeedDetail(e))
+
+        case let .bottleFeed(e):
+            Text(bottleFeedDetail(e))
+
+        case let .sleep(e):
+            if e.endedAt == nil {
+                HStack(spacing: 8) {
+                    Circle()
+                        .fill(BabyEventStyle.accentColor(for: .sleep))
+                        .frame(width: 7, height: 7)
+                    TimelineView(.periodic(from: .now, by: 1)) { context in
+                        Text("Running · \(sleepDurationText(from: e.startedAt, to: context.date))")
+                            .monospacedDigit()
+                    }
+                }
+            } else {
+                Text(completedSleepDetail(e))
+            }
+
+        case let .nappy(e):
+            Text(nappyDetail(e))
+        }
+    }
+
+    // MARK: - Welcome card
+
+    private var welcomeCard: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            Text("Welcome to Nest")
+                .font(.subheadline.weight(.semibold))
+            Text("Your timeline and summary are ready whenever you need them.")
+                .font(.subheadline)
+                .foregroundStyle(.secondary)
+                .fixedSize(horizontal: false, vertical: true)
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding(20)
+        .background(.thinMaterial, in: RoundedRectangle(cornerRadius: 20, style: .continuous))
+    }
+
+    // MARK: - Detail formatters
+
+    private func breastFeedDetail(_ e: BreastFeedEvent) -> String {
+        let duration = Int(e.endedAt.timeIntervalSince(e.startedAt) / 60)
+        let sideLabel: String
+        switch e.side {
+        case .left:  sideLabel = "Left side"
+        case .right: sideLabel = "Right side"
+        case .both:  sideLabel = "Both sides"
+        case nil:    sideLabel = ""
+        }
+        return ["\(duration) min", sideLabel].filter { !$0.isEmpty }.joined(separator: " · ")
+    }
+
+    private func bottleFeedDetail(_ e: BottleFeedEvent) -> String {
+        let milkLabel: String
+        switch e.milkType {
+        case .breastMilk: milkLabel = "Breast milk"
+        case .formula:    milkLabel = "Formula"
+        case .mixed:      milkLabel = "Mixed"
+        case .other:      milkLabel = "Other"
+        case nil:         milkLabel = ""
+        }
+        return ["\(e.amountMilliliters) mL", milkLabel].filter { !$0.isEmpty }.joined(separator: " · ")
+    }
+
+    private func completedSleepDetail(_ e: SleepEvent) -> String {
+        guard let endedAt = e.endedAt else { return "" }
+        let duration = Int(endedAt.timeIntervalSince(e.startedAt) / 60)
+        return "\(duration) min"
+    }
+
+    private func nappyDetail(_ e: NappyEvent) -> String {
+        switch e.type {
+        case .dry:   return "Dry"
+        case .wee:   return "Wee"
+        case .poo:   return "Poo"
+        case .mixed: return "Mixed"
+        }
+    }
+
+    private func eventTypeName(for event: BabyEvent) -> String {
+        switch event.kind {
+        case .breastFeed: return "Breast feed"
+        case .bottleFeed: return "Bottle feed"
+        case .sleep:      return "Sleep"
+        case .nappy:      return "Nappy"
+        }
+    }
+
+    private func sleepDurationText(from startedAt: Date, to now: Date) -> String {
+        let seconds = max(0, Int(now.timeIntervalSince(startedAt)))
+        let hours = seconds / 3_600
+        let minutes = (seconds % 3_600) / 60
+        let secs = seconds % 60
+        return String(format: "%02dh %02dm %02ds", hours, minutes, secs)
+    }
+
+    // MARK: - Animation
+
     private func animateIn() {
         if reduceMotion {
-            titleAppeared = true
-            subtitleAppeared = true
-            previewAppeared = true
+            appearedMask = [true, true, true]
             return
         }
-        withAnimation(.spring(response: 0.5, dampingFraction: 0.82)) {
-            titleAppeared = true
-        }
-        withAnimation(.spring(response: 0.5, dampingFraction: 0.82).delay(0.09)) {
-            subtitleAppeared = true
-        }
-        withAnimation(.spring(response: 0.52, dampingFraction: 0.82).delay(0.22)) {
-            previewAppeared = true
+        Task { @MainActor in
+            try? await Task.sleep(for: .milliseconds(420))
+            withAnimation(.spring(response: 0.55, dampingFraction: 0.82)) {
+                appearedMask[0] = true
+            }
+            try? await Task.sleep(for: .milliseconds(320))
+            withAnimation(.spring(response: 0.55, dampingFraction: 0.82)) {
+                appearedMask[1] = true
+            }
+            try? await Task.sleep(for: .milliseconds(380))
+            withAnimation(.spring(response: 0.55, dampingFraction: 0.82)) {
+                appearedMask[2] = true
+            }
         }
     }
 }

--- a/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/OnboardingAppPreviewStepView.swift
+++ b/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/OnboardingAppPreviewStepView.swift
@@ -2,11 +2,18 @@ import SwiftUI
 
 /// A non-interactive embed of the real `ChildHomeView` shown after the user logs
 /// their first event. Demonstrates what the app looks like with live data.
+///
+/// Title and subtitle stagger in first, then the app preview slides up with a
+/// slight delay so the text has a moment to settle before the UI appears.
 struct OnboardingAppPreviewStepView: View {
     let model: AppModel
 
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
     @State private var homeViewModel: HomeViewModel
     @State private var childProfileViewModel: ChildProfileViewModel
+    @State private var titleAppeared = false
+    @State private var subtitleAppeared = false
+    @State private var previewAppeared = false
 
     init(model: AppModel) {
         self.model = model
@@ -15,17 +22,59 @@ struct OnboardingAppPreviewStepView: View {
     }
 
     var body: some View {
-        ChildHomeView(
-            model: model,
-            viewModel: homeViewModel,
-            childProfileViewModel: childProfileViewModel,
-            stopSleep: {},
-            quickLogBreastFeed: {},
-            quickLogBottleFeed: {},
-            quickLogSleep: {},
-            quickLogNappy: {}
-        )
-        .allowsHitTesting(false)
+        VStack(alignment: .leading, spacing: 0) {
+            VStack(alignment: .leading, spacing: 12) {
+                Text("Here's your app")
+                    .font(.largeTitle.weight(.bold))
+                    .opacity(titleAppeared ? 1 : 0)
+                    .offset(y: titleAppeared ? 0 : 18)
+
+                Text("Everything you just logged is already there.")
+                    .font(.title3)
+                    .foregroundStyle(.secondary)
+                    .fixedSize(horizontal: false, vertical: true)
+                    .opacity(subtitleAppeared ? 1 : 0)
+                    .offset(y: subtitleAppeared ? 0 : 14)
+            }
+            .padding(.horizontal, 24)
+            .padding(.top, 32)
+            .padding(.bottom, 16)
+
+            ChildHomeView(
+                model: model,
+                viewModel: homeViewModel,
+                childProfileViewModel: childProfileViewModel,
+                stopSleep: {},
+                quickLogBreastFeed: {},
+                quickLogBottleFeed: {},
+                quickLogSleep: {},
+                quickLogNappy: {}
+            )
+            .allowsHitTesting(false)
+            .opacity(previewAppeared ? 1 : 0)
+            .offset(y: previewAppeared ? 0 : 24)
+        }
+        .onAppear {
+            animateIn()
+        }
+    }
+
+    private func animateIn() {
+        if reduceMotion {
+            titleAppeared = true
+            subtitleAppeared = true
+            previewAppeared = true
+            return
+        }
+        withAnimation(.spring(response: 0.5, dampingFraction: 0.82)) {
+            titleAppeared = true
+        }
+        withAnimation(.spring(response: 0.5, dampingFraction: 0.82).delay(0.09)) {
+            subtitleAppeared = true
+        }
+        withAnimation(.spring(response: 0.52, dampingFraction: 0.82).delay(0.22)) {
+            previewAppeared = true
+        }
     }
 }
 

--- a/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/OnboardingAppPreviewStepView.swift
+++ b/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/OnboardingAppPreviewStepView.swift
@@ -1,0 +1,36 @@
+import SwiftUI
+
+/// A non-interactive embed of the real `ChildHomeView` shown after the user logs
+/// their first event. Demonstrates what the app looks like with live data.
+struct OnboardingAppPreviewStepView: View {
+    let model: AppModel
+
+    @State private var homeViewModel: HomeViewModel
+    @State private var childProfileViewModel: ChildProfileViewModel
+
+    init(model: AppModel) {
+        self.model = model
+        _homeViewModel = State(initialValue: HomeViewModel(appModel: model))
+        _childProfileViewModel = State(initialValue: ChildProfileViewModel(appModel: model))
+    }
+
+    var body: some View {
+        ChildHomeView(
+            model: model,
+            viewModel: homeViewModel,
+            childProfileViewModel: childProfileViewModel,
+            stopSleep: {},
+            quickLogBreastFeed: {},
+            quickLogBottleFeed: {},
+            quickLogSleep: {},
+            quickLogNappy: {}
+        )
+        .allowsHitTesting(false)
+    }
+}
+
+#Preview {
+    OnboardingAppPreviewStepView(
+        model: ChildProfilePreviewFactory.makeModel()
+    )
+}

--- a/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/OnboardingAppPreviewStepView.swift
+++ b/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/OnboardingAppPreviewStepView.swift
@@ -11,7 +11,7 @@ struct OnboardingAppPreviewStepView: View {
     let model: AppModel
 
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
-    @State private var appearedMask: [Bool] = [false, false, false]
+    @State private var appearedMask: [Bool] = [false, false, false, false]
 
     private var firstName: String {
         let full = model.localUser?.displayName ?? ""
@@ -29,6 +29,15 @@ struct OnboardingAppPreviewStepView: View {
     var body: some View {
         ScrollView {
             VStack(alignment: .leading, spacing: 28) {
+                // Symbol scene
+                AnimatedSymbolSceneView(symbolNames: [
+                    "checkmark.seal.fill",
+                    "star.fill",
+                    "heart.fill",
+                ])
+                .opacity(appearedMask[0] ? 1 : 0)
+                .offset(y: appearedMask[0] ? 0 : 18)
+
                 // Welcome heading
                 VStack(alignment: .leading, spacing: 10) {
                     Text("Welcome, \(firstName)!")
@@ -39,20 +48,20 @@ struct OnboardingAppPreviewStepView: View {
                         .foregroundStyle(.secondary)
                         .fixedSize(horizontal: false, vertical: true)
                 }
-                .opacity(appearedMask[0] ? 1 : 0)
-                .offset(y: appearedMask[0] ? 0 : 18)
+                .opacity(appearedMask[1] ? 1 : 0)
+                .offset(y: appearedMask[1] ? 0 : 18)
 
                 // Event summary card
                 if let event = latestEvent {
                     eventCard(for: event)
-                        .opacity(appearedMask[1] ? 1 : 0)
-                        .offset(y: appearedMask[1] ? 0 : 16)
+                        .opacity(appearedMask[2] ? 1 : 0)
+                        .offset(y: appearedMask[2] ? 0 : 16)
                 }
 
                 // Welcome to Nest
                 welcomeCard
-                    .opacity(appearedMask[2] ? 1 : 0)
-                    .offset(y: appearedMask[2] ? 0 : 14)
+                    .opacity(appearedMask[3] ? 1 : 0)
+                    .offset(y: appearedMask[3] ? 0 : 14)
             }
             .frame(maxWidth: .infinity, alignment: .leading)
             .padding(.horizontal, 24)
@@ -189,7 +198,7 @@ struct OnboardingAppPreviewStepView: View {
 
     private func animateIn() {
         if reduceMotion {
-            appearedMask = [true, true, true]
+            appearedMask = [true, true, true, true]
             return
         }
         Task { @MainActor in
@@ -197,13 +206,17 @@ struct OnboardingAppPreviewStepView: View {
             withAnimation(.spring(response: 0.55, dampingFraction: 0.82)) {
                 appearedMask[0] = true
             }
-            try? await Task.sleep(for: .milliseconds(320))
+            try? await Task.sleep(for: .milliseconds(280))
             withAnimation(.spring(response: 0.55, dampingFraction: 0.82)) {
                 appearedMask[1] = true
             }
-            try? await Task.sleep(for: .milliseconds(380))
+            try? await Task.sleep(for: .milliseconds(320))
             withAnimation(.spring(response: 0.55, dampingFraction: 0.82)) {
                 appearedMask[2] = true
+            }
+            try? await Task.sleep(for: .milliseconds(380))
+            withAnimation(.spring(response: 0.55, dampingFraction: 0.82)) {
+                appearedMask[3] = true
             }
         }
     }

--- a/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/OnboardingChartsDemoView.swift
+++ b/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/OnboardingChartsDemoView.swift
@@ -125,8 +125,8 @@ struct OnboardingChartsDemoView: View {
                     series: .value("Series", "average")
                 )
                 .interpolationMethod(.monotone)
-                .foregroundStyle(Color.secondary.opacity(0.5))
-                .lineStyle(StrokeStyle(lineWidth: 1.5, dash: [5, 3]))
+                .foregroundStyle(Color.secondary.opacity(0.3))
+                .lineStyle(StrokeStyle(lineWidth: 1, dash: [3, 6]))
             }
             // Today — area fill behind solid line
             ForEach(todayPoints) { point in

--- a/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/OnboardingChartsDemoView.swift
+++ b/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/OnboardingChartsDemoView.swift
@@ -4,13 +4,14 @@ import SwiftUI
 
 /// Two animated chart cards used on the "Spot the patterns" onboarding page.
 ///
-/// Displays a Sleep chart and a Bottle Feed chart with hardcoded demo data.
-/// Each chart's line draws in from left to right using a horizontal clip mask —
-/// sleep first, then bottle feed — so the viewer sees the data fill in.
+/// Each card fades in and slides up one after the other. Once both cards have
+/// settled, the chart lines draw in left to right using a horizontal clip mask —
+/// sleep first, then bottle feed.
 struct OnboardingChartsDemoView: View {
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
 
-    @State private var appeared = false
+    @State private var sleepCardVisible = false
+    @State private var bottleCardVisible = false
     @State private var sleepProgress: CGFloat = 0
     @State private var bottleProgress: CGFloat = 0
 
@@ -24,6 +25,13 @@ struct OnboardingChartsDemoView: View {
                 progress: sleepProgress,
                 valueFormatter: { "\($0) min" }
             )
+            .opacity(sleepCardVisible ? 1 : 0)
+            .offset(y: sleepCardVisible ? 0 : 20)
+            .animation(
+                reduceMotion ? nil : .spring(response: 0.5, dampingFraction: 0.8),
+                value: sleepCardVisible
+            )
+
             chartCard(
                 title: "Bottle Feed",
                 systemImage: BabyEventStyle.systemImage(for: .bottleFeed),
@@ -32,17 +40,17 @@ struct OnboardingChartsDemoView: View {
                 progress: bottleProgress,
                 valueFormatter: { "\($0) mL" }
             )
+            .opacity(bottleCardVisible ? 1 : 0)
+            .offset(y: bottleCardVisible ? 0 : 20)
+            .animation(
+                reduceMotion ? nil : .spring(response: 0.5, dampingFraction: 0.8),
+                value: bottleCardVisible
+            )
         }
-        // Entry slide-up
-        .opacity(appeared ? 1 : 0)
-        .offset(y: appeared ? 0 : 28)
-        .animation(
-            reduceMotion ? nil : .spring(response: 0.52, dampingFraction: 0.82).delay(0.15),
-            value: appeared
-        )
         .onAppear {
-            appeared = true
             guard !reduceMotion else {
+                sleepCardVisible = true
+                bottleCardVisible = true
                 sleepProgress = 1
                 bottleProgress = 1
                 return
@@ -50,12 +58,18 @@ struct OnboardingChartsDemoView: View {
             Task { @MainActor in
                 // Wait for the page slide-in to settle
                 try? await Task.sleep(for: .milliseconds(420))
+                sleepCardVisible = true
+                // Stagger the second card in
+                try? await Task.sleep(for: .milliseconds(180))
+                bottleCardVisible = true
+                // Wait for the bottle card spring to land before drawing charts
+                try? await Task.sleep(for: .milliseconds(500))
                 // Draw sleep line left to right
                 withAnimation(.easeInOut(duration: 1.3)) {
                     sleepProgress = 1
                 }
                 // Wait for sleep to finish then pause before bottle
-                try? await Task.sleep(for: .milliseconds(1300 + 700))
+                try? await Task.sleep(for: .milliseconds(1300 + 600))
                 // Draw bottle line left to right
                 withAnimation(.easeInOut(duration: 1.3)) {
                     bottleProgress = 1

--- a/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/OnboardingChartsDemoView.swift
+++ b/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/OnboardingChartsDemoView.swift
@@ -1,9 +1,16 @@
 import SwiftUI
 
-/// A scaled, clipped, non-interactive embed of `SummaryScreenView` using static preview data.
-/// Used as the demo embed on the "Spot the patterns" onboarding page.
+/// A scaled, clipped demo of `SummaryScreenView` used on the "Spot the patterns"
+/// onboarding page.
+///
+/// Slides up and fades in on appear. The Charts framework animates its own content
+/// on first render, providing natural visual interest without extra animation overhead.
 struct OnboardingChartsDemoView: View {
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
     @State private var viewModel = OnboardingDemoDataFactory.summaryViewModel
+
+    @State private var appeared = false
+
     private let naturalHeight: CGFloat = 560
 
     var body: some View {
@@ -14,6 +21,16 @@ struct OnboardingChartsDemoView: View {
             .clipped()
             .clipShape(RoundedRectangle(cornerRadius: 24, style: .continuous))
             .allowsHitTesting(false)
+            // Entry slide-up
+            .opacity(appeared ? 1 : 0)
+            .offset(y: appeared ? 0 : 28)
+            .animation(
+                reduceMotion ? nil : .spring(response: 0.52, dampingFraction: 0.82).delay(0.15),
+                value: appeared
+            )
+            .onAppear {
+                appeared = true
+            }
     }
 }
 

--- a/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/OnboardingChartsDemoView.swift
+++ b/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/OnboardingChartsDemoView.swift
@@ -68,8 +68,8 @@ struct OnboardingChartsDemoView: View {
                 withAnimation(.easeInOut(duration: 1.3)) {
                     sleepProgress = 1
                 }
-                // Wait for sleep to finish then pause before bottle
-                try? await Task.sleep(for: .milliseconds(1300 + 600))
+                // Start bottle halfway through the sleep draw so the two charts overlap.
+                try? await Task.sleep(for: .milliseconds(650))
                 // Draw bottle line left to right
                 withAnimation(.easeInOut(duration: 1.3)) {
                     bottleProgress = 1

--- a/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/OnboardingChartsDemoView.swift
+++ b/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/OnboardingChartsDemoView.swift
@@ -1,0 +1,23 @@
+import SwiftUI
+
+/// A scaled, clipped, non-interactive embed of `SummaryScreenView` using static preview data.
+/// Used as the demo embed on the "Spot the patterns" onboarding page.
+struct OnboardingChartsDemoView: View {
+    @State private var viewModel = OnboardingDemoDataFactory.summaryViewModel
+    private let naturalHeight: CGFloat = 560
+
+    var body: some View {
+        SummaryScreenView(viewModel: viewModel)
+            .frame(height: naturalHeight)
+            .scaleEffect(0.72, anchor: .top)
+            .frame(height: naturalHeight * 0.72)
+            .clipped()
+            .clipShape(RoundedRectangle(cornerRadius: 24, style: .continuous))
+            .allowsHitTesting(false)
+    }
+}
+
+#Preview {
+    OnboardingChartsDemoView()
+        .padding(.horizontal, 24)
+}

--- a/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/OnboardingChartsDemoView.swift
+++ b/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/OnboardingChartsDemoView.swift
@@ -1,32 +1,38 @@
+import Charts
+import BabyTrackerDomain
 import SwiftUI
 
-/// A scaled, clipped demo of `SummaryScreenView` used on the "Spot the patterns"
-/// onboarding page.
+/// Two animated chart cards used on the "Spot the patterns" onboarding page.
 ///
-/// Slides up and fades in on appear. `SummaryScreenView` is inserted into the hierarchy
-/// only after the entry animation settles so the Charts framework fires its built-in
-/// line-draw and bar-grow animations while the demo is fully visible.
+/// Displays a Sleep chart and a Bottle Feed chart with hardcoded demo data.
+/// Each chart's line draws in from left to right using a horizontal clip mask —
+/// sleep first, then bottle feed — so the viewer sees the data fill in.
 struct OnboardingChartsDemoView: View {
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
 
     @State private var appeared = false
-    @State private var showCharts = false
-
-    private let naturalHeight: CGFloat = 560
+    @State private var sleepProgress: CGFloat = 0
+    @State private var bottleProgress: CGFloat = 0
 
     var body: some View {
-        ZStack {
-            if showCharts {
-                SummaryScreenView(viewModel: OnboardingDemoDataFactory.summaryViewModel)
-                    .allowsHitTesting(false)
-                    .transition(.opacity)
-            }
+        VStack(spacing: 12) {
+            chartCard(
+                title: "Sleep",
+                systemImage: BabyEventStyle.systemImage(for: .sleep),
+                tint: Color(.systemIndigo),
+                series: Self.sleepSeries,
+                progress: sleepProgress,
+                valueFormatter: { "\($0) min" }
+            )
+            chartCard(
+                title: "Bottle Feed",
+                systemImage: BabyEventStyle.systemImage(for: .bottleFeed),
+                tint: Color.blue,
+                series: Self.bottleSeries,
+                progress: bottleProgress,
+                valueFormatter: { "\($0) mL" }
+            )
         }
-        .frame(height: naturalHeight)
-        .scaleEffect(0.72, anchor: .top)
-        .frame(height: naturalHeight * 0.72)
-        .clipped()
-        .clipShape(RoundedRectangle(cornerRadius: 24, style: .continuous))
         // Entry slide-up
         .opacity(appeared ? 1 : 0)
         .offset(y: appeared ? 0 : 28)
@@ -37,19 +43,167 @@ struct OnboardingChartsDemoView: View {
         .onAppear {
             appeared = true
             guard !reduceMotion else {
-                showCharts = true
+                sleepProgress = 1
+                bottleProgress = 1
                 return
             }
-            // Insert SummaryScreenView after the entry slide settles so Charts
-            // fires its line-draw and bar-grow animations while visible.
             Task { @MainActor in
-                try? await Task.sleep(for: .milliseconds(600))
-                withAnimation(.easeIn(duration: 0.25)) {
-                    showCharts = true
+                // Wait for the page slide-in to settle
+                try? await Task.sleep(for: .milliseconds(420))
+                // Draw sleep line left to right
+                withAnimation(.easeInOut(duration: 1.3)) {
+                    sleepProgress = 1
+                }
+                // Wait for sleep to finish then pause before bottle
+                try? await Task.sleep(for: .milliseconds(1300 + 700))
+                // Draw bottle line left to right
+                withAnimation(.easeInOut(duration: 1.3)) {
+                    bottleProgress = 1
                 }
             }
         }
     }
+
+    // MARK: - Chart card
+
+    private func chartCard(
+        title: String,
+        systemImage: String,
+        tint: Color,
+        series: HourlyCumulativeSeries,
+        progress: CGFloat,
+        valueFormatter: @escaping (Int) -> String
+    ) -> some View {
+        VStack(alignment: .leading, spacing: 4) {
+            Label(title, systemImage: systemImage)
+                .font(.subheadline.weight(.semibold))
+                .foregroundStyle(tint)
+
+            demoChart(series: series, tint: tint)
+                // Horizontal clip mask: reveals the chart left-to-right as progress goes 0→1.
+                .mask {
+                    GeometryReader { geo in
+                        HStack(spacing: 0) {
+                            Color.black
+                                .frame(width: geo.size.width * progress)
+                            Color.clear
+                        }
+                    }
+                }
+        }
+        .padding(14)
+        .background(.thinMaterial, in: RoundedRectangle(cornerRadius: 16, style: .continuous))
+    }
+
+    // MARK: - Chart
+
+    private func demoChart(series: HourlyCumulativeSeries, tint: Color) -> some View {
+        let maxValue = max(1, (series.todayCumulative + series.averageCumulative).max() ?? 1)
+        let avgPoints = series.averageCumulative.enumerated().map { DemoHourPoint(id: $0, hour: $0, value: $1) }
+        let todayPoints = series.todayCumulative.enumerated().map { DemoHourPoint(id: $0, hour: $0, value: $1) }
+
+        return Chart {
+            // 7-day average — dashed, secondary
+            ForEach(avgPoints) { point in
+                LineMark(
+                    x: .value("Hour", point.hour),
+                    y: .value("Avg", point.value),
+                    series: .value("Series", "average")
+                )
+                .interpolationMethod(.monotone)
+                .foregroundStyle(Color.secondary.opacity(0.5))
+                .lineStyle(StrokeStyle(lineWidth: 1.5, dash: [5, 3]))
+            }
+            // Today — area fill behind solid line
+            ForEach(todayPoints) { point in
+                AreaMark(
+                    x: .value("Hour", point.hour),
+                    y: .value("Today", point.value)
+                )
+                .interpolationMethod(.monotone)
+                .foregroundStyle(tint.opacity(0.12))
+            }
+            ForEach(todayPoints) { point in
+                LineMark(
+                    x: .value("Hour", point.hour),
+                    y: .value("Today", point.value),
+                    series: .value("Series", "today")
+                )
+                .interpolationMethod(.monotone)
+                .foregroundStyle(tint)
+                .lineStyle(StrokeStyle(lineWidth: 2, lineCap: .round, lineJoin: .round))
+            }
+        }
+        .chartXScale(domain: 0...23)
+        .chartYScale(domain: 0...maxValue)
+        .chartXAxis {
+            AxisMarks(values: [0, 6, 12, 18]) { value in
+                AxisGridLine()
+                AxisValueLabel {
+                    switch value.as(Int.self) {
+                    case 0:  Text("12a")
+                    case 6:  Text("6a")
+                    case 12: Text("12p")
+                    case 18: Text("6p")
+                    default: EmptyView()
+                    }
+                }
+            }
+        }
+        .chartYAxis(.hidden)
+        .chartLegend(.hidden)
+        .allowsHitTesting(false)
+        .frame(height: 80)
+        .padding(.top, 4)
+    }
+
+    // MARK: - Supporting types
+
+    private struct DemoHourPoint: Identifiable {
+        let id: Int
+        let hour: Int
+        let value: Int
+    }
+
+    // MARK: - Sample data
+
+    /// Cumulative sleep minutes by hour.
+    /// ~5h night sleep, 1h morning nap around 9am, 1.5h afternoon nap around 1pm, 1h bedtime around 7pm.
+    private static let sleepSeries = HourlyCumulativeSeries(
+        todayCumulative: [
+            60, 120, 180, 240, 300, 300, 300, 300, 300, // 12a–8a (hours 0–8, night sleep ends ~5am)
+            360, 360, 360, 360,                          // 9a–12p (hours 9–12, morning nap at 9am)
+            420, 480, 480,                               // 1p–3p  (hours 13–15, afternoon nap)
+            480, 480, 480,                               // 4p–6p  (hours 16–18)
+            540, 540, 540, 540, 540,                     // 7p–11p (hours 19–23, bedtime at 7pm)
+        ],
+        averageCumulative: [
+            55, 110, 165, 220, 275, 275, 275, 275, 275,
+            335, 335, 335, 335,
+            395, 455, 455,
+            455, 455, 455,
+            515, 515, 515, 515, 515,
+        ]
+    )
+
+    /// Cumulative bottle feed volume (mL) by hour.
+    /// Four feeds: 6am 150mL, 10am 150mL, 2pm 150mL, 5:30pm 150mL.
+    private static let bottleSeries = HourlyCumulativeSeries(
+        todayCumulative: [
+            0, 0, 0, 0, 0, 0,            // 12a–5a
+            150, 150, 150, 150,           // 6a–9a
+            300, 300, 300, 300,           // 10a–1p
+            450, 450, 450,               // 2p–4p
+            600, 600, 600, 600, 600, 600, 600, // 5p–11p
+        ],
+        averageCumulative: [
+            0, 0, 0, 0, 0, 0,
+            130, 130, 130, 130,
+            260, 260, 260, 260,
+            390, 390, 390,
+            520, 520, 520, 520, 520, 520, 520,
+        ]
+    )
 }
 
 #Preview {

--- a/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/OnboardingChartsDemoView.swift
+++ b/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/OnboardingChartsDemoView.swift
@@ -3,34 +3,52 @@ import SwiftUI
 /// A scaled, clipped demo of `SummaryScreenView` used on the "Spot the patterns"
 /// onboarding page.
 ///
-/// Slides up and fades in on appear. The Charts framework animates its own content
-/// on first render, providing natural visual interest without extra animation overhead.
+/// Slides up and fades in on appear. `SummaryScreenView` is inserted into the hierarchy
+/// only after the entry animation settles so the Charts framework fires its built-in
+/// line-draw and bar-grow animations while the demo is fully visible.
 struct OnboardingChartsDemoView: View {
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
-    @State private var viewModel = OnboardingDemoDataFactory.summaryViewModel
 
     @State private var appeared = false
+    @State private var showCharts = false
 
     private let naturalHeight: CGFloat = 560
 
     var body: some View {
-        SummaryScreenView(viewModel: viewModel)
-            .frame(height: naturalHeight)
-            .scaleEffect(0.72, anchor: .top)
-            .frame(height: naturalHeight * 0.72)
-            .clipped()
-            .clipShape(RoundedRectangle(cornerRadius: 24, style: .continuous))
-            .allowsHitTesting(false)
-            // Entry slide-up
-            .opacity(appeared ? 1 : 0)
-            .offset(y: appeared ? 0 : 28)
-            .animation(
-                reduceMotion ? nil : .spring(response: 0.52, dampingFraction: 0.82).delay(0.15),
-                value: appeared
-            )
-            .onAppear {
-                appeared = true
+        ZStack {
+            if showCharts {
+                SummaryScreenView(viewModel: OnboardingDemoDataFactory.summaryViewModel)
+                    .allowsHitTesting(false)
+                    .transition(.opacity)
             }
+        }
+        .frame(height: naturalHeight)
+        .scaleEffect(0.72, anchor: .top)
+        .frame(height: naturalHeight * 0.72)
+        .clipped()
+        .clipShape(RoundedRectangle(cornerRadius: 24, style: .continuous))
+        // Entry slide-up
+        .opacity(appeared ? 1 : 0)
+        .offset(y: appeared ? 0 : 28)
+        .animation(
+            reduceMotion ? nil : .spring(response: 0.52, dampingFraction: 0.82).delay(0.15),
+            value: appeared
+        )
+        .onAppear {
+            appeared = true
+            guard !reduceMotion else {
+                showCharts = true
+                return
+            }
+            // Insert SummaryScreenView after the entry slide settles so Charts
+            // fires its line-draw and bar-grow animations while visible.
+            Task { @MainActor in
+                try? await Task.sleep(for: .milliseconds(600))
+                withAnimation(.easeIn(duration: 0.25)) {
+                    showCharts = true
+                }
+            }
+        }
     }
 }
 

--- a/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/OnboardingDemoPageContainer.swift
+++ b/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/OnboardingDemoPageContainer.swift
@@ -1,0 +1,103 @@
+import SwiftUI
+
+/// Animated page wrapper used by the three feature-demo steps (Quick Log, Timeline, Charts).
+///
+/// Title and body text stagger in on appear. The `demo` content is responsible for its
+/// own entry animation so per-element timing is preserved. The page indicator dots are
+/// rendered at the bottom.
+struct OnboardingDemoPageContainer<Demo: View>: View {
+    let title: String
+    let message: String
+    let pageIndex: Int
+    let totalDemoPages: Int
+    let demo: () -> Demo
+
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+    @State private var titleAppeared = false
+    @State private var messageAppeared = false
+
+    init(
+        title: String,
+        message: String,
+        pageIndex: Int,
+        totalDemoPages: Int = 4,
+        @ViewBuilder demo: @escaping () -> Demo
+    ) {
+        self.title = title
+        self.message = message
+        self.pageIndex = pageIndex
+        self.totalDemoPages = totalDemoPages
+        self.demo = demo
+    }
+
+    var body: some View {
+        VStack(spacing: 0) {
+            VStack(alignment: .leading, spacing: 12) {
+                Text(title)
+                    .font(.largeTitle.weight(.bold))
+                    .fixedSize(horizontal: false, vertical: true)
+                    .opacity(titleAppeared ? 1 : 0)
+                    .offset(y: titleAppeared ? 0 : 18)
+
+                Text(message)
+                    .font(.title3)
+                    .foregroundStyle(.secondary)
+                    .fixedSize(horizontal: false, vertical: true)
+                    .opacity(messageAppeared ? 1 : 0)
+                    .offset(y: messageAppeared ? 0 : 14)
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .padding(.horizontal, 24)
+            .padding(.top, 32)
+            .padding(.bottom, 20)
+
+            demo()
+                .padding(.horizontal, 24)
+
+            pageIndicator
+                .padding(.top, 20)
+        }
+        .onAppear {
+            animateIn()
+        }
+    }
+
+    private var pageIndicator: some View {
+        HStack(spacing: 8) {
+            ForEach(0..<totalDemoPages, id: \.self) { index in
+                Capsule()
+                    .fill(index == pageIndex ? Color.accentColor : Color.secondary.opacity(0.18))
+                    .frame(width: index == pageIndex ? 28 : 10, height: 10)
+            }
+        }
+        .accessibilityElement(children: .ignore)
+        .accessibilityLabel("Onboarding step \(pageIndex + 1) of \(totalDemoPages)")
+    }
+
+    private func animateIn() {
+        if reduceMotion {
+            titleAppeared = true
+            messageAppeared = true
+            return
+        }
+
+        withAnimation(.spring(response: 0.5, dampingFraction: 0.82)) {
+            titleAppeared = true
+        }
+        withAnimation(.spring(response: 0.5, dampingFraction: 0.82).delay(0.09)) {
+            messageAppeared = true
+        }
+    }
+}
+
+#Preview {
+    OnboardingDemoPageContainer(
+        title: "Log in seconds",
+        message: "Tap one button, fill in the details, done. No fumbling around.",
+        pageIndex: 1
+    ) {
+        Color.accentColor.opacity(0.1)
+            .frame(height: 180)
+            .clipShape(RoundedRectangle(cornerRadius: 24, style: .continuous))
+    }
+}

--- a/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/OnboardingDemoPageContainer.swift
+++ b/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/OnboardingDemoPageContainer.swift
@@ -3,13 +3,12 @@ import SwiftUI
 /// Animated page wrapper used by the three feature-demo steps (Quick Log, Timeline, Charts).
 ///
 /// Title and body text stagger in on appear. The `demo` content is responsible for its
-/// own entry animation so per-element timing is preserved. The page indicator dots are
-/// rendered at the bottom.
+/// own entry animation so per-element timing is preserved. The page indicator lives in
+/// `InteractiveOnboardingView`'s footer so it stays pinned just above the Continue button
+/// across all four intro pages.
 struct OnboardingDemoPageContainer<Demo: View>: View {
     let title: String
     let message: String
-    let pageIndex: Int
-    let totalDemoPages: Int
     let demo: () -> Demo
 
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
@@ -19,14 +18,10 @@ struct OnboardingDemoPageContainer<Demo: View>: View {
     init(
         title: String,
         message: String,
-        pageIndex: Int,
-        totalDemoPages: Int = 4,
         @ViewBuilder demo: @escaping () -> Demo
     ) {
         self.title = title
         self.message = message
-        self.pageIndex = pageIndex
-        self.totalDemoPages = totalDemoPages
         self.demo = demo
     }
 
@@ -53,25 +48,10 @@ struct OnboardingDemoPageContainer<Demo: View>: View {
 
             demo()
                 .padding(.horizontal, 24)
-
-            pageIndicator
-                .padding(.top, 20)
         }
         .onAppear {
             animateIn()
         }
-    }
-
-    private var pageIndicator: some View {
-        HStack(spacing: 8) {
-            ForEach(0..<totalDemoPages, id: \.self) { index in
-                Capsule()
-                    .fill(index == pageIndex ? Color.accentColor : Color.secondary.opacity(0.18))
-                    .frame(width: index == pageIndex ? 28 : 10, height: 10)
-            }
-        }
-        .accessibilityElement(children: .ignore)
-        .accessibilityLabel("Onboarding step \(pageIndex + 1) of \(totalDemoPages)")
     }
 
     private func animateIn() {
@@ -93,8 +73,7 @@ struct OnboardingDemoPageContainer<Demo: View>: View {
 #Preview {
     OnboardingDemoPageContainer(
         title: "Log in seconds",
-        message: "Tap one button, fill in the details, done. No fumbling around.",
-        pageIndex: 1
+        message: "Tap one button, fill in the details, done. No fumbling around."
     ) {
         Color.accentColor.opacity(0.1)
             .frame(height: 180)

--- a/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/OnboardingDemoPageContainer.swift
+++ b/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/OnboardingDemoPageContainer.swift
@@ -32,14 +32,12 @@ struct OnboardingDemoPageContainer<Demo: View>: View {
                     .font(.largeTitle.weight(.bold))
                     .fixedSize(horizontal: false, vertical: true)
                     .opacity(titleAppeared ? 1 : 0)
-                    .offset(y: titleAppeared ? 0 : 18)
 
                 Text(message)
                     .font(.title3)
                     .foregroundStyle(.secondary)
                     .fixedSize(horizontal: false, vertical: true)
                     .opacity(messageAppeared ? 1 : 0)
-                    .offset(y: messageAppeared ? 0 : 14)
             }
             .frame(maxWidth: .infinity, alignment: .leading)
             .padding(.horizontal, 24)
@@ -61,10 +59,10 @@ struct OnboardingDemoPageContainer<Demo: View>: View {
             return
         }
 
-        withAnimation(.spring(response: 0.5, dampingFraction: 0.82)) {
+        withAnimation(.easeIn(duration: 0.35)) {
             titleAppeared = true
         }
-        withAnimation(.spring(response: 0.5, dampingFraction: 0.82).delay(0.09)) {
+        withAnimation(.easeIn(duration: 0.35).delay(0.1)) {
             messageAppeared = true
         }
     }

--- a/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/OnboardingFirstEventStepView.swift
+++ b/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/OnboardingFirstEventStepView.swift
@@ -2,8 +2,11 @@ import BabyTrackerDomain
 import SwiftUI
 
 /// The first-event logging step in the interactive onboarding flow.
+///
 /// Presents the real quick-log editor sheets so the user can log an event before
-/// entering the main app. On a successful save the `onEventSaved` callback fires.
+/// entering the main app. Buttons stagger in with a bouncy spring then cycle
+/// through a zoom-up → wiggle → zoom-down sequence, matching the Quick Log
+/// demo page. On a successful save the `onEventSaved` callback fires.
 struct OnboardingFirstEventStepView: View {
     let model: AppModel
     let onEventSaved: () -> Void
@@ -14,6 +17,9 @@ struct OnboardingFirstEventStepView: View {
     @State private var activeEventSheet: ChildEventSheet?
     @State private var firstEventSaved = false
     @State private var appearedMask: [Bool] = [false, false, false, false, false, false]
+    @State private var highlightedIndex = 0
+    @State private var wiggleScales: [Double] = [1.0, 1.0, 1.0, 1.0]
+    @State private var rotations: [Double] = [0, 0, 0, 0]
 
     private var childName: String {
         model.currentChild?.name ?? "your baby"
@@ -38,22 +44,24 @@ struct OnboardingFirstEventStepView: View {
 
                 VStack(spacing: 12) {
                     HStack(spacing: 12) {
-                        quickLogButton("Breast Feed", kind: .breastFeed, appeared: appearedMask[2]) {
+                        quickLogButton(0, title: "Breast Feed", kind: .breastFeed) {
                             activeEventSheet = .quickLogBreastFeed
                         }
-                        quickLogButton("Bottle Feed", kind: .bottleFeed, appeared: appearedMask[3]) {
+                        quickLogButton(1, title: "Bottle Feed", kind: .bottleFeed) {
                             activeEventSheet = .quickLogBottleFeed
                         }
                     }
+                    .geometryGroup()
 
                     HStack(spacing: 12) {
-                        quickLogButton("Start Sleep", kind: .sleep, appeared: appearedMask[4]) {
+                        quickLogButton(2, title: "Start Sleep", kind: .sleep) {
                             activeEventSheet = .startSleep(suggestions: [])
                         }
-                        quickLogButton("Nappy", kind: .nappy, appeared: appearedMask[5]) {
+                        quickLogButton(3, title: "Nappy", kind: .nappy) {
                             activeEventSheet = .quickLogNappy(.mixed)
                         }
                     }
+                    .geometryGroup()
                 }
             }
             .frame(maxWidth: .infinity, alignment: .leading)
@@ -65,6 +73,21 @@ struct OnboardingFirstEventStepView: View {
         .onAppear {
             staggerIn()
         }
+        .task(id: reduceMotion) {
+            guard !reduceMotion else { return }
+            // Wait for page slide-in + full stagger to settle before first wiggle
+            try? await Task.sleep(for: .milliseconds(1200))
+            animateWiggle(0)
+            while !Task.isCancelled {
+                try? await Task.sleep(for: .seconds(2.4))
+                guard !Task.isCancelled else { break }
+                let next = (highlightedIndex + 1) % 4
+                withAnimation(.spring(response: 0.38, dampingFraction: 0.62)) {
+                    highlightedIndex = next
+                }
+                animateWiggle(next)
+            }
+        }
         .sheet(item: $activeEventSheet, onDismiss: { activeEventSheet = nil }) { sheet in
             eventSheet(for: sheet)
         }
@@ -73,22 +96,55 @@ struct OnboardingFirstEventStepView: View {
         }
     }
 
+    // MARK: - Button
+
+    private func quickLogButton(
+        _ buttonIndex: Int,
+        title: String,
+        kind: BabyEventKind,
+        action: @escaping () -> Void
+    ) -> some View {
+        let appeared = appearedMask[buttonIndex + 2]
+        let isHighlighted = highlightedIndex == buttonIndex && appearedMask.allSatisfy { $0 }
+
+        return Button(action: action) {
+            Label(title, systemImage: BabyEventStyle.systemImage(for: kind))
+                .font(.headline)
+                .frame(maxWidth: .infinity, minHeight: 56, alignment: .leading)
+                .padding(.horizontal, 14)
+                .foregroundStyle(BabyEventStyle.buttonForegroundColor(for: kind))
+                .background(
+                    RoundedRectangle(cornerRadius: 18, style: .continuous)
+                        .fill(BabyEventStyle.buttonFillColor(for: kind))
+                        .shadow(
+                            color: BabyEventStyle.buttonFillColor(for: kind).opacity(isHighlighted ? 0.55 : 0),
+                            radius: isHighlighted ? 10 : 0,
+                            y: isHighlighted ? 4 : 0
+                        )
+                )
+        }
+        .buttonStyle(.plain)
+        .scaleEffect(wiggleScales[buttonIndex])
+        .rotationEffect(.degrees(rotations[buttonIndex]))
+        .opacity(appeared ? 1 : 0)
+        .offset(y: appeared ? 0 : 22)
+    }
+
+    // MARK: - Animation
+
     private func staggerIn() {
         if reduceMotion {
             appearedMask = Array(repeating: true, count: appearedMask.count)
             return
         }
         Task { @MainActor in
-            // Wait for the page slide-in to settle
             try? await Task.sleep(for: .milliseconds(420))
-            // Title and subtitle — gentle spring
             withAnimation(.spring(response: 0.5, dampingFraction: 0.82)) {
                 appearedMask[0] = true
             }
             withAnimation(.spring(response: 0.5, dampingFraction: 0.82).delay(0.08)) {
                 appearedMask[1] = true
             }
-            // Buttons — bouncy spring staggered in one by one
             for index in 2..<appearedMask.count {
                 let delay = Double(index - 2) * 0.1
                 withAnimation(.spring(response: 0.38, dampingFraction: 0.52).delay(delay)) {
@@ -98,27 +154,29 @@ struct OnboardingFirstEventStepView: View {
         }
     }
 
-    private func quickLogButton(
-        _ title: String,
-        kind: BabyEventKind,
-        appeared: Bool,
-        action: @escaping () -> Void
-    ) -> some View {
-        Button(action: action) {
-            Label(title, systemImage: BabyEventStyle.systemImage(for: kind))
-                .font(.headline)
-                .frame(maxWidth: .infinity, minHeight: 56, alignment: .leading)
-                .padding(.horizontal, 14)
-                .foregroundStyle(BabyEventStyle.buttonForegroundColor(for: kind))
-                .background(
-                    RoundedRectangle(cornerRadius: 18, style: .continuous)
-                        .fill(BabyEventStyle.buttonFillColor(for: kind))
-                )
+    /// Plays a zoom-up → wiggle → zoom-down sequence on the button at `index`.
+    private func animateWiggle(_ index: Int) {
+        guard !reduceMotion else { return }
+        withAnimation(.spring(response: 0.22, dampingFraction: 0.6)) {
+            wiggleScales[index] = 1.06
         }
-        .buttonStyle(.plain)
-        .opacity(appeared ? 1 : 0)
-        .offset(y: appeared ? 0 : 22)
+        Task { @MainActor in
+            try? await Task.sleep(for: .milliseconds(160))
+            let rotationSteps: [Double] = [4, -4, 3, 0]
+            for rot in rotationSteps {
+                guard !Task.isCancelled else { return }
+                withAnimation(.spring(response: 0.14, dampingFraction: 0.6)) {
+                    rotations[index] = rot
+                }
+                try? await Task.sleep(for: .milliseconds(110))
+            }
+            withAnimation(.spring(response: 0.3, dampingFraction: 0.75)) {
+                wiggleScales[index] = 1.0
+            }
+        }
     }
+
+    // MARK: - Event sheets
 
     @ViewBuilder
     private func eventSheet(for sheet: ChildEventSheet) -> some View {

--- a/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/OnboardingFirstEventStepView.swift
+++ b/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/OnboardingFirstEventStepView.swift
@@ -9,8 +9,11 @@ struct OnboardingFirstEventStepView: View {
     let onEventSaved: () -> Void
     let skipAction: () -> Void
 
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+
     @State private var activeEventSheet: ChildEventSheet?
     @State private var firstEventSaved = false
+    @State private var appearedMask: [Bool] = [false, false, false, false, false, false]
 
     private var childName: String {
         model.currentChild?.name ?? "your baby"
@@ -22,28 +25,32 @@ struct OnboardingFirstEventStepView: View {
                 VStack(alignment: .leading, spacing: 12) {
                     Text("Log your first event")
                         .font(.largeTitle.weight(.bold))
+                        .opacity(appearedMask[0] ? 1 : 0)
+                        .offset(y: appearedMask[0] ? 0 : 18)
 
                     Text("Try it now — pick whichever happened most recently.")
                         .font(.title3)
                         .foregroundStyle(.secondary)
                         .fixedSize(horizontal: false, vertical: true)
+                        .opacity(appearedMask[1] ? 1 : 0)
+                        .offset(y: appearedMask[1] ? 0 : 14)
                 }
 
                 VStack(spacing: 12) {
                     HStack(spacing: 12) {
-                        quickLogButton("Breast Feed", kind: .breastFeed) {
+                        quickLogButton("Breast Feed", kind: .breastFeed, appeared: appearedMask[2]) {
                             activeEventSheet = .quickLogBreastFeed
                         }
-                        quickLogButton("Bottle Feed", kind: .bottleFeed) {
+                        quickLogButton("Bottle Feed", kind: .bottleFeed, appeared: appearedMask[3]) {
                             activeEventSheet = .quickLogBottleFeed
                         }
                     }
 
                     HStack(spacing: 12) {
-                        quickLogButton("Start Sleep", kind: .sleep) {
+                        quickLogButton("Start Sleep", kind: .sleep, appeared: appearedMask[4]) {
                             activeEventSheet = .startSleep(suggestions: [])
                         }
-                        quickLogButton("Nappy", kind: .nappy) {
+                        quickLogButton("Nappy", kind: .nappy, appeared: appearedMask[5]) {
                             activeEventSheet = .quickLogNappy(.mixed)
                         }
                     }
@@ -55,6 +62,9 @@ struct OnboardingFirstEventStepView: View {
             .padding(.bottom, 8)
         }
         .scrollBounceBehavior(.basedOnSize)
+        .onAppear {
+            staggerIn()
+        }
         .sheet(item: $activeEventSheet, onDismiss: { activeEventSheet = nil }) { sheet in
             eventSheet(for: sheet)
         }
@@ -63,9 +73,23 @@ struct OnboardingFirstEventStepView: View {
         }
     }
 
+    private func staggerIn() {
+        if reduceMotion {
+            appearedMask = Array(repeating: true, count: appearedMask.count)
+            return
+        }
+        for index in 0..<appearedMask.count {
+            let delay = Double(index) * 0.08
+            withAnimation(.spring(response: 0.5, dampingFraction: 0.82).delay(delay)) {
+                appearedMask[index] = true
+            }
+        }
+    }
+
     private func quickLogButton(
         _ title: String,
         kind: BabyEventKind,
+        appeared: Bool,
         action: @escaping () -> Void
     ) -> some View {
         Button(action: action) {
@@ -80,6 +104,8 @@ struct OnboardingFirstEventStepView: View {
                 )
         }
         .buttonStyle(.plain)
+        .opacity(appeared ? 1 : 0)
+        .offset(y: appeared ? 0 : 18)
     }
 
     @ViewBuilder

--- a/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/OnboardingFirstEventStepView.swift
+++ b/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/OnboardingFirstEventStepView.swift
@@ -1,0 +1,191 @@
+import BabyTrackerDomain
+import SwiftUI
+
+/// The first-event logging step in the interactive onboarding flow.
+/// Presents the real quick-log editor sheets so the user can log an event before
+/// entering the main app. On a successful save the `onEventSaved` callback fires.
+struct OnboardingFirstEventStepView: View {
+    let model: AppModel
+    let onEventSaved: () -> Void
+    let skipAction: () -> Void
+
+    @State private var activeEventSheet: ChildEventSheet?
+    @State private var firstEventSaved = false
+
+    private var childName: String {
+        model.currentChild?.name ?? "your baby"
+    }
+
+    var body: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: 24) {
+                VStack(alignment: .leading, spacing: 12) {
+                    Text("Log your first event")
+                        .font(.largeTitle.weight(.bold))
+
+                    Text("Try it now — pick whichever happened most recently.")
+                        .font(.title3)
+                        .foregroundStyle(.secondary)
+                        .fixedSize(horizontal: false, vertical: true)
+                }
+
+                VStack(spacing: 12) {
+                    HStack(spacing: 12) {
+                        quickLogButton("Breast Feed", kind: .breastFeed) {
+                            activeEventSheet = .quickLogBreastFeed
+                        }
+                        quickLogButton("Bottle Feed", kind: .bottleFeed) {
+                            activeEventSheet = .quickLogBottleFeed
+                        }
+                    }
+
+                    HStack(spacing: 12) {
+                        quickLogButton("Start Sleep", kind: .sleep) {
+                            activeEventSheet = .startSleep(suggestions: [])
+                        }
+                        quickLogButton("Nappy", kind: .nappy) {
+                            activeEventSheet = .quickLogNappy(.mixed)
+                        }
+                    }
+                }
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .padding(.horizontal, 24)
+            .padding(.top, 32)
+            .padding(.bottom, 8)
+        }
+        .scrollBounceBehavior(.basedOnSize)
+        .sheet(item: $activeEventSheet, onDismiss: { activeEventSheet = nil }) { sheet in
+            eventSheet(for: sheet)
+        }
+        .onChange(of: firstEventSaved) { _, saved in
+            if saved { onEventSaved() }
+        }
+    }
+
+    private func quickLogButton(
+        _ title: String,
+        kind: BabyEventKind,
+        action: @escaping () -> Void
+    ) -> some View {
+        Button(action: action) {
+            Label(title, systemImage: BabyEventStyle.systemImage(for: kind))
+                .font(.headline)
+                .frame(maxWidth: .infinity, minHeight: 56, alignment: .leading)
+                .padding(.horizontal, 14)
+                .foregroundStyle(BabyEventStyle.buttonForegroundColor(for: kind))
+                .background(
+                    RoundedRectangle(cornerRadius: 18, style: .continuous)
+                        .fill(BabyEventStyle.buttonFillColor(for: kind))
+                )
+        }
+        .buttonStyle(.plain)
+    }
+
+    @ViewBuilder
+    private func eventSheet(for sheet: ChildEventSheet) -> some View {
+        switch sheet {
+        case .quickLogBreastFeed:
+            BreastFeedEditorSheetView(
+                navigationTitle: "Breast Feed",
+                primaryActionTitle: "Save",
+                childName: childName,
+                initialDurationMinutes: 15,
+                initialEndTime: Date(),
+                initialSide: nil
+            ) { durationMinutes, endTime, side, leftDurationSeconds, rightDurationSeconds in
+                let didSave = model.logBreastFeed(
+                    durationMinutes: durationMinutes,
+                    endTime: endTime,
+                    side: side,
+                    leftDurationSeconds: leftDurationSeconds,
+                    rightDurationSeconds: rightDurationSeconds
+                )
+                if didSave {
+                    activeEventSheet = nil
+                    firstEventSaved = true
+                }
+                return didSave
+            }
+
+        case .quickLogBottleFeed:
+            BottleFeedEditorSheetView(
+                navigationTitle: "Bottle Feed",
+                primaryActionTitle: "Save",
+                childName: childName,
+                preferredVolumeUnit: model.currentChild?.preferredFeedVolumeUnit ?? .milliliters,
+                initialAmountMilliliters: 120,
+                initialOccurredAt: Date(),
+                initialMilkType: .formula
+            ) { amountMilliliters, occurredAt, milkType in
+                let didSave = model.logBottleFeed(
+                    amountMilliliters: amountMilliliters,
+                    occurredAt: occurredAt,
+                    milkType: milkType
+                )
+                if didSave {
+                    activeEventSheet = nil
+                    firstEventSaved = true
+                }
+                return didSave
+            }
+
+        case let .startSleep(suggestions):
+            SleepEditorSheetView(
+                mode: .start,
+                childName: childName,
+                initialStartedAt: Date(),
+                initialEndedAt: nil,
+                startSuggestions: suggestions
+            ) { startedAt, endedAt in
+                let didSave: Bool
+                if let endedAt {
+                    didSave = model.logSleep(startedAt: startedAt, endedAt: endedAt)
+                } else {
+                    didSave = model.startSleep(startedAt: startedAt)
+                }
+                if didSave {
+                    activeEventSheet = nil
+                    firstEventSaved = true
+                }
+                return didSave
+            }
+
+        case let .quickLogNappy(type):
+            NappyEditorSheetView(
+                navigationTitle: "Nappy",
+                primaryActionTitle: "Save",
+                childName: childName,
+                initialType: type,
+                initialOccurredAt: Date(),
+                initialPeeVolume: nil,
+                initialPooVolume: nil,
+                initialPooColor: nil
+            ) { updatedType, occurredAt, peeVolume, pooVolume, pooColor in
+                let didSave = model.logNappy(
+                    type: updatedType,
+                    occurredAt: occurredAt,
+                    peeVolume: peeVolume,
+                    pooVolume: pooVolume,
+                    pooColor: pooColor
+                )
+                if didSave {
+                    activeEventSheet = nil
+                    firstEventSaved = true
+                }
+                return didSave
+            }
+
+        default:
+            EmptyView()
+        }
+    }
+}
+
+#Preview {
+    OnboardingFirstEventStepView(
+        model: ChildProfilePreviewFactory.makeModel(),
+        onEventSaved: {},
+        skipAction: {}
+    )
+}

--- a/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/OnboardingFirstEventStepView.swift
+++ b/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/OnboardingFirstEventStepView.swift
@@ -78,10 +78,22 @@ struct OnboardingFirstEventStepView: View {
             appearedMask = Array(repeating: true, count: appearedMask.count)
             return
         }
-        for index in 0..<appearedMask.count {
-            let delay = Double(index) * 0.08
-            withAnimation(.spring(response: 0.5, dampingFraction: 0.82).delay(delay)) {
-                appearedMask[index] = true
+        Task { @MainActor in
+            // Wait for the page slide-in to settle
+            try? await Task.sleep(for: .milliseconds(420))
+            // Title and subtitle — gentle spring
+            withAnimation(.spring(response: 0.5, dampingFraction: 0.82)) {
+                appearedMask[0] = true
+            }
+            withAnimation(.spring(response: 0.5, dampingFraction: 0.82).delay(0.08)) {
+                appearedMask[1] = true
+            }
+            // Buttons — bouncy spring staggered in one by one
+            for index in 2..<appearedMask.count {
+                let delay = Double(index - 2) * 0.1
+                withAnimation(.spring(response: 0.38, dampingFraction: 0.52).delay(delay)) {
+                    appearedMask[index] = true
+                }
             }
         }
     }
@@ -105,7 +117,7 @@ struct OnboardingFirstEventStepView: View {
         }
         .buttonStyle(.plain)
         .opacity(appeared ? 1 : 0)
-        .offset(y: appeared ? 0 : 18)
+        .offset(y: appeared ? 0 : 22)
     }
 
     @ViewBuilder

--- a/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/OnboardingLiveActivityDemoView.swift
+++ b/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/OnboardingLiveActivityDemoView.swift
@@ -1,0 +1,352 @@
+import BabyTrackerDomain
+import BabyTrackerLiveActivities
+import SwiftUI
+import UIKit
+
+/// A lock-screen Live Activity demo used on the onboarding flow.
+///
+/// The device shell is rendered locally in SwiftUI so the feature package stays
+/// independent from the widget target while still showing a realistic preview.
+struct OnboardingLiveActivityDemoView: View {
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+
+    @State private var deviceVisible = false
+    @State private var activityVisible = false
+    @State private var deviceFrameSnapshot: UIImage?
+
+    private let state = FeedLiveActivityAttributes.ContentState(
+        childID: UUID(uuidString: "11111111-2222-3333-4444-555555555555")!,
+        childName: "Robyn Murphy",
+        lastFeedKind: .breastFeed,
+        lastFeedAt: Date.now.addingTimeInterval(-95 * 60),
+        lastSleepAt: Date.now.addingTimeInterval(-3 * 60 * 60),
+        activeSleepStartedAt: Date.now.addingTimeInterval(-28 * 60),
+        lastNappyAt: Date.now.addingTimeInterval(-80 * 60)
+    )
+
+    var body: some View {
+        GeometryReader { geo in
+            let demoViewportHeight = min(geo.size.height, 360.0)
+            let deviceWidth = max(220, geo.size.width - 28)
+            let deviceHeight = deviceWidth * 2.03
+
+            ZStack(alignment: .bottom) {
+                deviceFrameWrapper(width: deviceWidth, height: deviceHeight)
+
+                liveActivityCard
+                    .frame(width: deviceWidth - 42)
+                    .opacity(activityVisible ? 1 : 0)
+                    .padding(.bottom, deviceHeight * 0.12)
+                    .offset(y: activityVisible ? 0 : 24)
+                    .scaleEffect(activityVisible ? 1 : 0.95, anchor: .bottom)
+            }
+            .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .bottom)
+            .frame(height: demoViewportHeight, alignment: .bottom)
+            .clipped()
+            .mask {
+                LinearGradient(
+                    stops: [
+                        .init(color: .clear, location: 0.0),
+                        .init(color: .black.opacity(0.15), location: 0.10),
+                        .init(color: .black.opacity(0.7), location: 0.20),
+                        .init(color: .black, location: 0.30),
+                        .init(color: .black, location: 1.0),
+                    ],
+                    startPoint: .top,
+                    endPoint: .bottom
+                )
+            }
+            .padding(.bottom, 4)
+        }
+        .frame(height: 360)
+        .onAppear {
+            prepareDeviceFrameSnapshot()
+            animateIn()
+        }
+    }
+
+    private func deviceFrameWrapper(width: CGFloat, height: CGFloat) -> some View {
+        ZStack {
+            if let deviceFrameSnapshot {
+                Image(uiImage: deviceFrameSnapshot)
+                    .resizable()
+                    .interpolation(.high)
+                    .frame(width: width, height: height)
+            } else {
+                deviceShell(width: width, height: height)
+                    .frame(width: width, height: height)
+            }
+        }
+        .opacity(deviceVisible ? 1 : 0)
+        .offset(y: deviceVisible ? 0 : 46)
+    }
+
+    private func deviceShell(width: CGFloat, height: CGFloat) -> some View {
+        let outerCorner = width * 0.16
+        let screenCorner = width * 0.13
+        let inset = width * 0.035
+
+        return ZStack(alignment: .top) {
+            RoundedRectangle(cornerRadius: outerCorner, style: .continuous)
+                .fill(
+                    LinearGradient(
+                        colors: [
+                            Color(red: 0.20, green: 0.21, blue: 0.24),
+                            Color(red: 0.07, green: 0.07, blue: 0.09),
+                        ],
+                        startPoint: .topLeading,
+                        endPoint: .bottomTrailing
+                    )
+                )
+                .overlay {
+                    RoundedRectangle(cornerRadius: outerCorner, style: .continuous)
+                        .strokeBorder(Color.white.opacity(0.14), lineWidth: 1)
+                }
+                .shadow(color: .black.opacity(0.2), radius: 24, y: 14)
+
+            RoundedRectangle(cornerRadius: screenCorner, style: .continuous)
+                .fill(Color.black)
+                .overlay {
+                    lockScreenBackground
+                        .clipShape(RoundedRectangle(cornerRadius: screenCorner, style: .continuous))
+                }
+                .padding(inset)
+                .overlay(alignment: .top) {
+                    Capsule()
+                        .fill(.black.opacity(0.9))
+                        .frame(width: width * 0.34, height: 28)
+                        .padding(.top, 18)
+                }
+                .overlay(alignment: .top) {
+                    VStack(spacing: 6) {
+                        Text("9:41")
+                            .font(.system(size: 40, weight: .thin, design: .rounded))
+                            .foregroundStyle(.white.opacity(0.9))
+                        Text("Tuesday, April 13")
+                            .font(.subheadline.weight(.medium))
+                            .foregroundStyle(.white.opacity(0.7))
+                    }
+                    .padding(.top, 66)
+                }
+        }
+        .mask {
+            RoundedRectangle(cornerRadius: outerCorner, style: .continuous)
+                .fill(
+                    LinearGradient(
+                        stops: [
+                            .init(color: .clear, location: 0.0),
+                            .init(color: .clear, location: 0.12),
+                            .init(color: .black.opacity(0.35), location: 0.26),
+                            .init(color: .black, location: 0.42),
+                            .init(color: .black, location: 1.0),
+                        ],
+                        startPoint: .top,
+                        endPoint: .bottom
+                    )
+                )
+        }
+    }
+
+    private var lockScreenBackground: some View {
+        ZStack {
+            LinearGradient(
+                colors: [
+                    Color(red: 0.13, green: 0.11, blue: 0.25),
+                    Color(red: 0.18, green: 0.27, blue: 0.47),
+                    Color(red: 0.10, green: 0.15, blue: 0.25),
+                ],
+                startPoint: .topLeading,
+                endPoint: .bottomTrailing
+            )
+
+            Circle()
+                .fill(Color.white.opacity(0.10))
+                .frame(width: 210)
+                .blur(radius: 12)
+                .offset(x: 58, y: -120)
+
+            Circle()
+                .fill(Color(red: 0.62, green: 0.78, blue: 1.0).opacity(0.18))
+                .frame(width: 180)
+                .blur(radius: 18)
+                .offset(x: -70, y: -40)
+        }
+    }
+
+    private var liveActivityCard: some View {
+        VStack(alignment: .center, spacing: 12) {
+            Text(state.childName)
+                .font(.headline)
+                .lineLimit(1)
+                .minimumScaleFactor(0.85)
+                .foregroundStyle(.white)
+
+            HStack(alignment: .center, spacing: 8) {
+                metricTile(
+                    title: "Feed",
+                    icon: symbolName(for: state.lastFeedKind),
+                    color: accentColor(for: .bottleFeed)
+                ) {
+                    Text(state.lastFeedAt, style: .timer)
+                        .liveActivityTimerStyle()
+                }
+
+                metricTile(
+                    title: state.activeSleepStartedAt == nil ? "Since sleep" : "Asleep",
+                    icon: symbolName(for: .sleep),
+                    color: accentColor(for: .sleep)
+                ) {
+                    if let activeSleepStartedAt = state.activeSleepStartedAt {
+                        Text(activeSleepStartedAt, style: .timer)
+                            .liveActivityTimerStyle()
+                    } else if let lastSleepAt = state.lastSleepAt {
+                        Text(lastSleepAt, style: .timer)
+                            .liveActivityTimerStyle()
+                    } else {
+                        Text("—")
+                    }
+                }
+
+                metricTile(
+                    title: "Nappy",
+                    icon: symbolName(for: .nappy),
+                    color: accentColor(for: .nappy)
+                ) {
+                    if let lastNappyAt = state.lastNappyAt {
+                        Text(lastNappyAt, style: .timer)
+                            .liveActivityTimerStyle()
+                    } else {
+                        Text("—")
+                    }
+                }
+            }
+
+            if state.activeSleepStartedAt != nil {
+                Label("Stop Sleep", systemImage: "stop.fill")
+                    .font(.footnote.weight(.semibold))
+                    .frame(maxWidth: .infinity)
+                    .padding(.vertical, 10)
+                    .background(accentColor(for: .sleep), in: Capsule())
+                    .foregroundStyle(.white)
+            }
+        }
+        .padding(.horizontal, 16)
+        .padding(.vertical, 12)
+        .background(
+            RoundedRectangle(cornerRadius: 24, style: .continuous)
+                .fill(Color(red: 0.12, green: 0.15, blue: 0.24))
+        )
+        .overlay {
+            RoundedRectangle(cornerRadius: 24, style: .continuous)
+                .strokeBorder(Color.white.opacity(0.08), lineWidth: 1)
+        }
+        .shadow(color: .black.opacity(0.22), radius: 16, y: 10)
+    }
+
+    private func metricTile(
+        title: String,
+        icon: String,
+        color: Color,
+        @ViewBuilder value: () -> some View
+    ) -> some View {
+        VStack(alignment: .center, spacing: 6) {
+            HStack(alignment: .center, spacing: 4) {
+                Image(systemName: icon)
+                    .frame(width: 14)
+                Text(title)
+            }
+            .font(.caption2.weight(.medium))
+            .lineLimit(1)
+            .minimumScaleFactor(0.8)
+            .foregroundStyle(color)
+            .frame(height: 16)
+
+            value()
+                .font(.footnote.weight(.semibold))
+                .monospacedDigit()
+                .lineLimit(1)
+                .minimumScaleFactor(0.75)
+                .foregroundStyle(.white)
+                .frame(height: 24, alignment: .center)
+        }
+        .frame(maxWidth: .infinity)
+    }
+
+    private func animateIn() {
+        if reduceMotion {
+            deviceVisible = true
+            activityVisible = true
+            return
+        }
+
+        Task { @MainActor in
+            try? await Task.sleep(for: .milliseconds(420))
+            withAnimation(.spring(response: 0.58, dampingFraction: 0.84)) {
+                deviceVisible = true
+            }
+            try? await Task.sleep(for: .milliseconds(300))
+            withAnimation(.spring(response: 0.52, dampingFraction: 0.82)) {
+                activityVisible = true
+            }
+        }
+    }
+
+    @MainActor
+    private func prepareDeviceFrameSnapshot() {
+        guard deviceFrameSnapshot == nil else { return }
+
+        let width: CGFloat = 320
+        let height = width * 2.03
+        let renderer = ImageRenderer(
+            content: deviceShell(width: width, height: height)
+                .frame(width: width, height: height)
+        )
+        renderer.scale = UIScreen.main.scale
+        deviceFrameSnapshot = renderer.uiImage
+    }
+
+    private func symbolName(for kind: BabyEventKind) -> String {
+        switch kind {
+        case .breastFeed:
+            "heart.text.square"
+        case .bottleFeed:
+            "drop.circle"
+        case .sleep:
+            "bed.double"
+        case .nappy:
+            "checklist"
+        }
+    }
+
+    private func accentColor(for kind: BabyEventKind) -> Color {
+        switch kind {
+        case .breastFeed:
+            Color(red: 0.84, green: 0.29, blue: 0.42)
+        case .bottleFeed:
+            Color(red: 0.15, green: 0.56, blue: 0.72)
+        case .sleep:
+            Color(red: 0.29, green: 0.33, blue: 0.73)
+        case .nappy:
+            Color(red: 0.74, green: 0.47, blue: 0.16)
+        }
+    }
+}
+
+#Preview {
+    OnboardingLiveActivityDemoView()
+        .padding(.horizontal, 24)
+}
+
+private extension Text {
+    func liveActivityTimerStyle() -> some View {
+        HStack(alignment: .center) {
+            Spacer()
+            Text("00:00:00")
+                .hidden()
+                .overlay {
+                    self
+                }
+            Spacer()
+        }
+    }
+}

--- a/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/OnboardingNotificationsDemoView.swift
+++ b/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/OnboardingNotificationsDemoView.swift
@@ -1,0 +1,154 @@
+import SwiftUI
+
+/// A notification preview scene used in onboarding before requesting permission.
+struct OnboardingNotificationsDemoView: View {
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+    @Environment(\.colorScheme) private var colorScheme
+
+    @State private var visibleMask = [false, false, false]
+
+    private let notifications: [DemoNotification] = [
+        DemoNotification(
+            title: "Bottle feed logged",
+            message: "Aoife added a 150 mL bottle for Robyn.",
+            minutesAgo: 2
+        ),
+        DemoNotification(
+            title: "Sleep started",
+            message: "Robyn went down for a nap 8 minutes ago.",
+            minutesAgo: 8
+        ),
+        DemoNotification(
+            title: "Nappy changed",
+            message: "Dry nappy logged just now.",
+            minutesAgo: 0
+        ),
+    ]
+
+    var body: some View {
+        VStack(spacing: 12) {
+            ForEach(Array(notifications.enumerated()), id: \.offset) { index, notification in
+                notificationCard(notification)
+                    .opacity(visibleMask[index] ? 1 : 0)
+                    .offset(y: visibleMask[index] ? 0 : 18)
+                    .scaleEffect(visibleMask[index] ? 1 : 0.97, anchor: .top)
+            }
+        }
+        .frame(maxWidth: .infinity)
+        .onAppear {
+            animateIn()
+        }
+    }
+
+    private func notificationCard(_ notification: DemoNotification) -> some View {
+        HStack(alignment: .top, spacing: 12) {
+            RoundedRectangle(cornerRadius: 11, style: .continuous)
+                .fill(
+                    LinearGradient(
+                        colors: [
+                            Color.accentColor,
+                            Color.accentColor.opacity(0.75),
+                        ],
+                        startPoint: .topLeading,
+                        endPoint: .bottomTrailing
+                    )
+                )
+                .frame(width: 36, height: 36)
+                .overlay {
+                    Image(systemName: "bird.fill")
+                        .font(.system(size: 15, weight: .semibold))
+                        .foregroundStyle(.white)
+                }
+
+            VStack(alignment: .leading, spacing: 6) {
+                HStack(alignment: .firstTextBaseline, spacing: 8) {
+                    Text("Nest")
+                        .font(.caption.weight(.semibold))
+                        .foregroundStyle(.primary)
+
+                    Spacer(minLength: 0)
+
+                    Text(timestampText(for: notification.minutesAgo))
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+
+                Text(notification.title)
+                    .font(.subheadline.weight(.semibold))
+                    .foregroundStyle(.primary)
+
+                Text(notification.message)
+                    .font(.subheadline)
+                    .foregroundStyle(.secondary)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+        }
+        .padding(14)
+        .background(notificationCardBackground, in: RoundedRectangle(cornerRadius: 24, style: .continuous))
+        .overlay {
+            RoundedRectangle(cornerRadius: 24, style: .continuous)
+                .strokeBorder(notificationBorderColor, lineWidth: 1)
+        }
+        .shadow(color: .black.opacity(colorScheme == .dark ? 0.24 : 0.08), radius: 14, y: 8)
+    }
+
+    private var notificationCardBackground: some ShapeStyle {
+        if colorScheme == .dark {
+            return AnyShapeStyle(
+                LinearGradient(
+                    colors: [
+                        Color.white.opacity(0.10),
+                        Color.white.opacity(0.06),
+                    ],
+                    startPoint: .topLeading,
+                    endPoint: .bottomTrailing
+                )
+            )
+        } else {
+            return AnyShapeStyle(.thinMaterial)
+        }
+    }
+
+    private var notificationBorderColor: Color {
+        colorScheme == .dark ? Color.white.opacity(0.08) : Color.white.opacity(0.7)
+    }
+
+    private func timestampText(for minutesAgo: Int) -> String {
+        switch minutesAgo {
+        case 0:
+            return "now"
+        case 1:
+            return "1m ago"
+        default:
+            return "\(minutesAgo)m ago"
+        }
+    }
+
+    private func animateIn() {
+        guard !reduceMotion else {
+            visibleMask = [true, true, true]
+            return
+        }
+
+        Task { @MainActor in
+            try? await Task.sleep(for: .milliseconds(420))
+            for index in notifications.indices {
+                withAnimation(.spring(response: 0.46, dampingFraction: 0.82)) {
+                    visibleMask[index] = true
+                }
+                try? await Task.sleep(for: .milliseconds(180))
+            }
+        }
+    }
+}
+
+#Preview {
+    OnboardingNotificationsDemoView()
+        .padding(.horizontal, 24)
+}
+
+private struct DemoNotification {
+    let title: String
+    let message: String
+    let minutesAgo: Int
+}

--- a/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/OnboardingQuickLogDemoView.swift
+++ b/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/OnboardingQuickLogDemoView.swift
@@ -3,13 +3,15 @@ import SwiftUI
 
 /// A demo of the Quick Log grid, used on the "Log in seconds" onboarding page.
 ///
-/// Buttons stagger in on appear, then cycle a gentle spotlight highlight so
-/// each event type gets a moment of attention.
+/// Buttons pop in one by one on appear. Each button then cycles through a
+/// zoom-up → wiggle → zoom-down animation when it becomes the active spotlight.
 struct OnboardingQuickLogDemoView: View {
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
 
     @State private var appearedMask: [Bool] = [false, false, false, false]
     @State private var highlightedIndex = 0
+    @State private var wiggleScales: [Double] = [1.0, 1.0, 1.0, 1.0]
+    @State private var rotations: [Double] = [0, 0, 0, 0]
 
     private let buttons: [(title: String, kind: BabyEventKind)] = [
         ("Breast Feed", .breastFeed),
@@ -46,22 +48,23 @@ struct OnboardingQuickLogDemoView: View {
         }
         .task(id: reduceMotion) {
             guard !reduceMotion else { return }
-            // Wait for stagger to finish before cycling starts
-            try? await Task.sleep(for: .milliseconds(900))
+            // Wait for pop-in stagger to finish
+            try? await Task.sleep(for: .milliseconds(1000))
+            // Animate the initial highlighted button
+            animateWiggle(0)
             while !Task.isCancelled {
-                try? await Task.sleep(for: .seconds(2.2))
+                try? await Task.sleep(for: .seconds(2.4))
                 guard !Task.isCancelled else { break }
-                await MainActor.run {
-                    withAnimation(.spring(response: 0.38, dampingFraction: 0.62)) {
-                        highlightedIndex = (highlightedIndex + 1) % buttons.count
-                    }
+                let next = (highlightedIndex + 1) % buttons.count
+                withAnimation(.spring(response: 0.38, dampingFraction: 0.62)) {
+                    highlightedIndex = next
                 }
+                animateWiggle(next)
             }
         }
     }
 
     private func demoButton(index: Int) -> some View {
-        let entry = appearedMask[index]
         let isHighlighted = highlightedIndex == index && appearedMask.allSatisfy({ $0 })
         let item = buttons[index]
 
@@ -79,9 +82,10 @@ struct OnboardingQuickLogDemoView: View {
                         y: isHighlighted ? 4 : 0
                     )
             )
-            .scaleEffect(isHighlighted ? 1.035 : 1.0)
-            .opacity(entry ? 1 : 0)
-            .offset(y: entry ? 0 : 18)
+            .scaleEffect(wiggleScales[index])
+            .rotationEffect(.degrees(rotations[index]))
+            .opacity(appearedMask[index] ? 1 : 0)
+            .offset(y: appearedMask[index] ? 0 : 22)
     }
 
     private func staggerIn() {
@@ -89,11 +93,37 @@ struct OnboardingQuickLogDemoView: View {
             appearedMask = [true, true, true, true]
             return
         }
-
         for index in 0..<buttons.count {
-            let delay = Double(index) * 0.09
-            withAnimation(.spring(response: 0.46, dampingFraction: 0.8).delay(delay)) {
+            let delay = Double(index) * 0.1
+            // Bouncy spring for the "pop" entry feel
+            withAnimation(.spring(response: 0.38, dampingFraction: 0.52).delay(delay)) {
                 appearedMask[index] = true
+            }
+        }
+    }
+
+    /// Plays a zoom-up → wiggle → zoom-down sequence on the button at `index`.
+    private func animateWiggle(_ index: Int) {
+        guard !reduceMotion else { return }
+        // 1. Zoom up
+        withAnimation(.spring(response: 0.22, dampingFraction: 0.55)) {
+            wiggleScales[index] = 1.13
+        }
+        Task { @MainActor in
+            // 2. Short pause so zoom lands before wiggle starts
+            try? await Task.sleep(for: .milliseconds(170))
+            // 3. Wiggle sequence
+            let rotationSteps: [Double] = [9, -9, 7, -7, 4, 0]
+            for rot in rotationSteps {
+                guard !Task.isCancelled else { return }
+                withAnimation(.spring(response: 0.11, dampingFraction: 0.55)) {
+                    rotations[index] = rot
+                }
+                try? await Task.sleep(for: .milliseconds(95))
+            }
+            // 4. Zoom back to normal
+            withAnimation(.spring(response: 0.3, dampingFraction: 0.72)) {
+                wiggleScales[index] = 1.0
             }
         }
     }

--- a/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/OnboardingQuickLogDemoView.swift
+++ b/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/OnboardingQuickLogDemoView.swift
@@ -44,12 +44,20 @@ struct OnboardingQuickLogDemoView: View {
         .padding(.vertical, 12)
         .background(Color(.systemGroupedBackground))
         .onAppear {
-            staggerIn()
+            if reduceMotion {
+                appearedMask = [true, true, true, true]
+                return
+            }
+            // Delay until the page slide-in transition has settled (~420ms spring)
+            Task { @MainActor in
+                try? await Task.sleep(for: .milliseconds(420))
+                staggerIn()
+            }
         }
         .task(id: reduceMotion) {
             guard !reduceMotion else { return }
-            // Wait for pop-in stagger to finish
-            try? await Task.sleep(for: .milliseconds(1000))
+            // Wait for slide-in + full stagger to finish before first wiggle
+            try? await Task.sleep(for: .milliseconds(1350))
             // Animate the initial highlighted button
             animateWiggle(0)
             while !Task.isCancelled {
@@ -89,13 +97,8 @@ struct OnboardingQuickLogDemoView: View {
     }
 
     private func staggerIn() {
-        if reduceMotion {
-            appearedMask = [true, true, true, true]
-            return
-        }
         for index in 0..<buttons.count {
             let delay = Double(index) * 0.1
-            // Bouncy spring for the "pop" entry feel
             withAnimation(.spring(response: 0.38, dampingFraction: 0.52).delay(delay)) {
                 appearedMask[index] = true
             }
@@ -105,24 +108,24 @@ struct OnboardingQuickLogDemoView: View {
     /// Plays a zoom-up → wiggle → zoom-down sequence on the button at `index`.
     private func animateWiggle(_ index: Int) {
         guard !reduceMotion else { return }
-        // 1. Zoom up
-        withAnimation(.spring(response: 0.22, dampingFraction: 0.55)) {
-            wiggleScales[index] = 1.13
+        // 1. Zoom up slightly
+        withAnimation(.spring(response: 0.22, dampingFraction: 0.6)) {
+            wiggleScales[index] = 1.06
         }
         Task { @MainActor in
             // 2. Short pause so zoom lands before wiggle starts
-            try? await Task.sleep(for: .milliseconds(170))
-            // 3. Wiggle sequence
-            let rotationSteps: [Double] = [9, -9, 7, -7, 4, 0]
+            try? await Task.sleep(for: .milliseconds(160))
+            // 3. Gentle wiggle sequence
+            let rotationSteps: [Double] = [4, -4, 3, 0]
             for rot in rotationSteps {
                 guard !Task.isCancelled else { return }
-                withAnimation(.spring(response: 0.11, dampingFraction: 0.55)) {
+                withAnimation(.spring(response: 0.14, dampingFraction: 0.6)) {
                     rotations[index] = rot
                 }
-                try? await Task.sleep(for: .milliseconds(95))
+                try? await Task.sleep(for: .milliseconds(110))
             }
             // 4. Zoom back to normal
-            withAnimation(.spring(response: 0.3, dampingFraction: 0.72)) {
+            withAnimation(.spring(response: 0.3, dampingFraction: 0.75)) {
                 wiggleScales[index] = 1.0
             }
         }

--- a/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/OnboardingQuickLogDemoView.swift
+++ b/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/OnboardingQuickLogDemoView.swift
@@ -1,9 +1,23 @@
 import BabyTrackerDomain
 import SwiftUI
 
-/// A static, non-interactive replica of the Quick Log grid shown on the Home tab.
-/// Used as the demo embed on the "Log in seconds" onboarding page.
+/// A demo of the Quick Log grid, used on the "Log in seconds" onboarding page.
+///
+/// Buttons stagger in on appear, then cycle a gentle spotlight highlight so
+/// each event type gets a moment of attention.
 struct OnboardingQuickLogDemoView: View {
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+
+    @State private var appearedMask: [Bool] = [false, false, false, false]
+    @State private var highlightedIndex = 0
+
+    private let buttons: [(title: String, kind: BabyEventKind)] = [
+        ("Breast Feed", .breastFeed),
+        ("Bottle Feed", .bottleFeed),
+        ("Start Sleep", .sleep),
+        ("Nappy", .nappy),
+    ]
+
     var body: some View {
         VStack(alignment: .leading, spacing: 12) {
             Text("Quick Log")
@@ -12,35 +26,80 @@ struct OnboardingQuickLogDemoView: View {
 
             VStack(spacing: 12) {
                 HStack(spacing: 12) {
-                    demoButton("Breast Feed", kind: .breastFeed)
-                    demoButton("Bottle Feed", kind: .bottleFeed)
+                    demoButton(index: 0)
+                    demoButton(index: 1)
                 }
+                .geometryGroup()
 
                 HStack(spacing: 12) {
-                    demoButton("Start Sleep", kind: .sleep)
-                    demoButton("Nappy", kind: .nappy)
+                    demoButton(index: 2)
+                    demoButton(index: 3)
                 }
+                .geometryGroup()
             }
             .padding(.horizontal, 16)
         }
         .padding(.vertical, 12)
         .background(Color(.systemGroupedBackground))
+        .onAppear {
+            staggerIn()
+        }
+        .task(id: reduceMotion) {
+            guard !reduceMotion else { return }
+            // Wait for stagger to finish before cycling starts
+            try? await Task.sleep(for: .milliseconds(900))
+            while !Task.isCancelled {
+                try? await Task.sleep(for: .seconds(2.2))
+                guard !Task.isCancelled else { break }
+                await MainActor.run {
+                    withAnimation(.spring(response: 0.38, dampingFraction: 0.62)) {
+                        highlightedIndex = (highlightedIndex + 1) % buttons.count
+                    }
+                }
+            }
+        }
     }
 
-    private func demoButton(_ title: String, kind: BabyEventKind) -> some View {
-        Label(title, systemImage: BabyEventStyle.systemImage(for: kind))
+    private func demoButton(index: Int) -> some View {
+        let entry = appearedMask[index]
+        let isHighlighted = highlightedIndex == index && appearedMask.allSatisfy({ $0 })
+        let item = buttons[index]
+
+        return Label(item.title, systemImage: BabyEventStyle.systemImage(for: item.kind))
             .font(.headline)
             .frame(maxWidth: .infinity, minHeight: 56, alignment: .leading)
             .padding(.horizontal, 14)
-            .foregroundStyle(BabyEventStyle.buttonForegroundColor(for: kind))
+            .foregroundStyle(BabyEventStyle.buttonForegroundColor(for: item.kind))
             .background(
                 RoundedRectangle(cornerRadius: 18, style: .continuous)
-                    .fill(BabyEventStyle.buttonFillColor(for: kind))
+                    .fill(BabyEventStyle.buttonFillColor(for: item.kind))
+                    .shadow(
+                        color: BabyEventStyle.buttonFillColor(for: item.kind).opacity(isHighlighted ? 0.55 : 0),
+                        radius: isHighlighted ? 10 : 0,
+                        y: isHighlighted ? 4 : 0
+                    )
             )
+            .scaleEffect(isHighlighted ? 1.035 : 1.0)
+            .opacity(entry ? 1 : 0)
+            .offset(y: entry ? 0 : 18)
+    }
+
+    private func staggerIn() {
+        if reduceMotion {
+            appearedMask = [true, true, true, true]
+            return
+        }
+
+        for index in 0..<buttons.count {
+            let delay = Double(index) * 0.09
+            withAnimation(.spring(response: 0.46, dampingFraction: 0.8).delay(delay)) {
+                appearedMask[index] = true
+            }
+        }
     }
 }
 
 #Preview {
     OnboardingQuickLogDemoView()
-        .frame(width: 320)
+        .frame(width: 360)
 }

--- a/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/OnboardingQuickLogDemoView.swift
+++ b/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/OnboardingQuickLogDemoView.swift
@@ -8,6 +8,7 @@ import SwiftUI
 struct OnboardingQuickLogDemoView: View {
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
 
+    @State private var cardVisible = false
     @State private var appearedMask: [Bool] = [false, false, false, false]
     @State private var highlightedIndex = 0
     @State private var wiggleScales: [Double] = [1.0, 1.0, 1.0, 1.0]
@@ -43,21 +44,31 @@ struct OnboardingQuickLogDemoView: View {
         }
         .padding(.vertical, 12)
         .background(Color(.systemGroupedBackground))
+        .opacity(cardVisible ? 1 : 0)
+        .offset(y: cardVisible ? 0 : 20)
+        .animation(
+            reduceMotion ? nil : .spring(response: 0.5, dampingFraction: 0.8),
+            value: cardVisible
+        )
         .onAppear {
             if reduceMotion {
+                cardVisible = true
                 appearedMask = [true, true, true, true]
                 return
             }
-            // Delay until the page slide-in transition has settled (~420ms spring)
             Task { @MainActor in
+                // Delay until the page slide-in transition has settled (~420ms spring)
                 try? await Task.sleep(for: .milliseconds(420))
+                cardVisible = true
+                // Let the card spring land before the buttons start popping in.
+                try? await Task.sleep(for: .milliseconds(520))
                 staggerIn()
             }
         }
         .task(id: reduceMotion) {
             guard !reduceMotion else { return }
-            // Wait for slide-in + full stagger to finish before first wiggle
-            try? await Task.sleep(for: .milliseconds(1350))
+            // Wait for slide-in, card spring, and full stagger to finish before first wiggle.
+            try? await Task.sleep(for: .milliseconds(1870))
             // Animate the initial highlighted button
             animateWiggle(0)
             while !Task.isCancelled {

--- a/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/OnboardingQuickLogDemoView.swift
+++ b/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/OnboardingQuickLogDemoView.swift
@@ -1,0 +1,46 @@
+import BabyTrackerDomain
+import SwiftUI
+
+/// A static, non-interactive replica of the Quick Log grid shown on the Home tab.
+/// Used as the demo embed on the "Log in seconds" onboarding page.
+struct OnboardingQuickLogDemoView: View {
+    var body: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            Text("Quick Log")
+                .font(.headline)
+                .padding(.horizontal, 16)
+
+            VStack(spacing: 12) {
+                HStack(spacing: 12) {
+                    demoButton("Breast Feed", kind: .breastFeed)
+                    demoButton("Bottle Feed", kind: .bottleFeed)
+                }
+
+                HStack(spacing: 12) {
+                    demoButton("Start Sleep", kind: .sleep)
+                    demoButton("Nappy", kind: .nappy)
+                }
+            }
+            .padding(.horizontal, 16)
+        }
+        .padding(.vertical, 12)
+        .background(Color(.systemGroupedBackground))
+    }
+
+    private func demoButton(_ title: String, kind: BabyEventKind) -> some View {
+        Label(title, systemImage: BabyEventStyle.systemImage(for: kind))
+            .font(.headline)
+            .frame(maxWidth: .infinity, minHeight: 56, alignment: .leading)
+            .padding(.horizontal, 14)
+            .foregroundStyle(BabyEventStyle.buttonForegroundColor(for: kind))
+            .background(
+                RoundedRectangle(cornerRadius: 18, style: .continuous)
+                    .fill(BabyEventStyle.buttonFillColor(for: kind))
+            )
+    }
+}
+
+#Preview {
+    OnboardingQuickLogDemoView()
+        .frame(width: 320)
+}

--- a/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/OnboardingTimelineDemoView.swift
+++ b/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/OnboardingTimelineDemoView.swift
@@ -1,68 +1,232 @@
+import BabyTrackerDomain
 import SwiftUI
 
-/// A scaled, clipped demo of `TimelineWeekView` used on the "See the whole picture"
-/// onboarding page.
+/// Custom mini-timeline demo for the "See the whole picture" onboarding page.
 ///
-/// Slides up and fades in on appear, then breathes gently on a slow loop to suggest
-/// the timeline is alive and filling in.
+/// Five day-columns of event blocks fade in category by category — sleep first,
+/// then feeds, then nappies — so the viewer can see how a full day fills in.
+/// A legend then pops in item by item below the timeline.
 struct OnboardingTimelineDemoView: View {
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
 
-    @State private var appeared = false
-    @State private var breathing = false
-    @State private var blocksRevealed = false
+    @State private var columnsVisible = false
+    @State private var sleepVisible = false
+    @State private var feedsVisible = false
+    @State private var nappiesVisible = false
+    @State private var legendMask: [Bool] = [false, false, false, false]
 
-    private let naturalHeight: CGFloat = 380
+    private let columnHeight: CGFloat = 200
+
+    private let legendItems: [(kind: BabyEventKind, label: String)] = [
+        (.sleep, "Sleep"),
+        (.breastFeed, "Breast Feed"),
+        (.bottleFeed, "Bottle Feed"),
+        (.nappy, "Nappy"),
+    ]
 
     var body: some View {
-        TimelineWeekView(
-            columns: OnboardingDemoDataFactory.timelineStripColumns,
-            selectedDay: .now,
-            showDay: { _ in }
-        )
-        .frame(height: naturalHeight)
-        // Reveal blocks from top to bottom after entry settles
-        .mask(alignment: .top) {
-            Rectangle()
-                .frame(height: blocksRevealed ? naturalHeight : 0)
-                .animation(
-                    reduceMotion ? nil : .easeInOut(duration: 0.9),
-                    value: blocksRevealed
-                )
-        }
-        .scaleEffect(0.75, anchor: .top)
-        .frame(height: naturalHeight * 0.75)
-        .clipped()
-        .clipShape(RoundedRectangle(cornerRadius: 24, style: .continuous))
-        .allowsHitTesting(false)
-        // Gentle breathing after entry
-        .scaleEffect(breathing ? 1.012 : 1.0, anchor: .bottom)
-        .animation(
-            reduceMotion ? nil : .easeInOut(duration: 3.8).repeatForever(autoreverses: true),
-            value: breathing
-        )
-        // Entry slide-up
-        .opacity(appeared ? 1 : 0)
-        .offset(y: appeared ? 0 : 24)
-        .animation(
-            reduceMotion ? nil : .spring(response: 0.52, dampingFraction: 0.82).delay(0.15),
-            value: appeared
-        )
-        .onAppear {
-            if reduceMotion {
-                appeared = true
-                blocksRevealed = true
-                return
+        VStack(spacing: 14) {
+            // Mini timeline
+            HStack(alignment: .top, spacing: 7) {
+                ForEach(0..<5, id: \.self) { col in
+                    timelineColumn(col)
+                }
             }
-            appeared = true
-            // Reveal blocks and start breathing after the entry slide settles
-            Task { @MainActor in
-                try? await Task.sleep(for: .milliseconds(700))
-                blocksRevealed = true
-                breathing = true
+            .opacity(columnsVisible ? 1 : 0)
+            .offset(y: columnsVisible ? 0 : 14)
+            .animation(
+                reduceMotion ? nil : .spring(response: 0.5, dampingFraction: 0.8),
+                value: columnsVisible
+            )
+
+            // Legend
+            LazyVGrid(
+                columns: [GridItem(.flexible()), GridItem(.flexible())],
+                spacing: 8
+            ) {
+                ForEach(Array(legendItems.enumerated()), id: \.offset) { index, item in
+                    legendCell(kind: item.kind, label: item.label, index: index)
+                }
+            }
+            .padding(12)
+            .background(.ultraThinMaterial, in: RoundedRectangle(cornerRadius: 14, style: .continuous))
+        }
+        .onAppear {
+            animate()
+        }
+    }
+
+    // MARK: - Column
+
+    private func timelineColumn(_ column: Int) -> some View {
+        ZStack(alignment: .top) {
+            RoundedRectangle(cornerRadius: 5, style: .continuous)
+                .fill(Color(.quaternaryLabel).opacity(0.18))
+
+            ForEach(blocks(for: column)) { block in
+                RoundedRectangle(cornerRadius: 3, style: .continuous)
+                    .fill(BabyEventStyle.timelineFillColor(for: block.kind))
+                    .frame(height: max(5, CGFloat(block.end - block.start) * columnHeight))
+                    .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
+                    .offset(y: CGFloat(block.start) * columnHeight)
+                    .opacity(blockOpacity(for: block.kind))
+            }
+        }
+        .frame(maxWidth: .infinity)
+        .frame(height: columnHeight)
+        .clipShape(RoundedRectangle(cornerRadius: 5, style: .continuous))
+    }
+
+    private func blockOpacity(for kind: BabyEventKind) -> Double {
+        switch kind {
+        case .sleep:                    return sleepVisible   ? 1 : 0
+        case .breastFeed, .bottleFeed:  return feedsVisible   ? 1 : 0
+        case .nappy:                    return nappiesVisible ? 1 : 0
+        default:                        return 0
+        }
+    }
+
+    // MARK: - Legend cell
+
+    private func legendCell(kind: BabyEventKind, label: String, index: Int) -> some View {
+        HStack(spacing: 8) {
+            RoundedRectangle(cornerRadius: 4, style: .continuous)
+                .fill(BabyEventStyle.timelineFillColor(for: kind))
+                .frame(width: 26, height: 12)
+            Text(label)
+                .font(.caption.weight(.medium))
+                .foregroundStyle(.secondary)
+            Spacer(minLength: 0)
+        }
+        .opacity(legendMask[index] ? 1 : 0)
+        .offset(y: legendMask[index] ? 0 : 6)
+    }
+
+    // MARK: - Animation
+
+    private func animate() {
+        if reduceMotion {
+            columnsVisible = true
+            sleepVisible = true
+            feedsVisible = true
+            nappiesVisible = true
+            legendMask = [true, true, true, true]
+            return
+        }
+        Task { @MainActor in
+            // Wait for the page slide-in transition to land
+            try? await Task.sleep(for: .milliseconds(420))
+            withAnimation(.spring(response: 0.5, dampingFraction: 0.8)) {
+                columnsVisible = true
+            }
+            // Sleep blocks — most prominent, reveal first
+            try? await Task.sleep(for: .milliseconds(400))
+            withAnimation(.easeInOut(duration: 0.55)) { sleepVisible = true }
+            // Feed blocks
+            try? await Task.sleep(for: .milliseconds(700))
+            withAnimation(.easeInOut(duration: 0.55)) { feedsVisible = true }
+            // Nappy blocks
+            try? await Task.sleep(for: .milliseconds(600))
+            withAnimation(.easeInOut(duration: 0.55)) { nappiesVisible = true }
+            // Legend items stagger in
+            for i in 0..<legendItems.count {
+                try? await Task.sleep(for: .milliseconds(160))
+                withAnimation(.spring(response: 0.42, dampingFraction: 0.7)) {
+                    legendMask[i] = true
+                }
             }
         }
     }
+
+    // MARK: - Sample data
+
+    private struct Block: Identifiable {
+        let id: Int
+        let start: Double
+        let end: Double
+        let kind: BabyEventKind
+    }
+
+    private func blocks(for column: Int) -> [Block] {
+        Self.sampleData
+            .enumerated()
+            .compactMap { index, entry in
+                guard entry.column == column else { return nil }
+                return Block(id: index, start: entry.start, end: entry.end, kind: entry.kind)
+            }
+    }
+
+    private struct SampleEntry {
+        let column: Int
+        let start: Double
+        let end: Double
+        let kind: BabyEventKind
+    }
+
+    // start/end expressed as a fraction of the 24-hour day (0.0 = midnight, 1.0 = next midnight).
+    // Five columns represent five days with slight timing variation so the pattern looks natural.
+    private static let sampleData: [SampleEntry] = {
+        func s(_ col: Int, _ start: Double, _ end: Double, _ kind: BabyEventKind) -> SampleEntry {
+            SampleEntry(column: col, start: start, end: end, kind: kind)
+        }
+        return [
+            // ── Night sleeps (midnight to ~5am) ──────────────────────
+            s(0, 0.00, 0.21, .sleep), s(1, 0.00, 0.19, .sleep), s(2, 0.00, 0.22, .sleep),
+            s(3, 0.00, 0.20, .sleep), s(4, 0.00, 0.18, .sleep),
+
+            // ── Morning naps (~9–10am) ────────────────────────────────
+            s(0, 0.38, 0.44, .sleep), s(1, 0.37, 0.42, .sleep), s(2, 0.39, 0.45, .sleep),
+            s(3, 0.38, 0.43, .sleep), s(4, 0.36, 0.42, .sleep),
+
+            // ── Afternoon naps (~1–2:30pm) ────────────────────────────
+            s(0, 0.54, 0.61, .sleep), s(1, 0.55, 0.62, .sleep), s(2, 0.53, 0.60, .sleep),
+            s(3, 0.54, 0.61, .sleep), s(4, 0.55, 0.63, .sleep),
+
+            // ── Bedtime sleeps (~7:45pm onwards) ─────────────────────
+            s(0, 0.82, 1.00, .sleep), s(1, 0.83, 1.00, .sleep), s(2, 0.81, 1.00, .sleep),
+            s(3, 0.82, 1.00, .sleep), s(4, 0.84, 1.00, .sleep),
+
+            // ── Morning feeds (~6am) ──────────────────────────────────
+            s(0, 0.25, 0.29, .bottleFeed),  s(1, 0.24, 0.28, .breastFeed),
+            s(2, 0.26, 0.30, .bottleFeed),  s(3, 0.25, 0.29, .breastFeed),
+            s(4, 0.24, 0.28, .bottleFeed),
+
+            // ── Mid-day feeds (~10:30am) ──────────────────────────────
+            s(0, 0.45, 0.49, .breastFeed),  s(1, 0.44, 0.48, .bottleFeed),
+            s(2, 0.46, 0.50, .breastFeed),  s(3, 0.44, 0.48, .bottleFeed),
+            s(4, 0.43, 0.47, .breastFeed),
+
+            // ── Afternoon feeds (~2:30pm) ─────────────────────────────
+            s(0, 0.62, 0.66, .bottleFeed),  s(1, 0.63, 0.67, .breastFeed),
+            s(2, 0.61, 0.65, .bottleFeed),  s(3, 0.62, 0.66, .breastFeed),
+            s(4, 0.64, 0.68, .bottleFeed),
+
+            // ── Evening feeds (~5:30pm) ───────────────────────────────
+            s(0, 0.72, 0.76, .breastFeed),  s(1, 0.71, 0.75, .bottleFeed),
+            s(2, 0.73, 0.77, .breastFeed),  s(3, 0.72, 0.76, .bottleFeed),
+            s(4, 0.71, 0.75, .breastFeed),
+
+            // ── Morning nappies (~7:15am) ─────────────────────────────
+            s(0, 0.30, 0.312, .nappy), s(1, 0.29, 0.302, .nappy),
+            s(2, 0.31, 0.322, .nappy), s(3, 0.30, 0.312, .nappy),
+            s(4, 0.29, 0.302, .nappy),
+
+            // ── Mid-day nappies (~11:45am) ────────────────────────────
+            s(0, 0.49, 0.502, .nappy), s(1, 0.48, 0.492, .nappy),
+            s(2, 0.50, 0.512, .nappy), s(3, 0.49, 0.502, .nappy),
+            s(4, 0.48, 0.492, .nappy),
+
+            // ── Afternoon nappies (~3:30pm) ───────────────────────────
+            s(0, 0.66, 0.672, .nappy), s(1, 0.67, 0.682, .nappy),
+            s(2, 0.65, 0.662, .nappy), s(3, 0.66, 0.672, .nappy),
+            s(4, 0.68, 0.692, .nappy),
+
+            // ── Evening nappies (~6pm) ────────────────────────────────
+            s(0, 0.76, 0.772, .nappy), s(1, 0.75, 0.762, .nappy),
+            s(2, 0.77, 0.782, .nappy), s(3, 0.76, 0.772, .nappy),
+            s(4, 0.75, 0.762, .nappy),
+        ]
+    }()
 }
 
 #Preview {

--- a/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/OnboardingTimelineDemoView.swift
+++ b/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/OnboardingTimelineDemoView.swift
@@ -10,6 +10,7 @@ struct OnboardingTimelineDemoView: View {
 
     @State private var appeared = false
     @State private var breathing = false
+    @State private var blocksRevealed = false
 
     private let naturalHeight: CGFloat = 380
 
@@ -20,6 +21,15 @@ struct OnboardingTimelineDemoView: View {
             showDay: { _ in }
         )
         .frame(height: naturalHeight)
+        // Reveal blocks from top to bottom after entry settles
+        .mask(alignment: .top) {
+            Rectangle()
+                .frame(height: blocksRevealed ? naturalHeight : 0)
+                .animation(
+                    reduceMotion ? nil : .easeInOut(duration: 0.9),
+                    value: blocksRevealed
+                )
+        }
         .scaleEffect(0.75, anchor: .top)
         .frame(height: naturalHeight * 0.75)
         .clipped()
@@ -41,12 +51,14 @@ struct OnboardingTimelineDemoView: View {
         .onAppear {
             if reduceMotion {
                 appeared = true
+                blocksRevealed = true
                 return
             }
             appeared = true
-            // Start breathing after the entry settles
+            // Reveal blocks and start breathing after the entry slide settles
             Task { @MainActor in
                 try? await Task.sleep(for: .milliseconds(700))
+                blocksRevealed = true
                 breathing = true
             }
         }

--- a/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/OnboardingTimelineDemoView.swift
+++ b/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/OnboardingTimelineDemoView.swift
@@ -1,0 +1,26 @@
+import SwiftUI
+
+/// A scaled, clipped, non-interactive embed of `TimelineWeekView` using static demo data.
+/// Used as the demo embed on the "See the whole picture" onboarding page.
+struct OnboardingTimelineDemoView: View {
+    private let naturalHeight: CGFloat = 380
+
+    var body: some View {
+        TimelineWeekView(
+            columns: OnboardingDemoDataFactory.timelineStripColumns,
+            selectedDay: .now,
+            showDay: { _ in }
+        )
+        .frame(height: naturalHeight)
+        .scaleEffect(0.75, anchor: .top)
+        .frame(height: naturalHeight * 0.75)
+        .clipped()
+        .clipShape(RoundedRectangle(cornerRadius: 24, style: .continuous))
+        .allowsHitTesting(false)
+    }
+}
+
+#Preview {
+    OnboardingTimelineDemoView()
+        .padding(.horizontal, 24)
+}

--- a/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/OnboardingTimelineDemoView.swift
+++ b/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/OnboardingTimelineDemoView.swift
@@ -1,8 +1,16 @@
 import SwiftUI
 
-/// A scaled, clipped, non-interactive embed of `TimelineWeekView` using static demo data.
-/// Used as the demo embed on the "See the whole picture" onboarding page.
+/// A scaled, clipped demo of `TimelineWeekView` used on the "See the whole picture"
+/// onboarding page.
+///
+/// Slides up and fades in on appear, then breathes gently on a slow loop to suggest
+/// the timeline is alive and filling in.
 struct OnboardingTimelineDemoView: View {
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+
+    @State private var appeared = false
+    @State private var breathing = false
+
     private let naturalHeight: CGFloat = 380
 
     var body: some View {
@@ -17,6 +25,31 @@ struct OnboardingTimelineDemoView: View {
         .clipped()
         .clipShape(RoundedRectangle(cornerRadius: 24, style: .continuous))
         .allowsHitTesting(false)
+        // Gentle breathing after entry
+        .scaleEffect(breathing ? 1.012 : 1.0, anchor: .bottom)
+        .animation(
+            reduceMotion ? nil : .easeInOut(duration: 3.8).repeatForever(autoreverses: true),
+            value: breathing
+        )
+        // Entry slide-up
+        .opacity(appeared ? 1 : 0)
+        .offset(y: appeared ? 0 : 24)
+        .animation(
+            reduceMotion ? nil : .spring(response: 0.52, dampingFraction: 0.82).delay(0.15),
+            value: appeared
+        )
+        .onAppear {
+            if reduceMotion {
+                appeared = true
+                return
+            }
+            appeared = true
+            // Start breathing after the entry settles
+            Task { @MainActor in
+                try? await Task.sleep(for: .milliseconds(700))
+                breathing = true
+            }
+        }
     }
 }
 

--- a/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/OnboardingTimelineDemoView.swift
+++ b/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/OnboardingTimelineDemoView.swift
@@ -13,6 +13,9 @@ struct OnboardingTimelineDemoView: View {
     @State private var sleepVisible = false
     @State private var feedsVisible = false
     @State private var nappiesVisible = false
+    @State private var sleepOffset: CGFloat = 14
+    @State private var feedsOffset: CGFloat = 14
+    @State private var nappiesOffset: CGFloat = 14
     @State private var legendMask: [Bool] = [false, false, false, false]
 
     private let columnHeight: CGFloat = 200
@@ -68,7 +71,7 @@ struct OnboardingTimelineDemoView: View {
                     .fill(BabyEventStyle.timelineFillColor(for: block.kind))
                     .frame(height: max(5, CGFloat(block.end - block.start) * columnHeight))
                     .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
-                    .offset(y: CGFloat(block.start) * columnHeight)
+                    .offset(y: CGFloat(block.start) * columnHeight + blockOffset(for: block.kind))
                     .opacity(blockOpacity(for: block.kind))
             }
         }
@@ -82,6 +85,15 @@ struct OnboardingTimelineDemoView: View {
         case .sleep:                    return sleepVisible   ? 1 : 0
         case .breastFeed, .bottleFeed:  return feedsVisible   ? 1 : 0
         case .nappy:                    return nappiesVisible ? 1 : 0
+        default:                        return 0
+        }
+    }
+
+    private func blockOffset(for kind: BabyEventKind) -> CGFloat {
+        switch kind {
+        case .sleep:                    return sleepOffset
+        case .breastFeed, .bottleFeed:  return feedsOffset
+        case .nappy:                    return nappiesOffset
         default:                        return 0
         }
     }
@@ -110,6 +122,9 @@ struct OnboardingTimelineDemoView: View {
             sleepVisible = true
             feedsVisible = true
             nappiesVisible = true
+            sleepOffset = 0
+            feedsOffset = 0
+            nappiesOffset = 0
             legendMask = [true, true, true, true]
             return
         }
@@ -121,13 +136,22 @@ struct OnboardingTimelineDemoView: View {
             }
             // Sleep blocks — most prominent, reveal first
             try? await Task.sleep(for: .milliseconds(400))
-            withAnimation(.easeInOut(duration: 0.55)) { sleepVisible = true }
+            withAnimation(.easeInOut(duration: 0.55)) {
+                sleepVisible = true
+                sleepOffset = 0
+            }
             // Feed blocks
             try? await Task.sleep(for: .milliseconds(700))
-            withAnimation(.easeInOut(duration: 0.55)) { feedsVisible = true }
+            withAnimation(.easeInOut(duration: 0.55)) {
+                feedsVisible = true
+                feedsOffset = 0
+            }
             // Nappy blocks
             try? await Task.sleep(for: .milliseconds(600))
-            withAnimation(.easeInOut(duration: 0.55)) { nappiesVisible = true }
+            withAnimation(.easeInOut(duration: 0.55)) {
+                nappiesVisible = true
+                nappiesOffset = 0
+            }
             // Legend items stagger in
             for i in 0..<legendItems.count {
                 try? await Task.sleep(for: .milliseconds(160))

--- a/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/OnboardingTimelineDemoView.swift
+++ b/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/OnboardingTimelineDemoView.swift
@@ -26,13 +26,25 @@ struct OnboardingTimelineDemoView: View {
         (.bottleFeed, "Bottle Feed"),
         (.nappy, "Nappy"),
     ]
+    private let weekdayLabels = ["M", "T", "W", "T", "F"]
 
     var body: some View {
         VStack(spacing: 14) {
-            // Mini timeline
-            HStack(alignment: .top, spacing: 7) {
-                ForEach(0..<5, id: \.self) { col in
-                    timelineColumn(col)
+            VStack(spacing: 8) {
+                // Mini timeline
+                HStack(alignment: .top, spacing: 7) {
+                    ForEach(0..<5, id: \.self) { col in
+                        timelineColumn(col)
+                    }
+                }
+
+                HStack(spacing: 7) {
+                    ForEach(Array(weekdayLabels.enumerated()), id: \.offset) { _, label in
+                        Text(label)
+                            .font(.caption2.weight(.semibold))
+                            .foregroundStyle(.secondary)
+                            .frame(maxWidth: .infinity)
+                    }
                 }
             }
             .opacity(columnsVisible ? 1 : 0)
@@ -152,6 +164,7 @@ struct OnboardingTimelineDemoView: View {
                 nappiesVisible = true
                 nappiesOffset = 0
             }
+            try? await Task.sleep(for: .milliseconds(820))
             // Legend items stagger in
             for i in 0..<legendItems.count {
                 try? await Task.sleep(for: .milliseconds(160))

--- a/docs/plans/081-interactive-onboarding.md
+++ b/docs/plans/081-interactive-onboarding.md
@@ -1,0 +1,70 @@
+# 080 — Interactive Onboarding Experience
+
+## Goal
+
+Replace the static 4-page intro onboarding with a rich, interactive multi-step experience that:
+- Showcases the app's core features through inline demo views
+- Integrates baby setup directly into the onboarding
+- Guides the user through logging their first real event
+- Shows what the app looks like with live data before entering the main UI
+
+## Problem
+
+The existing `IdentityOnboardingView` shows 4 static, text-only intro pages followed by a caregiver name entry. After completing it, users land on a separate "no children" screen to add their baby. There is no guided first-event logging, no feature demos with real data, and no sense of what the app looks like populated.
+
+## Approach
+
+A new `InteractiveOnboardingView` is presented as a `fullScreenCover` from `AppRootView` whenever `model.isInteractiveOnboardingActive` is true. Using a full-screen cover rather than a route-based view means the onboarding survives the route changes that occur when `createLocalUser` and `createChild` are called mid-flow (which would otherwise transition the route away from `.identityOnboarding`).
+
+`AppModel.refresh()` sets `isInteractiveOnboardingActive = true` the first time it finds no local user, triggering the interactive onboarding on first launch. The replay-from-settings path (`showOnboarding()` from Profile) is unaffected — it sets `route = .identityOnboarding` with a local user already present, so `isInteractiveOnboardingActive` is never set and `IdentityOnboardingView` shows as before.
+
+### 8-step flow
+
+| Step | Name | What it shows |
+|------|------|---------------|
+| 0 | Welcome | Existing `OnboardingIntroStepView` with the pain-points page |
+| 1 | Quick Log Demo | `OnboardingQuickLogDemoView` — static replica of the 4 quick-log buttons |
+| 2 | Timeline Demo | `OnboardingTimelineDemoView` — scaled `TimelineWeekView` with demo data |
+| 3 | Charts Demo | `OnboardingChartsDemoView` — scaled `SummaryScreenView` with preview data |
+| 4 | Caregiver Name | `IdentityOnboardingNameStepView` (reused unchanged) |
+| 5 | Baby Setup | `OnboardingAddBabyStepView` — name + optional birthdate form |
+| 6 | First Event | `OnboardingFirstEventStepView` — real interactive quick-log buttons + editor sheets |
+| 7 | App Preview | `OnboardingAppPreviewStepView` — non-interactive `ChildHomeView` with live data |
+
+Steps 0–3 have a "Skip" button in the top bar that jumps to step 4 (caregiver name). Steps 5, 6 have a "Skip for now" link in the footer that exits the onboarding. Step 7 has "Let's Go" which dismisses the cover.
+
+At step 4, `model.createLocalUser()` is called — route changes to `.noChildren` but the full-screen cover stays visible.
+At step 5, `model.createChild()` is called — route changes to `.childProfile`.
+At step 6, the real event editors are presented and events are saved to the live database.
+At step 7, the real `ChildHomeView` renders with the just-logged event visible.
+
+Demo views use static data from `OnboardingDemoDataFactory` (timeline) and `SummaryScreenPreviewFactory` (charts). All demo views have `allowsHitTesting(false)`.
+
+## Files changed
+
+**New files (all in `Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/`):**
+- `Views/InteractiveOnboardingView.swift` — root container
+- `Views/OnboardingAddBabyStepView.swift` — step 5 baby form
+- `Views/OnboardingFirstEventStepView.swift` — step 6 first event logging
+- `Views/OnboardingAppPreviewStepView.swift` — step 7 live Home screen embed
+- `Views/OnboardingQuickLogDemoView.swift` — step 1 Quick Log demo
+- `Views/OnboardingTimelineDemoView.swift` — step 2 Timeline demo
+- `Views/OnboardingChartsDemoView.swift` — step 3 Charts demo
+- `OnboardingDemoDataFactory.swift` — static demo data factory
+
+**Modified files:**
+- `AppModel.swift` — added `isInteractiveOnboardingActive` property; set it in `refresh()` when `localUser == nil`
+- `Baby Tracker/App/AppRootView.swift` — added `fullScreenCover` driven by `isInteractiveOnboardingActive`
+
+**Unchanged:**
+- `IdentityOnboardingView.swift` — still used for settings replay path, no changes
+
+## Verification
+
+1. **First launch:** Delete app data / fresh install → interactive onboarding shows, all 8 steps work end-to-end, "Let's Go" lands on Home tab with logged event visible.
+2. **Skip paths:** Skip on steps 0–3 jumps to name entry. "Skip for now" on step 5 lands on noChildren screen. "Skip for now" on step 6 lands on Home tab.
+3. **Settings replay:** Profile → Replay Onboarding → legacy 4-page static flow shows.
+4. **Second child:** Add second child from Profile → noChildren → ChildCreationView path unaffected.
+5. **Tests pass:** `xcodebuild test` succeeds.
+
+- [x] Complete

--- a/docs/plans/082-onboarding-demo-animation-polish.md
+++ b/docs/plans/082-onboarding-demo-animation-polish.md
@@ -1,0 +1,30 @@
+# 082 — Onboarding Demo Animation Polish
+
+## Goal
+
+Tighten the onboarding demo pacing so each screen reads more clearly:
+- add weekday x-axis labels to the timeline demo
+- delay the timeline legend until the block animation fully finishes
+- overlap the second chart draw with the first chart draw
+- animate the Quick Log card in before its buttons pop in
+
+## Approach
+
+1. Update `OnboardingTimelineDemoView` to render weekday labels (`M T W T F`) under the five columns and treat that label row as part of the chart presentation.
+2. Adjust the timeline animation sequence so the legend begins only after the last block animation has completed, with a small extra pause before the stagger starts.
+3. Update `OnboardingChartsDemoView` so the bottle chart starts drawing halfway through the sleep chart animation instead of waiting for the first line to finish.
+4. Update `OnboardingQuickLogDemoView` so the full Quick Log card enters with the same card spring used on the charts page, then start the button stagger only after the card has settled.
+
+## Notes
+
+- This is a focused polish pass only; no onboarding flow logic changes are intended.
+- Existing previews remain sufficient because these changes only adjust presentation and animation timing.
+
+## Verification
+
+1. Open onboarding step "Log in seconds" and confirm the card slides/fades in before the four buttons start popping in.
+2. Open onboarding step "See the whole picture" and confirm weekday labels appear under the five columns.
+3. Confirm the timeline legend does not begin animating until the last timeline blocks have fully finished animating.
+4. Open onboarding step "Spot the patterns" and confirm the second chart line starts drawing while the first chart line is still animating.
+
+- [x] Complete

--- a/docs/plans/083-live-activity-onboarding-step.md
+++ b/docs/plans/083-live-activity-onboarding-step.md
@@ -1,0 +1,29 @@
+# 083 — Live Activity Onboarding Step
+
+## Goal
+
+Add a new onboarding page between "Spot the patterns" and profile setup that showcases the lock-screen Live Activity with ticking demo data.
+
+GitHub issue: #196
+
+## Approach
+
+1. Insert a new demo step into `InteractiveOnboardingView` after the charts page and before caregiver setup.
+2. Add a dedicated `OnboardingLiveActivityDemoView` inside `BabyTrackerFeature` so the onboarding can present the Live Activity without depending on the widget target.
+3. Use the shared `BabyTrackerLiveActivities` package for the dummy content-state model, but keep the visual rendering local to the feature package to preserve package boundaries.
+4. Present the demo inside a stylized iPhone frame with the lock-screen content anchored low on the screen and a fade mask over the top third so the eye stays on the Live Activity.
+5. Update onboarding previews and page-indicator counts to reflect the extra demo page.
+
+## Notes
+
+- Apple’s design resources provide official product bezels, but their marketing guidelines also limit modification and cropping of those images. For the in-app onboarding demo, use Apple’s public resources as visual reference only and render a simple SwiftUI device shell locally.
+
+## Verification
+
+1. The new Live Activity page appears after "Spot the patterns" and before caregiver name entry.
+2. The demo shows a partial device frame with the Live Activity near the bottom and a faded top section.
+3. Timer text in the demo updates live while the page is visible.
+4. Skip behavior still jumps from any demo page to caregiver setup.
+5. Onboarding previews still line up with the correct steps.
+
+- [x] Complete

--- a/docs/plans/084-notification-onboarding-step.md
+++ b/docs/plans/084-notification-onboarding-step.md
@@ -1,0 +1,31 @@
+# 084 — Notification Onboarding Step
+
+## Goal
+
+Add a dedicated onboarding page after the Live Activity demo that previews Nest notifications and requests push permission from that screen.
+
+GitHub issue: #197
+
+## Approach
+
+1. Insert a new onboarding step after the Live Activity page and before caregiver setup.
+2. Add `OnboardingNotificationsDemoView` with three staged notification cards that resemble iOS notifications and animate in sequentially.
+3. Move notification permission prompting off the caregiver-name submit path and onto the new page's Continue action.
+4. If permission is already granted, continue immediately. If it is not granted, show a pre-prompt alert and only call the native notification request after confirmation.
+5. Update previews and onboarding page-indicator counts to match the extra intro step.
+
+## Notes
+
+- The notification cards should read like realistic examples from Nest, but stay clearly demo data.
+- If the user declines the pre-prompt alert, continue onboarding without blocking setup.
+
+## Verification
+
+1. The notifications page appears after the Live Activity page.
+2. Three notification cards animate in one after another.
+3. Tapping Continue on that page advances immediately when notifications are already authorized.
+4. Tapping Continue when notifications are not authorized shows a pre-prompt alert first.
+5. Confirming the alert triggers the native request and then advances.
+6. Declining the alert continues onboarding without requesting permission.
+
+- [x] Complete


### PR DESCRIPTION
Replaces the static 4-page intro with an 8-step interactive onboarding.
New users see inline demos of the Quick Log grid, Timeline, and Summary
charts, then set up their caregiver profile and baby, log their first
real event, and land on a live Home screen before entering the main app.

- InteractiveOnboardingView presented as a fullScreenCover so it
  survives the route changes that occur when createLocalUser and
  createChild are called mid-flow
- AppModel.isInteractiveOnboardingActive flag drives the cover; set
  automatically on first launch (localUser == nil) in refresh()
- OnboardingDemoDataFactory provides static timeline strip columns and
  reuses SummaryScreenPreviewFactory for chart demo data
- Demo views (QuickLog, Timeline, Charts) are scaled, clipped, and
  allowsHitTesting(false) — faithful replicas of the real views
- First-event step uses the real editor sheets and saves to the
  live database so the App Preview step renders actual logged data
- Replay-from-settings path (IdentityOnboardingView) unchanged

Closes plan docs/plans/081-interactive-onboarding.md

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>