### PR TITLE
Position current time near bottom of timeline on open

### DIFF
--- a/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/TimelineDayGridPageView.swift
+++ b/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/TimelineDayGridPageView.swift
@@ -80,7 +80,7 @@ public struct TimelineDayGridPageView: View {
         let visibleHour = page.isToday ? calendar.component(.hour, from: .now) : 6
 
         DispatchQueue.main.async {
-            proxy.scrollTo("timeline-day-grid-hour-\(visibleHour)", anchor: .top)
+            proxy.scrollTo("timeline-day-grid-hour-\(visibleHour)", anchor: .bottom)
         }
     }
 }


### PR DESCRIPTION
## Summary

- Changes the scroll anchor in `TimelineDayGridPageView.scrollToVisibleHour` from `.top` to `.bottom`
- When the timeline opens, the current hour now lands at the **bottom** of the viewport, making the last 2–3 hours of activity immediately visible without scrolling

## Test plan

- [ ] Open the timeline tab — verify the current time indicator is near the bottom of the screen
- [ ] Confirm the last 2–3 hours of events are visible without scrolling
- [ ] Switch away from the timeline tab and back — verify the position is consistent
- [ ] Navigate to a past/future day — verify it still defaults to hour 6 near the bottom

Closes #207

https://claude.ai/code/session_014kfiSV1yAuWyQJ6g7QWJHR