### PR TITLE
Add average trend line to sleep, bottle, breast feed, and nappy charts

### DIFF
--- a/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/SummaryScreenView.swift
+++ b/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/SummaryScreenView.swift
@@ -116,11 +116,15 @@ private enum TrendsNappyChartFilter: String, TodayChartFilter {
     }
 
     func averageText(from data: [DailyNappyData]) -> String? {
+        guard let average = averageValue(from: data) else { return nil }
+        return "Avg \(average)/day"
+    }
+
+    func averageValue(from data: [DailyNappyData]) -> Int? {
         let values = data.map(count(for:))
         let nonZeroValues = values.filter { $0 > 0 }
         guard !nonZeroValues.isEmpty else { return nil }
-        let average = Int((Double(nonZeroValues.reduce(0, +)) / Double(nonZeroValues.count)).rounded())
-        return "Avg \(average)/day"
+        return Int((Double(nonZeroValues.reduce(0, +)) / Double(nonZeroValues.count)).rounded())
     }
 
     private func count(for day: DailyNappyData) -> Int {
@@ -172,11 +176,15 @@ private enum TrendsBottleChartFilter: String, TodayChartFilter {
     }
 
     func averageText(from data: [DailyBottleData], unit: FeedVolumeUnit) -> String? {
+        guard let average = averageValue(from: data) else { return nil }
+        return "Avg \(FeedVolumePresentation.perDayText(for: average, unit: unit))"
+    }
+
+    func averageValue(from data: [DailyBottleData]) -> Int? {
         let values = data.map(value(for:))
         let nonZeroValues = values.filter { $0 > 0 }
         guard !nonZeroValues.isEmpty else { return nil }
-        let average = Int((Double(nonZeroValues.reduce(0, +)) / Double(nonZeroValues.count)).rounded())
-        return "Avg \(FeedVolumePresentation.perDayText(for: average, unit: unit))"
+        return Int((Double(nonZeroValues.reduce(0, +)) / Double(nonZeroValues.count)).rounded())
     }
 
     private func value(for day: DailyBottleData) -> Int {
@@ -533,6 +541,7 @@ public struct SummaryScreenView: View {
         let preferredUnit = viewModel.preferredFeedVolumeUnit
         let points = selectedTrendsBottleFilter.points(from: data.dailyBottle)
         let avgText = selectedTrendsBottleFilter.averageText(from: data.dailyBottle, unit: preferredUnit)
+        let avgValue = selectedTrendsBottleFilter.averageValue(from: data.dailyBottle)
 
         return chartCard(
             title: "Bottle Feeds",
@@ -551,7 +560,8 @@ public struct SummaryScreenView: View {
                 tint: selectedTrendsBottleFilter.tint,
                 valueFormatter: { value in
                     FeedVolumePresentation.amountText(for: value, unit: preferredUnit)
-                }
+                },
+                averageValue: avgValue
             )
         }
     }
@@ -566,7 +576,11 @@ public struct SummaryScreenView: View {
             tint: .pink,
             subtitle: avgText ?? "No breast feeds in this period"
         ) {
-            TrendsBarChartView(points: points, tint: .pink)
+            TrendsBarChartView(
+                points: points,
+                tint: .pink,
+                averageValue: data.avgDailyBreastFeedSessions
+            )
         }
     }
 
