### PR TITLE
Cache live activity snapshot in UserDefaults to skip redundant updates

### DIFF
--- a/Baby Tracker/App/AppContainer.swift
+++ b/Baby Tracker/App/AppContainer.swift
@@ -41,7 +41,10 @@ struct AppContainer {
             LiveCloudKitClient()
         let liveActivityManager: any FeedLiveActivityManaging = launchConfiguration.usesNoOpLiveActivities ?
             NoOpFeedLiveActivityManager() :
-            FeedLiveActivityManager(userDefaults: userDefaults)
+            FeedLiveActivityManager()
+        let liveActivitySnapshotCache: any FeedLiveActivitySnapshotCaching = launchConfiguration.usesNoOpLiveActivities ?
+            InMemoryFeedLiveActivitySnapshotCache() :
+            UserDefaultsFeedLiveActivitySnapshotCache(userDefaults: userDefaults)
         let localNotificationManager: any LocalNotificationManaging = launchConfiguration.usesUnavailableCloudKitClient ?
             NoOpLocalNotificationManager() :
             SystemLocalNotificationManager()
@@ -64,6 +67,7 @@ struct AppContainer {
             eventRepository: eventRepository,
             syncEngine: syncEngine,
             liveActivityManager: liveActivityManager,
+            liveActivitySnapshotCache: liveActivitySnapshotCache,
             liveActivityPreferenceStore: liveActivityPreferenceStore,
             localNotificationManager: localNotificationManager,
             hapticFeedbackProvider: hapticFeedbackProvider,

--- a/Baby Tracker/App/AppContainer.swift
+++ b/Baby Tracker/App/AppContainer.swift
@@ -41,7 +41,7 @@ struct AppContainer {
             LiveCloudKitClient()
         let liveActivityManager: any FeedLiveActivityManaging = launchConfiguration.usesNoOpLiveActivities ?
             NoOpFeedLiveActivityManager() :
-            FeedLiveActivityManager()
+            FeedLiveActivityManager(userDefaults: userDefaults)
         let localNotificationManager: any LocalNotificationManaging = launchConfiguration.usesUnavailableCloudKitClient ?
             NoOpLocalNotificationManager() :
             SystemLocalNotificationManager()

--- a/Baby Tracker/App/FeedLiveActivityManager.swift
+++ b/Baby Tracker/App/FeedLiveActivityManager.swift
@@ -7,6 +7,28 @@ import Foundation
 final class FeedLiveActivityManager: FeedLiveActivityManaging {
     private var activeActivityID: String?
     private var synchronizationTask: Task<Void, Never>?
+    private let userDefaults: UserDefaults
+
+    private enum CacheKey {
+        static let lastSnapshot = "liveActivity.lastSnapshot"
+    }
+
+    init(userDefaults: UserDefaults = .standard) {
+        self.userDefaults = userDefaults
+    }
+
+    private func loadCachedSnapshot() -> FeedLiveActivitySnapshot? {
+        guard let data = userDefaults.data(forKey: CacheKey.lastSnapshot) else { return nil }
+        return try? JSONDecoder().decode(FeedLiveActivitySnapshot.self, from: data)
+    }
+
+    private func cacheSnapshot(_ snapshot: FeedLiveActivitySnapshot) {
+        userDefaults.set(try? JSONEncoder().encode(snapshot), forKey: CacheKey.lastSnapshot)
+    }
+
+    private func clearCache() {
+        userDefaults.removeObject(forKey: CacheKey.lastSnapshot)
+    }
 
     func synchronize(with snapshot: FeedLiveActivitySnapshot?) {
         synchronizationTask?.cancel()
@@ -20,6 +42,7 @@ final class FeedLiveActivityManager: FeedLiveActivityManaging {
 
         guard let snapshot else {
             await Self.endAllActivities()
+            clearCache()
             activeActivityID = nil
             return
         }
@@ -36,6 +59,10 @@ final class FeedLiveActivityManager: FeedLiveActivityManaging {
         }
 
         if let activeActivityID {
+            if snapshot == loadCachedSnapshot() {
+                return
+            }
+
             let didUpdate = await Self.updateActivity(
                 withID: activeActivityID,
                 content: content(for: snapshot)
@@ -44,6 +71,7 @@ final class FeedLiveActivityManager: FeedLiveActivityManaging {
             guard !Task.isCancelled else { return }
 
             if didUpdate {
+                cacheSnapshot(snapshot)
                 return
             }
 
@@ -59,6 +87,7 @@ final class FeedLiveActivityManager: FeedLiveActivityManaging {
                 pushType: nil
             )
             activeActivityID = activity.id
+            cacheSnapshot(snapshot)
         } catch {
             activeActivityID = nil
         }

--- a/Baby Tracker/App/FeedLiveActivityManager.swift
+++ b/Baby Tracker/App/FeedLiveActivityManager.swift
@@ -7,28 +7,6 @@ import Foundation
 final class FeedLiveActivityManager: FeedLiveActivityManaging {
     private var activeActivityID: String?
     private var synchronizationTask: Task<Void, Never>?
-    private let userDefaults: UserDefaults
-
-    private enum CacheKey {
-        static let lastSnapshot = "liveActivity.lastSnapshot"
-    }
-
-    init(userDefaults: UserDefaults = .standard) {
-        self.userDefaults = userDefaults
-    }
-
-    private func loadCachedSnapshot() -> FeedLiveActivitySnapshot? {
-        guard let data = userDefaults.data(forKey: CacheKey.lastSnapshot) else { return nil }
-        return try? JSONDecoder().decode(FeedLiveActivitySnapshot.self, from: data)
-    }
-
-    private func cacheSnapshot(_ snapshot: FeedLiveActivitySnapshot) {
-        userDefaults.set(try? JSONEncoder().encode(snapshot), forKey: CacheKey.lastSnapshot)
-    }
-
-    private func clearCache() {
-        userDefaults.removeObject(forKey: CacheKey.lastSnapshot)
-    }
 
     func synchronize(with snapshot: FeedLiveActivitySnapshot?) {
         synchronizationTask?.cancel()
@@ -42,7 +20,6 @@ final class FeedLiveActivityManager: FeedLiveActivityManaging {
 
         guard let snapshot else {
             await Self.endAllActivities()
-            clearCache()
             activeActivityID = nil
             return
         }
@@ -59,10 +36,6 @@ final class FeedLiveActivityManager: FeedLiveActivityManaging {
         }
 
         if let activeActivityID {
-            if snapshot == loadCachedSnapshot() {
-                return
-            }
-
             let didUpdate = await Self.updateActivity(
                 withID: activeActivityID,
                 content: content(for: snapshot)
@@ -71,7 +44,6 @@ final class FeedLiveActivityManager: FeedLiveActivityManaging {
             guard !Task.isCancelled else { return }
 
             if didUpdate {
-                cacheSnapshot(snapshot)
                 return
             }
 
@@ -87,7 +59,6 @@ final class FeedLiveActivityManager: FeedLiveActivityManaging {
                 pushType: nil
             )
             activeActivityID = activity.id
-            cacheSnapshot(snapshot)
         } catch {
             activeActivityID = nil
         }

--- a/Baby Tracker/App/UserDefaultsFeedLiveActivitySnapshotCache.swift
+++ b/Baby Tracker/App/UserDefaultsFeedLiveActivitySnapshotCache.swift
@@ -1,0 +1,28 @@
+import BabyTrackerFeature
+import Foundation
+
+@MainActor
+final class UserDefaultsFeedLiveActivitySnapshotCache: FeedLiveActivitySnapshotCaching {
+    private enum Key {
+        static let snapshot = "liveActivity.lastSnapshot"
+    }
+
+    private let userDefaults: UserDefaults
+
+    init(userDefaults: UserDefaults = .standard) {
+        self.userDefaults = userDefaults
+    }
+
+    func load() -> FeedLiveActivitySnapshot? {
+        guard let data = userDefaults.data(forKey: Key.snapshot) else { return nil }
+        return try? JSONDecoder().decode(FeedLiveActivitySnapshot.self, from: data)
+    }
+
+    func save(_ snapshot: FeedLiveActivitySnapshot?) {
+        if let snapshot {
+            userDefaults.set(try? JSONEncoder().encode(snapshot), forKey: Key.snapshot)
+        } else {
+            userDefaults.removeObject(forKey: Key.snapshot)
+        }
+    }
+}

--- a/Baby TrackerTests/UpdateFeedLiveActivityUseCaseTests.swift
+++ b/Baby TrackerTests/UpdateFeedLiveActivityUseCaseTests.swift
@@ -15,7 +15,8 @@ struct UpdateFeedLiveActivityUseCaseTests {
             child: context.child,
             activeSleep: nil,
             isLiveActivityEnabled: false,
-            liveActivityManager: spy
+            liveActivityManager: spy,
+            snapshotCache: InMemoryFeedLiveActivitySnapshotCache()
         )
 
         #expect(spy.latestSnapshot == nil)
@@ -32,7 +33,8 @@ struct UpdateFeedLiveActivityUseCaseTests {
             child: nil,
             activeSleep: nil,
             isLiveActivityEnabled: true,
-            liveActivityManager: spy
+            liveActivityManager: spy,
+            snapshotCache: InMemoryFeedLiveActivitySnapshotCache()
         )
 
         #expect(spy.latestSnapshot == nil)
@@ -49,7 +51,8 @@ struct UpdateFeedLiveActivityUseCaseTests {
             child: context.child,
             activeSleep: nil,
             isLiveActivityEnabled: true,
-            liveActivityManager: spy
+            liveActivityManager: spy,
+            snapshotCache: InMemoryFeedLiveActivitySnapshotCache()
         )
 
         let snapshot = try #require(spy.latestSnapshot)

--- a/Packages/BabyTrackerFeature/Package.swift
+++ b/Packages/BabyTrackerFeature/Package.swift
@@ -29,7 +29,10 @@ let package = Package(
         ),
         .testTarget(
             name: "BabyTrackerFeatureTests",
-            dependencies: ["BabyTrackerFeature"]
+            dependencies: [
+                "BabyTrackerFeature",
+                .product(name: "BabyTrackerDomain", package: "BabyTrackerDomain"),
+            ]
         ),
     ]
 )

--- a/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/AppModel.swift
+++ b/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/AppModel.swift
@@ -65,6 +65,7 @@ public final class AppModel {
     private let eventRepository: EventRepository
     private let syncEngine: any CloudKitSyncControlling
     private let liveActivityManager: any FeedLiveActivityManaging
+    private let liveActivitySnapshotCache: any FeedLiveActivitySnapshotCaching
     private let liveActivityPreferenceStore: any LiveActivityPreferenceStore
     private let localNotificationManager: any LocalNotificationManaging
     private let hapticFeedbackProvider: any HapticFeedbackProviding
@@ -88,6 +89,7 @@ public final class AppModel {
         eventRepository: EventRepository,
         syncEngine: any CloudKitSyncControlling,
         liveActivityManager: any FeedLiveActivityManaging = NoOpFeedLiveActivityManager(),
+        liveActivitySnapshotCache: any FeedLiveActivitySnapshotCaching = InMemoryFeedLiveActivitySnapshotCache(),
         liveActivityPreferenceStore: any LiveActivityPreferenceStore = InMemoryLiveActivityPreferenceStore(),
         localNotificationManager: any LocalNotificationManaging = NoOpLocalNotificationManager(),
         hapticFeedbackProvider: any HapticFeedbackProviding = NoOpHapticFeedbackProvider(),
@@ -101,6 +103,7 @@ public final class AppModel {
         self.eventRepository = eventRepository
         self.syncEngine = syncEngine
         self.liveActivityManager = liveActivityManager
+        self.liveActivitySnapshotCache = liveActivitySnapshotCache
         self.liveActivityPreferenceStore = liveActivityPreferenceStore
         self.localNotificationManager = localNotificationManager
         self.hapticFeedbackProvider = hapticFeedbackProvider
@@ -167,7 +170,7 @@ public final class AppModel {
         if isEnabled {
             refresh(selecting: childSelectionStore.loadSelectedChildID())
         } else {
-            liveActivityManager.synchronize(with: nil)
+            stopLiveActivity()
         }
     }
 
@@ -911,7 +914,7 @@ public final class AppModel {
                 activeChildren = []
                 archivedChildren = []
                 clearProfileData()
-                liveActivityManager.synchronize(with: nil)
+                stopLiveActivity()
                 return
             }
 
@@ -929,7 +932,7 @@ public final class AppModel {
             guard !activeChildren.isEmpty else {
                 route = .noChildren
                 clearProfileData()
-                liveActivityManager.synchronize(with: nil)
+                stopLiveActivity()
                 return
             }
 
@@ -941,7 +944,7 @@ public final class AppModel {
             if activeChildren.count > 1 && selectedSummary == nil {
                 route = .childPicker
                 clearProfileData()
-                liveActivityManager.synchronize(with: nil)
+                stopLiveActivity()
                 return
             }
 
@@ -1010,7 +1013,8 @@ public final class AppModel {
                 child: currentSummary.child,
                 activeSleep: currentActiveSleep,
                 isLiveActivityEnabled: isLiveActivityEnabled,
-                liveActivityManager: liveActivityManager
+                liveActivityManager: liveActivityManager,
+                snapshotCache: liveActivitySnapshotCache
             )
         } catch {
             AppLogger.shared.log(.error, category: "AppModel", "refresh failed: \(error)")
@@ -1020,9 +1024,14 @@ public final class AppModel {
             // shared child) must not wipe out the user's session.
             if localUser == nil {
                 route = .identityOnboarding
-                liveActivityManager.synchronize(with: nil)
+                stopLiveActivity()
             }
         }
+    }
+
+    private func stopLiveActivity() {
+        liveActivityManager.synchronize(with: nil)
+        liveActivitySnapshotCache.save(nil)
     }
 
     private func clearProfileData() {

--- a/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/AppModel.swift
+++ b/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/AppModel.swift
@@ -1030,8 +1030,10 @@ public final class AppModel {
     }
 
     private func stopLiveActivity() {
-        liveActivityManager.synchronize(with: nil)
-        liveActivitySnapshotCache.save(nil)
+        ResetFeedLiveActivityUseCase.execute(
+            liveActivityManager: liveActivityManager,
+            snapshotCache: liveActivitySnapshotCache
+        )
     }
 
     private func clearProfileData() {

--- a/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/FeedLiveActivitySnapshot.swift
+++ b/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/FeedLiveActivitySnapshot.swift
@@ -1,7 +1,7 @@
 import BabyTrackerDomain
 import Foundation
 
-public struct FeedLiveActivitySnapshot: Equatable, Sendable {
+public struct FeedLiveActivitySnapshot: Codable, Equatable, Sendable {
     public let childID: UUID
     public let childName: String
     public let lastFeedKind: BabyEventKind

--- a/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/FeedLiveActivitySnapshotCaching.swift
+++ b/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/FeedLiveActivitySnapshotCaching.swift
@@ -1,0 +1,7 @@
+import Foundation
+
+@MainActor
+public protocol FeedLiveActivitySnapshotCaching: AnyObject {
+    func load() -> FeedLiveActivitySnapshot?
+    func save(_ snapshot: FeedLiveActivitySnapshot?)
+}

--- a/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/InMemoryFeedLiveActivitySnapshotCache.swift
+++ b/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/InMemoryFeedLiveActivitySnapshotCache.swift
@@ -1,0 +1,12 @@
+import Foundation
+
+@MainActor
+public final class InMemoryFeedLiveActivitySnapshotCache: FeedLiveActivitySnapshotCaching {
+    private var snapshot: FeedLiveActivitySnapshot?
+
+    public init() {}
+
+    public func load() -> FeedLiveActivitySnapshot? { snapshot }
+
+    public func save(_ snapshot: FeedLiveActivitySnapshot?) { self.snapshot = snapshot }
+}

--- a/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/UseCases/ResetFeedLiveActivityUseCase.swift
+++ b/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/UseCases/ResetFeedLiveActivityUseCase.swift
@@ -1,14 +1,17 @@
-/// Clears the snapshot cache and ends the live activity.
-/// Call this to force a full restart of the live activity — e.g. when
-/// recovering from a stale state or when the user manually refreshes.
-/// The next call to UpdateFeedLiveActivityUseCase will start a fresh activity.
+/// Ends the live activity and clears the snapshot cache, but only if the
+/// cache contains data (i.e. a live activity is actually running).
+/// Call this to force a full restart — the next UpdateFeedLiveActivityUseCase
+/// call will start a fresh activity regardless of previously cached state.
 public enum ResetFeedLiveActivityUseCase {
     @MainActor
     public static func execute(
         liveActivityManager: any FeedLiveActivityManaging,
         snapshotCache: any FeedLiveActivitySnapshotCaching
     ) {
-        snapshotCache.save(nil)
+        guard snapshotCache.load() != nil else {
+            return
+        }
         liveActivityManager.synchronize(with: nil)
+        snapshotCache.save(nil)
     }
 }

--- a/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/UseCases/ResetFeedLiveActivityUseCase.swift
+++ b/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/UseCases/ResetFeedLiveActivityUseCase.swift
@@ -1,0 +1,14 @@
+/// Clears the snapshot cache and ends the live activity.
+/// Call this to force a full restart of the live activity — e.g. when
+/// recovering from a stale state or when the user manually refreshes.
+/// The next call to UpdateFeedLiveActivityUseCase will start a fresh activity.
+public enum ResetFeedLiveActivityUseCase {
+    @MainActor
+    public static func execute(
+        liveActivityManager: any FeedLiveActivityManaging,
+        snapshotCache: any FeedLiveActivitySnapshotCaching
+    ) {
+        snapshotCache.save(nil)
+        liveActivityManager.synchronize(with: nil)
+    }
+}

--- a/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/UseCases/UpdateFeedLiveActivityUseCase.swift
+++ b/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/UseCases/UpdateFeedLiveActivityUseCase.swift
@@ -1,6 +1,7 @@
 import BabyTrackerDomain
 
 /// Synchronizes the lock-screen live activity from the current in-memory profile state.
+/// Skips the write when the snapshot is unchanged, preserving Apple's update budget.
 public enum UpdateFeedLiveActivityUseCase {
     @MainActor
     public static func execute(
@@ -8,10 +9,12 @@ public enum UpdateFeedLiveActivityUseCase {
         child: Child?,
         activeSleep: SleepEvent?,
         isLiveActivityEnabled: Bool,
-        liveActivityManager: any FeedLiveActivityManaging
+        liveActivityManager: any FeedLiveActivityManaging,
+        snapshotCache: any FeedLiveActivitySnapshotCaching
     ) {
         guard isLiveActivityEnabled, let child else {
             liveActivityManager.synchronize(with: nil)
+            snapshotCache.save(nil)
             return
         }
 
@@ -20,6 +23,12 @@ public enum UpdateFeedLiveActivityUseCase {
             child: child,
             activeSleep: activeSleep
         )
+
+        guard snapshot != snapshotCache.load() else {
+            return
+        }
+
         liveActivityManager.synchronize(with: snapshot)
+        snapshotCache.save(snapshot)
     }
 }

--- a/Packages/BabyTrackerFeature/Tests/BabyTrackerFeatureTests/Helpers/SpyFeedLiveActivityManager.swift
+++ b/Packages/BabyTrackerFeature/Tests/BabyTrackerFeatureTests/Helpers/SpyFeedLiveActivityManager.swift
@@ -1,0 +1,10 @@
+@testable import BabyTrackerFeature
+
+@MainActor
+final class SpyFeedLiveActivityManager: FeedLiveActivityManaging {
+    private(set) var synchronizeCalls: [FeedLiveActivitySnapshot?] = []
+
+    func synchronize(with snapshot: FeedLiveActivitySnapshot?) {
+        synchronizeCalls.append(snapshot)
+    }
+}

--- a/Packages/BabyTrackerFeature/Tests/BabyTrackerFeatureTests/ResetFeedLiveActivityUseCaseTests.swift
+++ b/Packages/BabyTrackerFeature/Tests/BabyTrackerFeatureTests/ResetFeedLiveActivityUseCaseTests.swift
@@ -19,10 +19,22 @@ struct ResetFeedLiveActivityUseCaseTests {
         )
     }
 
-    // MARK: - Tests
+    // MARK: - Cache has data
 
     @Test
-    func clearsCacheOnReset() {
+    func synchronizesManagerWithNilWhenCacheHasData() {
+        let manager = SpyFeedLiveActivityManager()
+        let cache = InMemoryFeedLiveActivitySnapshotCache()
+        cache.save(makeSnapshot())
+
+        ResetFeedLiveActivityUseCase.execute(liveActivityManager: manager, snapshotCache: cache)
+
+        #expect(manager.synchronizeCalls.count == 1)
+        #expect(manager.synchronizeCalls.first == .some(nil))
+    }
+
+    @Test
+    func clearsCacheWhenCacheHasData() {
         let manager = SpyFeedLiveActivityManager()
         let cache = InMemoryFeedLiveActivitySnapshotCache()
         cache.save(makeSnapshot())
@@ -32,16 +44,19 @@ struct ResetFeedLiveActivityUseCaseTests {
         #expect(cache.load() == nil)
     }
 
+    // MARK: - Cache is empty
+
     @Test
-    func synchronizesManagerWithNilOnReset() {
+    func doesNothingWhenCacheIsEmpty() {
         let manager = SpyFeedLiveActivityManager()
         let cache = InMemoryFeedLiveActivitySnapshotCache()
 
         ResetFeedLiveActivityUseCase.execute(liveActivityManager: manager, snapshotCache: cache)
 
-        #expect(manager.synchronizeCalls.count == 1)
-        #expect(manager.synchronizeCalls.first == .some(nil))
+        #expect(manager.synchronizeCalls.isEmpty)
     }
+
+    // MARK: - Integration with UpdateFeedLiveActivityUseCase
 
     @Test
     func allowsSubsequentUpdateToWriteAfterReset() throws {
@@ -75,10 +90,10 @@ struct ResetFeedLiveActivityUseCaseTests {
 
         let callsBeforeReset = manager.synchronizeCalls.count
 
-        // Reset clears cache
+        // Reset ends the activity and clears the cache
         ResetFeedLiveActivityUseCase.execute(liveActivityManager: manager, snapshotCache: cache)
 
-        // Same data again — now goes through because cache was cleared by reset
+        // Same data again — goes through because cache was cleared by reset
         UpdateFeedLiveActivityUseCase.execute(
             events: events,
             child: child,
@@ -88,7 +103,7 @@ struct ResetFeedLiveActivityUseCaseTests {
             snapshotCache: cache
         )
 
-        // Reset itself + the post-reset update both produced calls
+        // Reset's nil synchronize + post-reset update both produced calls
         #expect(manager.synchronizeCalls.count == callsBeforeReset + 2)
     }
 }

--- a/Packages/BabyTrackerFeature/Tests/BabyTrackerFeatureTests/ResetFeedLiveActivityUseCaseTests.swift
+++ b/Packages/BabyTrackerFeature/Tests/BabyTrackerFeatureTests/ResetFeedLiveActivityUseCaseTests.swift
@@ -1,0 +1,94 @@
+@testable import BabyTrackerFeature
+import BabyTrackerDomain
+import Foundation
+import Testing
+
+@MainActor
+struct ResetFeedLiveActivityUseCaseTests {
+    // MARK: - Helpers
+
+    private func makeSnapshot() -> FeedLiveActivitySnapshot {
+        FeedLiveActivitySnapshot(
+            childID: UUID(),
+            childName: "Robin",
+            lastFeedKind: .bottleFeed,
+            lastFeedAt: .now,
+            lastSleepAt: nil,
+            activeSleepStartedAt: nil,
+            lastNappyAt: nil
+        )
+    }
+
+    // MARK: - Tests
+
+    @Test
+    func clearsCacheOnReset() {
+        let manager = SpyFeedLiveActivityManager()
+        let cache = InMemoryFeedLiveActivitySnapshotCache()
+        cache.save(makeSnapshot())
+
+        ResetFeedLiveActivityUseCase.execute(liveActivityManager: manager, snapshotCache: cache)
+
+        #expect(cache.load() == nil)
+    }
+
+    @Test
+    func synchronizesManagerWithNilOnReset() {
+        let manager = SpyFeedLiveActivityManager()
+        let cache = InMemoryFeedLiveActivitySnapshotCache()
+
+        ResetFeedLiveActivityUseCase.execute(liveActivityManager: manager, snapshotCache: cache)
+
+        #expect(manager.synchronizeCalls.count == 1)
+        #expect(manager.synchronizeCalls.first == .some(nil))
+    }
+
+    @Test
+    func allowsSubsequentUpdateToWriteAfterReset() throws {
+        let manager = SpyFeedLiveActivityManager()
+        let cache = InMemoryFeedLiveActivitySnapshotCache()
+        let child = try Child(name: "Robin", createdBy: UUID())
+        let events: [BabyEvent] = [.bottleFeed(try BottleFeedEvent(
+            metadata: EventMetadata(childID: child.id, occurredAt: .now, createdBy: UUID()),
+            amountMilliliters: 120
+        ))]
+
+        // First update — populates cache
+        UpdateFeedLiveActivityUseCase.execute(
+            events: events,
+            child: child,
+            activeSleep: nil,
+            isLiveActivityEnabled: true,
+            liveActivityManager: manager,
+            snapshotCache: cache
+        )
+
+        // Second update with same data — skipped by cache
+        UpdateFeedLiveActivityUseCase.execute(
+            events: events,
+            child: child,
+            activeSleep: nil,
+            isLiveActivityEnabled: true,
+            liveActivityManager: manager,
+            snapshotCache: cache
+        )
+
+        let callsBeforeReset = manager.synchronizeCalls.count
+
+        // Reset clears cache
+        ResetFeedLiveActivityUseCase.execute(liveActivityManager: manager, snapshotCache: cache)
+
+        // Same data again — now goes through because cache was cleared by reset
+        UpdateFeedLiveActivityUseCase.execute(
+            events: events,
+            child: child,
+            activeSleep: nil,
+            isLiveActivityEnabled: true,
+            liveActivityManager: manager,
+            snapshotCache: cache
+        )
+
+        // Reset itself + the post-reset update both produced calls
+        #expect(manager.synchronizeCalls.count == callsBeforeReset + 2)
+    }
+}

--- a/Packages/BabyTrackerFeature/Tests/BabyTrackerFeatureTests/UpdateFeedLiveActivityUseCaseTests.swift
+++ b/Packages/BabyTrackerFeature/Tests/BabyTrackerFeatureTests/UpdateFeedLiveActivityUseCaseTests.swift
@@ -1,0 +1,157 @@
+@testable import BabyTrackerFeature
+import BabyTrackerDomain
+import Foundation
+import Testing
+
+@MainActor
+struct UpdateFeedLiveActivityUseCaseTests {
+    // MARK: - Helpers
+
+    private func makeChild() throws -> Child {
+        try Child(name: "Robin", createdBy: UUID())
+    }
+
+    private func makeBottleFeedEvent(childID: UUID, occurredAt: Date = .now) throws -> BabyEvent {
+        .bottleFeed(try BottleFeedEvent(
+            metadata: EventMetadata(childID: childID, occurredAt: occurredAt, createdBy: UUID()),
+            amountMilliliters: 120
+        ))
+    }
+
+    private func execute(
+        events: [BabyEvent],
+        child: Child?,
+        isLiveActivityEnabled: Bool = true,
+        manager: SpyFeedLiveActivityManager,
+        cache: InMemoryFeedLiveActivitySnapshotCache
+    ) {
+        UpdateFeedLiveActivityUseCase.execute(
+            events: events,
+            child: child,
+            activeSleep: nil,
+            isLiveActivityEnabled: isLiveActivityEnabled,
+            liveActivityManager: manager,
+            snapshotCache: cache
+        )
+    }
+
+    // MARK: - Cache hit: skip
+
+    @Test
+    func skipsWriteWhenSnapshotMatchesCache() throws {
+        let manager = SpyFeedLiveActivityManager()
+        let cache = InMemoryFeedLiveActivitySnapshotCache()
+        let child = try makeChild()
+        let events = [try makeBottleFeedEvent(childID: child.id)]
+
+        // First call — populates the cache
+        execute(events: events, child: child, manager: manager, cache: cache)
+        let callsAfterFirst = manager.synchronizeCalls.count
+
+        // Second call with identical data — should be skipped
+        execute(events: events, child: child, manager: manager, cache: cache)
+
+        #expect(manager.synchronizeCalls.count == callsAfterFirst)
+    }
+
+    @Test
+    func doesNotUpdateCacheWhenSkipped() throws {
+        let manager = SpyFeedLiveActivityManager()
+        let cache = InMemoryFeedLiveActivitySnapshotCache()
+        let child = try makeChild()
+        let events = [try makeBottleFeedEvent(childID: child.id)]
+
+        execute(events: events, child: child, manager: manager, cache: cache)
+        let snapshotAfterFirst = cache.load()
+
+        execute(events: events, child: child, manager: manager, cache: cache)
+
+        #expect(cache.load() == snapshotAfterFirst)
+    }
+
+    // MARK: - Cache miss: write
+
+    @Test
+    func writesWhenCacheIsEmpty() throws {
+        let manager = SpyFeedLiveActivityManager()
+        let cache = InMemoryFeedLiveActivitySnapshotCache()
+        let child = try makeChild()
+        let events = [try makeBottleFeedEvent(childID: child.id)]
+
+        execute(events: events, child: child, manager: manager, cache: cache)
+
+        #expect(manager.synchronizeCalls.count == 1)
+    }
+
+    @Test
+    func writesWhenSnapshotDiffersFromCache() throws {
+        let manager = SpyFeedLiveActivityManager()
+        let cache = InMemoryFeedLiveActivitySnapshotCache()
+        let child = try makeChild()
+
+        execute(
+            events: [try makeBottleFeedEvent(childID: child.id, occurredAt: .now)],
+            child: child,
+            manager: manager,
+            cache: cache
+        )
+
+        // Different feed time → different snapshot
+        execute(
+            events: [try makeBottleFeedEvent(childID: child.id, occurredAt: .now.addingTimeInterval(3_600))],
+            child: child,
+            manager: manager,
+            cache: cache
+        )
+
+        #expect(manager.synchronizeCalls.count == 2)
+    }
+
+    @Test
+    func updatesCacheAfterWrite() throws {
+        let manager = SpyFeedLiveActivityManager()
+        let cache = InMemoryFeedLiveActivitySnapshotCache()
+        let child = try makeChild()
+        let events = [try makeBottleFeedEvent(childID: child.id)]
+
+        #expect(cache.load() == nil)
+
+        execute(events: events, child: child, manager: manager, cache: cache)
+
+        #expect(cache.load() != nil)
+    }
+
+    // MARK: - Disabled / no child
+
+    @Test
+    func synchronizesNilAndClearsCacheWhenDisabled() throws {
+        let manager = SpyFeedLiveActivityManager()
+        let cache = InMemoryFeedLiveActivitySnapshotCache()
+        let child = try makeChild()
+        let events = [try makeBottleFeedEvent(childID: child.id)]
+
+        // Populate cache first
+        execute(events: events, child: child, manager: manager, cache: cache)
+
+        execute(events: events, child: child, isLiveActivityEnabled: false, manager: manager, cache: cache)
+
+        #expect(manager.synchronizeCalls.last == nil)
+        #expect(cache.load() == nil)
+    }
+
+    @Test
+    func synchronizesNilAndClearsCacheWhenChildIsNil() throws {
+        let manager = SpyFeedLiveActivityManager()
+        let cache = InMemoryFeedLiveActivitySnapshotCache()
+        let child = try makeChild()
+        let events = [try makeBottleFeedEvent(childID: child.id)]
+
+        // Populate cache first
+        execute(events: events, child: child, manager: manager, cache: cache)
+
+        execute(events: events, child: nil, manager: manager, cache: cache)
+
+        #expect(manager.synchronizeCalls.last == nil)
+        #expect(cache.load() == nil)
+    }
+}


### PR DESCRIPTION
Before writing to the Live Activity, compare the incoming snapshot to the
last-written snapshot stored in UserDefaults. If the data hasn't changed,
skip the update entirely so Apple's rate-limit budget isn't exhausted by
no-op refreshes triggered by CloudKit syncs and other frequent events.

https://claude.ai/code/session_01L7WPLv9DeY1Z77dELwthcL