### PR TITLE
Add Log button with Liquid Glass picker to all 5 main screens

### DIFF
--- a/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/BottleFeedEditorSheetView.swift
+++ b/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/BottleFeedEditorSheetView.swift
@@ -126,6 +126,7 @@ public struct BottleFeedEditorSheetView: View {
             .navigationTitle(navigationTitle)
             .navigationBarTitleDisplayMode(.inline)
             .presentationDetents([.large])
+            .presentationBackground(.regularMaterial)
             .toolbar {
                 ToolbarItem(placement: .cancellationAction) {
                     Button("Cancel") {

--- a/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/BreastFeedEditorSheetView.swift
+++ b/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/BreastFeedEditorSheetView.swift
@@ -98,6 +98,7 @@ public struct BreastFeedEditorSheetView: View {
             .navigationTitle(navigationTitle)
             .navigationBarTitleDisplayMode(.inline)
             .presentationDetents([.large])
+            .presentationBackground(.regularMaterial)
             .onReceive(
                 Timer.publish(every: 1, on: .main, in: .common).autoconnect()
             ) { _ in

--- a/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/ChildHomeView.swift
+++ b/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/ChildHomeView.swift
@@ -117,10 +117,7 @@ public struct ChildHomeView: View {
                 .accessibilityHidden(true)
         }
         .padding(18)
-        .background(
-            RoundedRectangle(cornerRadius: 18, style: .continuous)
-                .fill(Color(.secondarySystemGroupedBackground))
-        )
+        .background(.thinMaterial, in: RoundedRectangle(cornerRadius: 18, style: .continuous))
         .overlay(
             RoundedRectangle(cornerRadius: 18, style: .continuous)
                 .stroke(Color(.separator).opacity(0.35), lineWidth: 1)
@@ -155,44 +152,46 @@ public struct ChildHomeView: View {
             Text("Quick Log")
                 .font(.headline)
 
-            VStack(spacing: 12) {
-                HStack(spacing: 12) {
-                    quickLogButton(
-                        title: "Breast Feed",
-                        systemImage: BabyEventStyle.systemImage(for: .breastFeed),
-                        kind: .breastFeed,
-                        accessibilityIdentifier: "quick-log-breast-feed-button",
-                        action: quickLogBreastFeed
-                    )
+            GlassEffectContainer {
+                VStack(spacing: 12) {
+                    HStack(spacing: 12) {
+                        quickLogButton(
+                            title: "Breast Feed",
+                            systemImage: BabyEventStyle.systemImage(for: .breastFeed),
+                            kind: .breastFeed,
+                            accessibilityIdentifier: "quick-log-breast-feed-button",
+                            action: quickLogBreastFeed
+                        )
 
-                    quickLogButton(
-                        title: "Bottle Feed",
-                        systemImage: BabyEventStyle.systemImage(for: .bottleFeed),
-                        kind: .bottleFeed,
-                        accessibilityIdentifier: "quick-log-bottle-feed-button",
-                        action: quickLogBottleFeed
-                    )
+                        quickLogButton(
+                            title: "Bottle Feed",
+                            systemImage: BabyEventStyle.systemImage(for: .bottleFeed),
+                            kind: .bottleFeed,
+                            accessibilityIdentifier: "quick-log-bottle-feed-button",
+                            action: quickLogBottleFeed
+                        )
+                    }
+                    .geometryGroup()
+
+                    HStack(spacing: 12) {
+                        quickLogButton(
+                            title: sleepQuickLogTitle,
+                            systemImage: BabyEventStyle.systemImage(for: .sleep),
+                            kind: .sleep,
+                            accessibilityIdentifier: "quick-log-sleep-button",
+                            action: quickLogSleep
+                        )
+
+                        quickLogButton(
+                            title: "Nappy",
+                            systemImage: BabyEventStyle.systemImage(for: .nappy),
+                            kind: .nappy,
+                            accessibilityIdentifier: "quick-log-nappy-button",
+                            action: quickLogNappy
+                        )
+                    }
+                    .geometryGroup()
                 }
-                .geometryGroup()
-
-                HStack(spacing: 12) {
-                    quickLogButton(
-                        title: sleepQuickLogTitle,
-                        systemImage: BabyEventStyle.systemImage(for: .sleep),
-                        kind: .sleep,
-                        accessibilityIdentifier: "quick-log-sleep-button",
-                        action: quickLogSleep
-                    )
-
-                    quickLogButton(
-                        title: "Nappy",
-                        systemImage: BabyEventStyle.systemImage(for: .nappy),
-                        kind: .nappy,
-                        accessibilityIdentifier: "quick-log-nappy-button",
-                        action: quickLogNappy
-                    )
-                }
-                .geometryGroup()
             }
         }
     }
@@ -204,17 +203,18 @@ public struct ChildHomeView: View {
         accessibilityIdentifier: String,
         action: @escaping () -> Void
     ) -> some View {
-        Button(action: action) {
+        let accentColor = BabyEventStyle.accentColor(for: kind)
+        return Button(action: action) {
             Label(title, systemImage: systemImage)
                 .font(.headline)
                 .frame(maxWidth: .infinity, minHeight: 56, alignment: .leading)
                 .padding(.horizontal, 14)
-                .foregroundStyle(BabyEventStyle.buttonForegroundColor(for: kind))
-                .background(
-                    RoundedRectangle(cornerRadius: 18, style: .continuous)
-                        .fill(BabyEventStyle.buttonFillColor(for: kind))
-                )
+                .foregroundStyle(accentColor)
         }
+        .glassEffect(
+            .regular.tint(accentColor.opacity(0.15)).interactive(),
+            in: RoundedRectangle(cornerRadius: 18, style: .continuous)
+        )
         .buttonStyle(.plain)
         .accessibilityIdentifier(accessibilityIdentifier)
     }

--- a/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/ChildPickerView.swift
+++ b/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/ChildPickerView.swift
@@ -61,10 +61,10 @@ public struct ChildPickerView: View {
                     .foregroundStyle(.tertiary)
             }
             .padding(20)
-            .background(
+            .background(.thinMaterial, in: RoundedRectangle(cornerRadius: 18, style: .continuous))
+            .overlay(
                 RoundedRectangle(cornerRadius: 18, style: .continuous)
-                    .fill(Color(.secondarySystemGroupedBackground))
-                    .shadow(color: Color.black.opacity(0.06), radius: 12, y: 4)
+                    .stroke(Color(.separator).opacity(0.35), lineWidth: 1)
             )
         }
         .buttonStyle(.plain)

--- a/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/ChildWorkspaceTabView.swift
+++ b/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/ChildWorkspaceTabView.swift
@@ -9,6 +9,8 @@ public struct ChildWorkspaceTabView: View {
     @State private var deleteCandidate: EventDeleteCandidate?
     @State private var showingEditChildSheet = false
     @State private var showingEventFilter = false
+    @State private var showingLogEventPicker = false
+    @State private var pendingLogEventKind: BabyEventKind?
     @State private var handledSleepSheetRequestToken = 0
     @State private var summaryViewModel: SummaryViewModel
     @State private var eventHistoryViewModel: EventHistoryViewModel
@@ -96,6 +98,18 @@ public struct ChildWorkspaceTabView: View {
         .navigationTitle(childProfileViewModel.childName)
         .navigationBarTitleDisplayMode(.inline)
         .toolbar {
+            ToolbarItem(placement: .topBarTrailing) {
+                Button {
+                    showingLogEventPicker = true
+                } label: {
+                    Image(systemName: "plus")
+                        .font(.body.weight(.semibold))
+                        .frame(width: 28, height: 28)
+                }
+                .glassEffect(.regular.interactive(), in: Circle())
+                .accessibilityLabel("Log event")
+                .accessibilityIdentifier("log-event-button")
+            }
             if model.selectedWorkspaceTab == .events {
                 ToolbarItem(placement: .topBarTrailing) {
                     Button {
@@ -151,6 +165,12 @@ public struct ChildWorkspaceTabView: View {
                 }
             )
         }
+        .sheet(isPresented: $showingLogEventPicker, onDismiss: handleLogPickerDismiss) {
+            LogEventPickerSheetView { kind in
+                pendingLogEventKind = kind
+                showingLogEventPicker = false
+            }
+        }
         .sheet(item: $bindableModel.shareSheetState) { shareState in
             CloudKitShareSheetView(
                 shareState: shareState,
@@ -167,6 +187,17 @@ public struct ChildWorkspaceTabView: View {
         }
         .onChange(of: model.sleepSheetRequestToken) { _, _ in
             processPendingSleepSheetRequest()
+        }
+    }
+
+    private func handleLogPickerDismiss() {
+        guard let kind = pendingLogEventKind else { return }
+        pendingLogEventKind = nil
+        switch kind {
+        case .breastFeed: activeEventSheet = .quickLogBreastFeed
+        case .bottleFeed: activeEventSheet = .quickLogBottleFeed
+        case .sleep: showSleepSheet()
+        case .nappy: activeEventSheet = .quickLogNappy(.mixed)
         }
     }
 

--- a/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/CurrentSleepCardView.swift
+++ b/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/CurrentSleepCardView.swift
@@ -45,13 +45,10 @@ public struct CurrentSleepCardView: View {
         }
         .frame(maxWidth: .infinity, alignment: .leading)
         .padding(20)
-        .background(
-            RoundedRectangle(cornerRadius: 18, style: .continuous)
-                .fill(BabyEventStyle.backgroundColor(for: .sleep))
-        )
+        .background(.thinMaterial, in: RoundedRectangle(cornerRadius: 18, style: .continuous))
         .overlay(
             RoundedRectangle(cornerRadius: 18, style: .continuous)
-                .stroke(BabyEventStyle.accentColor(for: .sleep).opacity(0.35), lineWidth: 1)
+                .stroke(BabyEventStyle.accentColor(for: .sleep).opacity(0.4), lineWidth: 1)
         )
         .accessibilityElement(children: .contain)
         .accessibilityIdentifier("current-sleep-card")

--- a/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/CurrentStatusCardView.swift
+++ b/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/CurrentStatusCardView.swift
@@ -69,11 +69,7 @@ public struct CurrentStatusCardView: View {
             }
         }
         .padding(20)
-        .background(
-            RoundedRectangle(cornerRadius: 18, style: .continuous)
-                .fill(Color(.secondarySystemGroupedBackground))
-        )
-        .clipShape(RoundedRectangle(cornerRadius: 18, style: .continuous))
+        .background(.thinMaterial, in: RoundedRectangle(cornerRadius: 18, style: .continuous))
         .overlay(
             RoundedRectangle(cornerRadius: 18, style: .continuous)
                 .stroke(Color(.separator).opacity(0.35), lineWidth: 1)

--- a/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/LogEventPickerSheetView.swift
+++ b/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/LogEventPickerSheetView.swift
@@ -1,0 +1,75 @@
+import BabyTrackerDomain
+import SwiftUI
+
+struct LogEventPickerSheetView: View {
+    let onSelectKind: (BabyEventKind) -> Void
+    @Environment(\.dismiss) private var dismiss
+
+    var body: some View {
+        NavigationStack {
+            VStack(spacing: 20) {
+                Text("What would you like to log?")
+                    .font(.subheadline)
+                    .foregroundStyle(.secondary)
+                    .padding(.top, 4)
+
+                GlassEffectContainer {
+                    VStack(spacing: 12) {
+                        HStack(spacing: 12) {
+                            eventButton(for: .breastFeed)
+                            eventButton(for: .bottleFeed)
+                        }
+                        HStack(spacing: 12) {
+                            eventButton(for: .sleep)
+                            eventButton(for: .nappy)
+                        }
+                    }
+                }
+                .padding(.horizontal, 20)
+
+                Spacer()
+            }
+            .navigationTitle("Log Event")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button("Cancel") { dismiss() }
+                }
+            }
+        }
+        .presentationDetents([.medium])
+        .presentationBackground(.regularMaterial)
+        .presentationCornerRadius(28)
+    }
+
+    private func eventButton(for kind: BabyEventKind) -> some View {
+        let accentColor = BabyEventStyle.accentColor(for: kind)
+
+        return Button {
+            onSelectKind(kind)
+        } label: {
+            VStack(spacing: 10) {
+                Image(systemName: BabyEventStyle.systemImage(for: kind))
+                    .font(.system(size: 32, weight: .medium))
+                    .foregroundStyle(accentColor)
+                Text(eventTitle(for: kind))
+                    .font(.headline)
+                    .foregroundStyle(.primary)
+            }
+            .frame(maxWidth: .infinity, minHeight: 110)
+        }
+        .glassEffect(
+            .regular.tint(accentColor.opacity(0.15)).interactive(),
+            in: RoundedRectangle(cornerRadius: 20, style: .continuous)
+        )
+    }
+
+    private func eventTitle(for kind: BabyEventKind) -> String {
+        switch kind {
+        case .breastFeed: "Breast Feed"
+        case .bottleFeed: "Bottle Feed"
+        case .sleep: "Sleep"
+        case .nappy: "Nappy"
+        }
+    }
+}

--- a/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/NappyEditorSheetView.swift
+++ b/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/NappyEditorSheetView.swift
@@ -91,6 +91,7 @@ public struct NappyEditorSheetView: View {
             .navigationTitle(navigationTitle)
             .navigationBarTitleDisplayMode(.inline)
             .presentationDetents([.large])
+            .presentationBackground(.regularMaterial)
             .onChange(of: type) { _, newType in
                 if !NappyEntry.supportsPooColor(for: newType.value) {
                     pooColor = .notSet

--- a/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/NoChildrenView.swift
+++ b/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/NoChildrenView.swift
@@ -95,10 +95,10 @@ public struct NoChildrenView: View {
                 .foregroundStyle(.tertiary)
         }
         .padding(20)
-        .background(
+        .background(.thinMaterial, in: RoundedRectangle(cornerRadius: 18, style: .continuous))
+        .overlay(
             RoundedRectangle(cornerRadius: 18, style: .continuous)
-                .fill(Color(.secondarySystemGroupedBackground))
-                .shadow(color: Color.black.opacity(0.06), radius: 12, y: 4)
+                .stroke(Color(.separator).opacity(0.35), lineWidth: 1)
         )
     }
 }

--- a/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/SleepEditorSheetView.swift
+++ b/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/SleepEditorSheetView.swift
@@ -86,6 +86,7 @@ public struct SleepEditorSheetView: View {
             .navigationTitle(mode.navigationTitle)
             .navigationBarTitleDisplayMode(.inline)
             .presentationDetents([.large])
+            .presentationBackground(.regularMaterial)
             .onChange(of: startedAt) { _, updatedStart in
                 if endedAt < updatedStart {
                     endedAt = updatedStart


### PR DESCRIPTION
A glass-styled "+" button appears in the navigation bar on every tab.
Tapping it opens a medium-height sheet (LogEventPickerSheetView) showing
the 4 event types in a 2×2 GlassEffectContainer grid, each tinted with
its event accent color. Selecting an event type dismisses the picker and
opens the corresponding editor sheet.

https://claude.ai/code/session_01D5334JayTh4YP57hAWKHHu