@@ -580,12 +594,18 @@ public struct SummaryScreenView: View {
             tint: .indigo,
             subtitle: avgText ?? "No sleep logged in this period"
         ) {
-            TrendsBarChartView(points: points, tint: .indigo, valueFormatter: { DurationText.short(minutes: $0) })
+            TrendsBarChartView(
+                points: points,
+                tint: .indigo,
+                valueFormatter: { DurationText.short(minutes: $0) },
+                averageValue: data.avgDailySleepMinutes
+            )
         }
     }
 
     private func nappyChartCard(data: TrendsSummaryData) -> some View {
         let avgText = selectedTrendsNappyFilter.averageText(from: data.dailyNappy)
+        let avgValue = selectedTrendsNappyFilter.averageValue(from: data.dailyNappy)
 
         return chartCard(
             title: "Nappies",
@@ -600,11 +620,12 @@ public struct SummaryScreenView: View {
             }
         ) {
             if selectedTrendsNappyFilter == .all {
-                TrendsNappyChartView(data: data.dailyNappy)
+                TrendsNappyChartView(data: data.dailyNappy, averageValue: avgValue)
             } else {
                 TrendsBarChartView(
                     points: selectedTrendsNappyFilter.points(from: data.dailyNappy),
-                    tint: selectedTrendsNappyFilter.tint
+                    tint: selectedTrendsNappyFilter.tint,
+                    averageValue: avgValue
                 )
             }
         }

--- a/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/TrendsBarChartView.swift
+++ b/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/TrendsBarChartView.swift
@@ -9,6 +9,7 @@ struct TrendsBarChartView: View {
     let points: [(String, Int)]
     let tint: Color
     var valueFormatter: ((Int) -> String)? = nil
+    var averageValue: Int? = nil
 
     @State private var selectedKey: String?
 
@@ -35,6 +36,17 @@ struct TrendsBarChartView: View {
                             .foregroundStyle(.secondary)
                     }
                 }
+            }
+
+            if let avg = averageValue {
+                RuleMark(y: .value("Average", avg))
+                    .foregroundStyle(.orange.opacity(0.8))
+                    .lineStyle(StrokeStyle(lineWidth: 1.5, dash: [5, 3]))
+                    .annotation(position: .top, alignment: .trailing, spacing: 2) {
+                        Text("Avg")
+                            .font(.system(size: 9).weight(.medium))
+                            .foregroundStyle(.orange.opacity(0.9))
+                    }
             }
 
             if let selectedPoint {
@@ -91,7 +103,9 @@ struct TrendsBarChartView: View {
     }
 
     private var yAxisUpperBound: Int {
-        TrendsChartLayout.yDomainUpperBound(for: points.map(\.1))
+        var values = points.map(\.1)
+        if let avg = averageValue { values.append(avg) }
+        return TrendsChartLayout.yDomainUpperBound(for: values)
     }
 }
 

--- a/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/TrendsNappyChartView.swift
+++ b/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/TrendsNappyChartView.swift
@@ -7,6 +7,7 @@ import SwiftUI
 /// for that day. The chart generates its own legend.
 struct TrendsNappyChartView: View {
     let data: [DailyNappyData]
+    var averageValue: Int? = nil
 
     @State private var selectedKey: String?
 
@@ -23,6 +24,17 @@ struct TrendsNappyChartView: View {
                 )
                 .foregroundStyle(by: .value("Type", segment.type))
                 .opacity(selectedKey == nil || selectedKey == segment.dayKey ? 1 : 0.3)
+            }
+
+            if let avg = averageValue {
+                RuleMark(y: .value("Average", avg))
+                    .foregroundStyle(.orange.opacity(0.8))
+                    .lineStyle(StrokeStyle(lineWidth: 1.5, dash: [5, 3]))
+                    .annotation(position: .top, alignment: .trailing, spacing: 2) {
+                        Text("Avg")
+                            .font(.system(size: 9).weight(.medium))
+                            .foregroundStyle(.orange.opacity(0.9))
+                    }
             }
 
             if let selectedDay {
@@ -101,7 +113,9 @@ struct TrendsNappyChartView: View {
     }
 
     private var yAxisUpperBound: Int {
-        TrendsChartLayout.yDomainUpperBound(for: data.map(\.totalCount))
+        var values = data.map(\.totalCount)
+        if let avg = averageValue { values.append(avg) }
+        return TrendsChartLayout.yDomainUpperBound(for: values)
     }
 }
 


### PR DESCRIPTION
## Summary

- Adds a dashed orange `RuleMark` horizontal average line to all four Trends tab charts: Sleep, Bottle Feed, Breast Feed, and Nappy
- The "Avg" label on the line makes its meaning immediately clear
- The Y-axis domain is expanded to always accommodate the average value, so the line is never clipped

## Implementation details

- `TrendsBarChartView`: added optional `averageValue: Int?` parameter; renders a dashed orange `RuleMark` with an "Avg" annotation when set
- `TrendsNappyChartView`: same treatment for the stacked nappy chart
- `SummaryScreenView`: added `averageValue(from:)` helpers to `TrendsBottleChartFilter` and `TrendsNappyChartFilter` (refactoring the shared average computation out of `averageText`); passes computed averages from `TrendsSummaryData` into each chart

## Test plan

- [ ] Open the Trends tab — Sleep, Bottle, Breast, and Nappy charts each show a dashed orange "Avg" line
- [ ] The line is visually distinct from the bars (orange vs the chart's tint colour, dashed vs solid)
- [ ] Changing the Bottle or Nappy filter updates the average line to reflect the filtered subset
- [ ] Charts with no data show no average line
- [ ] Selecting a bar still shows the callout; the average line remains visible underneath

Closes #210

https://claude.ai/code/session_01KRc3Xa3ixR3PREQB84i1aY