### PR TITLE
Add Log button with Liquid Glass picker to all 5 main screens

### DIFF
--- a/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/ChildWorkspaceTabView.swift
+++ b/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/ChildWorkspaceTabView.swift
@@ -9,6 +9,8 @@ public struct ChildWorkspaceTabView: View {
     @State private var deleteCandidate: EventDeleteCandidate?
     @State private var showingEditChildSheet = false
     @State private var showingEventFilter = false
+    @State private var showingLogEventPicker = false
+    @State private var pendingLogEventKind: BabyEventKind?
     @State private var handledSleepSheetRequestToken = 0
     @State private var summaryViewModel: SummaryViewModel
     @State private var eventHistoryViewModel: EventHistoryViewModel
@@ -96,6 +98,18 @@ public struct ChildWorkspaceTabView: View {
         .navigationTitle(childProfileViewModel.childName)
         .navigationBarTitleDisplayMode(.inline)
         .toolbar {
+            ToolbarItem(placement: .topBarTrailing) {
+                Button {
+                    showingLogEventPicker = true
+                } label: {
+                    Image(systemName: "plus")
+                        .font(.body.weight(.semibold))
+                        .frame(width: 28, height: 28)
+                }
+                .glassEffect(.regular.interactive(), in: Circle())
+                .accessibilityLabel("Log event")
+                .accessibilityIdentifier("log-event-button")
+            }
             if model.selectedWorkspaceTab == .events {
                 ToolbarItem(placement: .topBarTrailing) {
                     Button {
@@ -151,6 +165,12 @@ public struct ChildWorkspaceTabView: View {
                 }
             )
         }
+        .sheet(isPresented: $showingLogEventPicker, onDismiss: handleLogPickerDismiss) {
+            LogEventPickerSheetView { kind in
+                pendingLogEventKind = kind
+                showingLogEventPicker = false
+            }
+        }
         .sheet(item: $bindableModel.shareSheetState) { shareState in
             CloudKitShareSheetView(
                 shareState: shareState,
@@ -167,6 +187,17 @@ public struct ChildWorkspaceTabView: View {
         }
         .onChange(of: model.sleepSheetRequestToken) { _, _ in
             processPendingSleepSheetRequest()
+        }
+    }
+
+    private func handleLogPickerDismiss() {
+        guard let kind = pendingLogEventKind else { return }
+        pendingLogEventKind = nil
+        switch kind {
+        case .breastFeed: activeEventSheet = .quickLogBreastFeed
+        case .bottleFeed: activeEventSheet = .quickLogBottleFeed
+        case .sleep: showSleepSheet()
+        case .nappy: activeEventSheet = .quickLogNappy(.mixed)
         }
     }
 

--- a/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/LogEventPickerSheetView.swift
+++ b/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/LogEventPickerSheetView.swift
@@ -1,0 +1,75 @@
+import BabyTrackerDomain
+import SwiftUI
+
+struct LogEventPickerSheetView: View {
+    let onSelectKind: (BabyEventKind) -> Void
+    @Environment(\.dismiss) private var dismiss
+
+    var body: some View {
+        NavigationStack {
+            VStack(spacing: 20) {
+                Text("What would you like to log?")
+                    .font(.subheadline)
+                    .foregroundStyle(.secondary)
+                    .padding(.top, 4)
+
+                GlassEffectContainer {
+                    VStack(spacing: 12) {
+                        HStack(spacing: 12) {
+                            eventButton(for: .breastFeed)
+                            eventButton(for: .bottleFeed)
+                        }
+                        HStack(spacing: 12) {
+                            eventButton(for: .sleep)
+                            eventButton(for: .nappy)
+                        }
+                    }
+                }
+                .padding(.horizontal, 20)
+
+                Spacer()
+            }
+            .navigationTitle("Log Event")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button("Cancel") { dismiss() }
+                }
+            }
+        }
+        .presentationDetents([.medium])
+        .presentationBackground(.regularMaterial)
+        .presentationCornerRadius(28)
+    }
+
+    private func eventButton(for kind: BabyEventKind) -> some View {
+        let accentColor = BabyEventStyle.accentColor(for: kind)
+
+        return Button {
+            onSelectKind(kind)
+        } label: {
+            VStack(spacing: 10) {
+                Image(systemName: BabyEventStyle.systemImage(for: kind))
+                    .font(.system(size: 32, weight: .medium))
+                    .foregroundStyle(accentColor)
+                Text(eventTitle(for: kind))
+                    .font(.headline)
+                    .foregroundStyle(.primary)
+            }
+            .frame(maxWidth: .infinity, minHeight: 110)
+        }
+        .glassEffect(
+            .regular.tint(accentColor.opacity(0.15)).interactive(),
+            in: RoundedRectangle(cornerRadius: 20, style: .continuous)
+        )
+    }
+
+    private func eventTitle(for kind: BabyEventKind) -> String {
+        switch kind {
+        case .breastFeed: "Breast Feed"
+        case .bottleFeed: "Bottle Feed"
+        case .sleep: "Sleep"
+        case .nappy: "Nappy"
+        }
+    }
+}


### PR DESCRIPTION
A glass-styled "+" button appears in the navigation bar on every tab.
Tapping it opens a medium-height sheet (LogEventPickerSheetView) showing
the 4 event types in a 2×2 GlassEffectContainer grid, each tinted with
its event accent color. Selecting an event type dismisses the picker and
opens the corresponding editor sheet.

https://claude.ai/code/session_01D5334JayTh4YP57hAWKHHu