### PR TITLE
Add delete button to all event edit screens

### DIFF
--- a/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/BottleFeedEditorSheetView.swift
+++ b/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/BottleFeedEditorSheetView.swift
@@ -9,9 +9,11 @@ public struct BottleFeedEditorSheetView: View {
     let childName: String
     let preferredVolumeUnit: FeedVolumeUnit
     let saveAction: (_ amountMilliliters: Int, _ occurredAt: Date, _ milkType: MilkType?) -> Bool
+    let deleteAction: (() -> Void)?
 
     @Environment(\.dismiss) private var dismiss
     @State private var amountText: String
+    @State private var showDeleteConfirmation = false
     @State private var occurredAt: Date
     @State private var milkType: MilkTypeChoice
     @State private var showCustomAmount: Bool = false
@@ -36,12 +38,14 @@ public struct BottleFeedEditorSheetView: View {
         initialMilkType: MilkType?,
         initialTimePreset: QuickTimeSelectorView.TimePreset = .now,
         showCustomAmountOnOpen: Bool = false,
+        deleteAction: (() -> Void)? = nil,
         saveAction: @escaping (_ amountMilliliters: Int, _ occurredAt: Date, _ milkType: MilkType?) -> Bool
     ) {
         self.navigationTitle = navigationTitle
         self.primaryActionTitle = primaryActionTitle
         self.childName = childName
         self.preferredVolumeUnit = preferredVolumeUnit
+        self.deleteAction = deleteAction
         self.saveAction = saveAction
         _amountText = State(initialValue: Self.initialAmountText(
             for: initialAmountMilliliters,
@@ -119,6 +123,24 @@ public struct BottleFeedEditorSheetView: View {
                             .foregroundStyle(.red)
                     }
                 }
+
+                if deleteAction != nil {
+                    Section {
+                        Button("Delete Bottle Feed", role: .destructive) {
+                            showDeleteConfirmation = true
+                        }
+                        .accessibilityIdentifier("delete-bottle-feed-button")
+                    }
+                }
+            }
+            .alert("Delete Bottle Feed?", isPresented: $showDeleteConfirmation) {
+                Button("Delete", role: .destructive) {
+                    deleteAction?()
+                    dismiss()
+                }
+                Button("Cancel", role: .cancel) {}
+            } message: {
+                Text("This event will be permanently removed.")
             }
             .tint(Self.eventColor)
             .scrollContentBackground(.hidden)

--- a/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/BreastFeedEditorSheetView.swift
+++ b/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/BreastFeedEditorSheetView.swift
@@ -9,9 +9,11 @@ public struct BreastFeedEditorSheetView: View {
     let childName: String
     let allowsTimerMode: Bool
     let saveAction: (_ durationMinutes: Int, _ endTime: Date, _ side: BreastSide?, _ leftDurationSeconds: Int?, _ rightDurationSeconds: Int?) -> Bool
+    let deleteAction: (() -> Void)?
     private let initialTimePreset: QuickTimeSelectorView.TimePreset
 
     @Environment(\.dismiss) private var dismiss
+    @State private var showDeleteConfirmation = false
 
     // Mode
     @State private var mode: FeedMode = .timer
@@ -46,12 +48,14 @@ public struct BreastFeedEditorSheetView: View {
         initialTimePreset: QuickTimeSelectorView.TimePreset = .now,
         initialLeftDurationSeconds: Int? = nil,
         initialRightDurationSeconds: Int? = nil,
+        deleteAction: (() -> Void)? = nil,
         saveAction: @escaping (_ durationMinutes: Int, _ endTime: Date, _ side: BreastSide?, _ leftDurationSeconds: Int?, _ rightDurationSeconds: Int?) -> Bool
     ) {
         self.navigationTitle = navigationTitle
         self.primaryActionTitle = primaryActionTitle
         self.childName = childName
         self.allowsTimerMode = allowsTimerMode
+        self.deleteAction = deleteAction
         self.saveAction = saveAction
         self.initialTimePreset = initialTimePreset
         _mode = State(initialValue: allowsTimerMode ? .timer : .manual)
@@ -91,6 +95,24 @@ public struct BreastFeedEditorSheetView: View {
                 } else {
                     manualModeContent
                 }
+
+                if deleteAction != nil {
+                    Section {
+                        Button("Delete Breast Feed", role: .destructive) {
+                            showDeleteConfirmation = true
+                        }
+                        .accessibilityIdentifier("delete-breast-feed-button")
+                    }
+                }
+            }
+            .alert("Delete Breast Feed?", isPresented: $showDeleteConfirmation) {
+                Button("Delete", role: .destructive) {
+                    deleteAction?()
+                    dismiss()
+                }
+                Button("Cancel", role: .cancel) {}
+            } message: {
+                Text("This event will be permanently removed.")
             }
             .tint(Self.eventColor)
             .scrollContentBackground(.hidden)

--- a/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/ChildWorkspaceTabView.swift
+++ b/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/ChildWorkspaceTabView.swift
@@ -358,7 +358,12 @@ public struct ChildWorkspaceTabView: View {
                 allowsTimerMode: false,
                 initialTimePreset: .custom,
                 initialLeftDurationSeconds: leftDurationSeconds,
-                initialRightDurationSeconds: rightDurationSeconds
+                initialRightDurationSeconds: rightDurationSeconds,
+                deleteAction: childProfileViewModel.canManageEvents ? {
+                    if model.deleteEvent(id: id) {
+                        activeEventSheet = nil
+                    }
+                } : nil
             ) { updatedDuration, updatedEndTime, updatedSide, updatedLeft, updatedRight in
                 let didSave = model.updateBreastFeed(
                     id: id,
@@ -384,6 +389,11 @@ public struct ChildWorkspaceTabView: View {
                 initialMilkType: milkType,
                 initialTimePreset: .custom,
                 showCustomAmountOnOpen: true,
+                deleteAction: childProfileViewModel.canManageEvents ? {
+                    if model.deleteEvent(id: id) {
+                        activeEventSheet = nil
+                    }
+                } : nil
             ) { updatedAmount, updatedOccurredAt, updatedMilkType in
                 let didSave = model.updateBottleFeed(
                     id: id,
@@ -418,6 +428,11 @@ public struct ChildWorkspaceTabView: View {
                     }
                     return didSave
                 },
+                deleteAction: childProfileViewModel.canManageEvents ? {
+                    if model.deleteEvent(id: id) {
+                        activeEventSheet = nil
+                    }
+                } : nil,
                 resumeAction: {
                     let didResume = model.resumeSleep(id: id, startedAt: startedAt)
                     if didResume {
@@ -435,7 +450,12 @@ public struct ChildWorkspaceTabView: View {
                 initialPeeVolume: peeVolume,
                 initialPooVolume: pooVolume,
                 initialPooColor: pooColor,
-                initialTimePreset: .custom
+                initialTimePreset: .custom,
+                deleteAction: childProfileViewModel.canManageEvents ? {
+                    if model.deleteEvent(id: id) {
+                        activeEventSheet = nil
+                    }
+                } : nil
             ) { updatedType, updatedOccurredAt, updatedPeeVolume, updatedPooVolume, updatedPooColor in
                 let didSave = model.updateNappy(
                     id: id,

--- a/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/NappyEditorSheetView.swift
+++ b/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/NappyEditorSheetView.swift
@@ -8,9 +8,11 @@ public struct NappyEditorSheetView: View {
     let primaryActionTitle: String
     let childName: String
     let saveAction: (_ type: NappyType, _ occurredAt: Date, _ peeVolume: NappyVolume?, _ pooVolume: NappyVolume?, _ pooColor: PooColor?) -> Bool
+    let deleteAction: (() -> Void)?
 
     @Environment(\.dismiss) private var dismiss
     @State private var type: NappyTypeChoice
+    @State private var showDeleteConfirmation = false
     @State private var occurredAt: Date
     @State private var peeVolume: NappyVolumeChoice
     @State private var pooVolume: NappyVolumeChoice
@@ -27,11 +29,13 @@ public struct NappyEditorSheetView: View {
         initialPooVolume: NappyVolume?,
         initialPooColor: PooColor?,
         initialTimePreset: QuickTimeSelectorView.TimePreset = .now,
+        deleteAction: (() -> Void)? = nil,
         saveAction: @escaping (_ type: NappyType, _ occurredAt: Date, _ peeVolume: NappyVolume?, _ pooVolume: NappyVolume?, _ pooColor: PooColor?) -> Bool
     ) {
         self.navigationTitle = navigationTitle
         self.primaryActionTitle = primaryActionTitle
         self.childName = childName
+        self.deleteAction = deleteAction
         self.saveAction = saveAction
         _type = State(initialValue: NappyTypeChoice(type: initialType))
         _occurredAt = State(initialValue: initialOccurredAt)
@@ -84,6 +88,24 @@ public struct NappyEditorSheetView: View {
                         pooColorButtons
                     }
                 }
+
+                if deleteAction != nil {
+                    Section {
+                        Button("Delete Nappy", role: .destructive) {
+                            showDeleteConfirmation = true
+                        }
+                        .accessibilityIdentifier("delete-nappy-button")
+                    }
+                }
+            }
+            .alert("Delete Nappy?", isPresented: $showDeleteConfirmation) {
+                Button("Delete", role: .destructive) {
+                    deleteAction?()
+                    dismiss()
+                }
+                Button("Cancel", role: .cancel) {}
+            } message: {
+                Text("This event will be permanently removed.")
             }
             .tint(Self.eventColor)
             .scrollContentBackground(.hidden)

--- a/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/SleepEditorSheetView.swift
+++ b/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/SleepEditorSheetView.swift
@@ -14,6 +14,7 @@ public struct SleepEditorSheetView: View {
 
     @Environment(\.dismiss) private var dismiss
     @State private var startedAt: Date
+    @State private var showDeleteConfirmation = false
     @State private var endedAt: Date
     @State private var includesEndTime: Bool
 
@@ -70,15 +71,23 @@ public struct SleepEditorSheetView: View {
                     }
                 }
 
-                if let deleteAction {
+                if deleteAction != nil {
                     Section {
                         Button("Delete Sleep", role: .destructive) {
-                            deleteAction()
-                            dismiss()
+                            showDeleteConfirmation = true
                         }
                         .accessibilityIdentifier("delete-sleep-button")
                     }
                 }
+            }
+            .alert("Delete Sleep?", isPresented: $showDeleteConfirmation) {
+                Button("Delete", role: .destructive) {
+                    deleteAction?()
+                    dismiss()
+                }
+                Button("Cancel", role: .cancel) {}
+            } message: {
+                Text("This event will be permanently removed.")
             }
             .tint(Self.eventColor)
             .scrollContentBackground(.hidden)


### PR DESCRIPTION
## Summary

Closes #208.

- Adds an optional `deleteAction` closure to `BreastFeedEditorSheetView`, `BottleFeedEditorSheetView`, and `NappyEditorSheetView`
- Each edit screen now shows a destructive "Delete" button at the bottom of the form; tapping it presents a confirmation alert before executing the deletion and dismissing the sheet
- Wires up the missing `deleteAction` on the `editSleep` case in `ChildWorkspaceTabView` (it was only wired for `endSleep` previously)
- Upgrades the existing sleep delete button to use the same confirmation-alert pattern for consistency
- Delete is only offered to users with `canManageEvents` permission, matching the existing access-control pattern

## Test plan

- [ ] Open the edit sheet for a breast feed event — confirm a "Delete Breast Feed" button appears at the bottom
- [ ] Tap "Delete Breast Feed" — confirm a confirmation alert appears with "Delete" and "Cancel" options
- [ ] Tap "Cancel" — confirm the sheet stays open and the event is not deleted
- [ ] Tap "Delete Breast Feed" again, then confirm "Delete" — confirm the sheet dismisses and the event no longer appears in the timeline/history
- [ ] Repeat the above steps for bottle feed, nappy, and sleep edit screens
- [ ] Verify the delete button does not appear for users without `canManageEvents` permission (e.g. a shared read-only user)

https://claude.ai/code/session_01CRR58KHqAnWpzjt71AQt1Q