### PR TITLE
Show per-type last activity summary on home screen

### DIFF
--- a/Baby TrackerTests/BuildCurrentStatusViewStateUseCaseTests.swift
+++ b/Baby TrackerTests/BuildCurrentStatusViewStateUseCaseTests.swift
@@ -1,0 +1,162 @@
+import BabyTrackerDomain
+import BabyTrackerFeature
+import Foundation
+import Testing
+
+struct BuildCurrentStatusViewStateUseCaseTests {
+    private let childID = UUID()
+    private let userID = UUID()
+
+    private func makeChild() throws -> Child {
+        try Child(id: childID, name: "Poppy", birthDate: Date(timeIntervalSince1970: 0), createdBy: userID, preferredFeedVolumeUnit: .milliliters)
+    }
+
+    @Test
+    func returnsNilsWhenNoEvents() throws {
+        let child = try makeChild()
+        let result = BuildCurrentStatusViewStateUseCase.execute(events: [], child: child)
+
+        #expect(result.lastBreastFeed == nil)
+        #expect(result.lastBottleFeed == nil)
+        #expect(result.lastNappy == nil)
+        #expect(result.lastSleep == nil)
+        #expect(result.feedsTodayCount == 0)
+    }
+
+    @Test
+    func populatesLastBreastFeedWithDetailText() throws {
+        let child = try makeChild()
+        let t = Date(timeIntervalSince1970: 10_000)
+        let events: [BabyEvent] = [
+            .breastFeed(
+                try BreastFeedEvent(
+                    metadata: EventMetadata(childID: childID, occurredAt: t, createdAt: t, createdBy: userID),
+                    side: .left,
+                    startedAt: t.addingTimeInterval(-600),
+                    endedAt: t
+                )
+            ),
+        ]
+
+        let result = BuildCurrentStatusViewStateUseCase.execute(events: events, child: child)
+
+        let breastFeed = try #require(result.lastBreastFeed)
+        #expect(breastFeed.kind == .breastFeed)
+        #expect(breastFeed.occurredAt == t)
+        #expect(breastFeed.detailText?.contains("Left") == true)
+        #expect(result.lastBottleFeed == nil)
+    }
+
+    @Test
+    func populatesLastBottleFeedWithDetailText() throws {
+        let child = try makeChild()
+        let t = Date(timeIntervalSince1970: 10_000)
+        let events: [BabyEvent] = [
+            .bottleFeed(
+                try BottleFeedEvent(
+                    metadata: EventMetadata(childID: childID, occurredAt: t, createdAt: t, createdBy: userID),
+                    amountMilliliters: 150,
+                    milkType: .formula
+                )
+            ),
+        ]
+
+        let result = BuildCurrentStatusViewStateUseCase.execute(events: events, child: child)
+
+        let bottleFeed = try #require(result.lastBottleFeed)
+        #expect(bottleFeed.kind == .bottleFeed)
+        #expect(bottleFeed.occurredAt == t)
+        #expect(bottleFeed.detailText?.contains("Formula") == true)
+        #expect(result.lastBreastFeed == nil)
+    }
+
+    @Test
+    func picksMostRecentBreastFeed() throws {
+        let child = try makeChild()
+        let earlier = Date(timeIntervalSince1970: 5_000)
+        let later = Date(timeIntervalSince1970: 10_000)
+        let events: [BabyEvent] = [
+            .breastFeed(
+                try BreastFeedEvent(
+                    metadata: EventMetadata(childID: childID, occurredAt: earlier, createdAt: earlier, createdBy: userID),
+                    side: .right,
+                    startedAt: earlier.addingTimeInterval(-300),
+                    endedAt: earlier
+                )
+            ),
+            .breastFeed(
+                try BreastFeedEvent(
+                    metadata: EventMetadata(childID: childID, occurredAt: later, createdAt: later, createdBy: userID),
+                    side: .left,
+                    startedAt: later.addingTimeInterval(-900),
+                    endedAt: later
+                )
+            ),
+        ]
+
+        let result = BuildCurrentStatusViewStateUseCase.execute(events: events, child: child)
+
+        #expect(result.lastBreastFeed?.occurredAt == later)
+        #expect(result.lastBreastFeed?.detailText?.contains("Left") == true)
+    }
+
+    @Test
+    func populatesLastNappyWithDetailText() throws {
+        let child = try makeChild()
+        let t = Date(timeIntervalSince1970: 10_000)
+        let events: [BabyEvent] = [
+            .nappy(
+                try NappyEvent(
+                    metadata: EventMetadata(childID: childID, occurredAt: t, createdAt: t, createdBy: userID),
+                    type: .poo,
+                    pooVolume: .medium,
+                    pooColor: .yellow
+                )
+            ),
+        ]
+
+        let result = BuildCurrentStatusViewStateUseCase.execute(events: events, child: child)
+
+        let nappy = try #require(result.lastNappy)
+        #expect(nappy.occurredAt == t)
+        #expect(nappy.detailText?.contains("Poo") == true)
+    }
+
+    @Test
+    func countsFeedsTodayAcrossBothTypes() throws {
+        var calendar = Calendar(identifier: .gregorian)
+        calendar.timeZone = TimeZone(secondsFromGMT: 0)!
+        let child = try makeChild()
+        let day = try #require(calendar.date(from: DateComponents(year: 2026, month: 4, day: 1, hour: 12)))
+        let morning = try #require(calendar.date(from: DateComponents(year: 2026, month: 4, day: 1, hour: 8)))
+        let midday = try #require(calendar.date(from: DateComponents(year: 2026, month: 4, day: 1, hour: 11)))
+        let yesterday = try #require(calendar.date(from: DateComponents(year: 2026, month: 3, day: 31, hour: 20)))
+
+        let events: [BabyEvent] = [
+            .breastFeed(
+                try BreastFeedEvent(
+                    metadata: EventMetadata(childID: childID, occurredAt: morning, createdAt: morning, createdBy: userID),
+                    side: .left,
+                    startedAt: morning.addingTimeInterval(-600),
+                    endedAt: morning
+                )
+            ),
+            .bottleFeed(
+                try BottleFeedEvent(
+                    metadata: EventMetadata(childID: childID, occurredAt: midday, createdAt: midday, createdBy: userID),
+                    amountMilliliters: 120
+                )
+            ),
+            .bottleFeed(
+                try BottleFeedEvent(
+                    metadata: EventMetadata(childID: childID, occurredAt: yesterday, createdAt: yesterday, createdBy: userID),
+                    amountMilliliters: 100
+                )
+            ),
+        ]
+
+        let result = BuildCurrentStatusViewStateUseCase.execute(events: events, child: child, day: day, calendar: calendar)
+
+        #expect(result.feedsTodayCount == 2)
+    }
+}

--- a/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/CurrentStatusCardViewState.swift
+++ b/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/CurrentStatusCardViewState.swift
@@ -2,19 +2,22 @@ import Foundation
 
 public struct CurrentStatusCardViewState: Equatable, Sendable {
     public let lastSleep: LastSleepSummaryViewState?
-    public let timeSinceLastFeedAt: Date?
+    public let lastBreastFeed: LastEventSummaryViewState?
+    public let lastBottleFeed: LastEventSummaryViewState?
     public let feedsTodayCount: Int
-    public let timeSinceLastNappyAt: Date?
+    public let lastNappy: LastNappySummaryViewState?
 
     public init(
         lastSleep: LastSleepSummaryViewState?,
-        timeSinceLastFeedAt: Date?,
+        lastBreastFeed: LastEventSummaryViewState?,
+        lastBottleFeed: LastEventSummaryViewState?,
         feedsTodayCount: Int,
-        timeSinceLastNappyAt: Date?
+        lastNappy: LastNappySummaryViewState?
     ) {
         self.lastSleep = lastSleep
-        self.timeSinceLastFeedAt = timeSinceLastFeedAt
+        self.lastBreastFeed = lastBreastFeed
+        self.lastBottleFeed = lastBottleFeed
         self.feedsTodayCount = feedsTodayCount
-        self.timeSinceLastNappyAt = timeSinceLastNappyAt
+        self.lastNappy = lastNappy
     }
 }

--- a/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/UseCases/BuildCurrentStatusViewStateUseCase.swift
+++ b/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/UseCases/BuildCurrentStatusViewStateUseCase.swift
@@ -2,7 +2,7 @@ import BabyTrackerDomain
 import Foundation
 
 /// Produces the current-status card state for the home screen by composing
-/// `FeedSummaryCalculator` and `LastNappySummaryCalculator`.
+/// the per-type feed calculators, `LastNappySummaryCalculator`, and `LastSleepSummaryCalculator`.
 public enum BuildCurrentStatusViewStateUseCase {
     public static func execute(
         events: [BabyEvent],
@@ -19,12 +19,57 @@ public enum BuildCurrentStatusViewStateUseCase {
         )
         let lastNappy = LastNappySummaryCalculator.makeSummary(from: events)
         let lastSleep = LastSleepSummaryCalculator.makeSummary(from: events, activeSleep: activeSleep)
+        let lastBreastFeed = lastBreastFeedSummary(from: events)
+        let lastBottleFeed = lastBottleFeedSummary(from: events, preferredFeedVolumeUnit: child.preferredFeedVolumeUnit)
 
         return CurrentStatusCardViewState(
             lastSleep: lastSleep,
-            timeSinceLastFeedAt: feedSummary?.lastFeedAt,
+            lastBreastFeed: lastBreastFeed,
+            lastBottleFeed: lastBottleFeed,
             feedsTodayCount: feedSummary?.feedsTodayCount ?? 0,
-            timeSinceLastNappyAt: lastNappy?.occurredAt
+            lastNappy: lastNappy
+        )
+    }
+
+    private static func lastBreastFeedSummary(from events: [BabyEvent]) -> LastEventSummaryViewState? {
+        let breastFeeds = events.compactMap { event -> BreastFeedEvent? in
+            guard case let .breastFeed(feed) = event else { return nil }
+            return feed
+        }
+
+        guard let last = breastFeeds.max(by: { $0.metadata.occurredAt < $1.metadata.occurredAt }) else {
+            return nil
+        }
+
+        return LastEventSummaryViewState(
+            kind: .breastFeed,
+            title: BabyEventPresentation.title(for: .breastFeed),
+            detailText: BabyEventPresentation.detailText(for: .breastFeed(last)),
+            occurredAt: last.metadata.occurredAt
+        )
+    }
+
+    private static func lastBottleFeedSummary(
+        from events: [BabyEvent],
+        preferredFeedVolumeUnit: FeedVolumeUnit
+    ) -> LastEventSummaryViewState? {
+        let bottleFeeds = events.compactMap { event -> BottleFeedEvent? in
+            guard case let .bottleFeed(feed) = event else { return nil }
+            return feed
+        }
+
+        guard let last = bottleFeeds.max(by: { $0.metadata.occurredAt < $1.metadata.occurredAt }) else {
+            return nil
+        }
+
+        return LastEventSummaryViewState(
+            kind: .bottleFeed,
+            title: BabyEventPresentation.title(for: .bottleFeed),
+            detailText: BabyEventPresentation.detailText(
+                for: .bottleFeed(last),
+                preferredFeedVolumeUnit: preferredFeedVolumeUnit
+            ),
+            occurredAt: last.metadata.occurredAt
         )
     }
 }

--- a/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/ViewModels/HomeViewModel.swift
+++ b/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/ViewModels/HomeViewModel.swift
@@ -21,7 +21,7 @@ public final class HomeViewModel {
 
     public var currentStatus: CurrentStatusCardViewState {
         guard let child = appModel.currentChild else {
-            return CurrentStatusCardViewState(lastSleep: nil, timeSinceLastFeedAt: nil, feedsTodayCount: 0, timeSinceLastNappyAt: nil)
+            return CurrentStatusCardViewState(lastSleep: nil, lastBreastFeed: nil, lastBottleFeed: nil, feedsTodayCount: 0, lastNappy: nil)
         }
         return BuildCurrentStatusViewStateUseCase.execute(events: appModel.events, child: child, activeSleep: appModel.activeSleep)
     }

--- a/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/CurrentStatusCardView.swift
+++ b/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/CurrentStatusCardView.swift
@@ -17,6 +17,7 @@ public struct CurrentStatusCardView: View {
             if showSleepRow {
                 statusRow(
                     title: "Last sleep",
+                    subtitle: lastSleepDetailText,
                     systemImage: BabyEventStyle.systemImage(for: .sleep),
                     iconTint: BabyEventStyle.accentColor(for: .sleep),
                     identifier: "current-status-sleep"
@@ -30,13 +31,30 @@ public struct CurrentStatusCardView: View {
             }
 
             statusRow(
-                title: "Time since last feed",
-                systemImage: "drop.fill",
-                iconTint: BabyEventStyle.accentColor(for: .bottleFeed),
-                identifier: "current-status-time-since-last-feed"
+                title: "Last breast feed",
+                subtitle: status.lastBreastFeed?.detailText,
+                systemImage: BabyEventStyle.systemImage(for: .breastFeed),
+                iconTint: BabyEventStyle.accentColor(for: .breastFeed),
+                identifier: "current-status-last-breast-feed"
             ) {
-                if let lastFeedAt = status.timeSinceLastFeedAt {
-                    relativeTimeText(for: lastFeedAt)
+                if let lastBreastFeed = status.lastBreastFeed {
+                    relativeTimeText(for: lastBreastFeed.occurredAt)
+                } else {
+                    Text("No feeds yet")
+                }
+            }
+
+            Divider()
+
+            statusRow(
+                title: "Last bottle feed",
+                subtitle: status.lastBottleFeed?.detailText,
+                systemImage: BabyEventStyle.systemImage(for: .bottleFeed),
+                iconTint: BabyEventStyle.accentColor(for: .bottleFeed),
+                identifier: "current-status-last-bottle-feed"
+            ) {
+                if let lastBottleFeed = status.lastBottleFeed {
+                    relativeTimeText(for: lastBottleFeed.occurredAt)
                 } else {
                     Text("No feeds yet")
                 }
@@ -56,13 +74,14 @@ public struct CurrentStatusCardView: View {
             Divider()
 
             statusRow(
-                title: "Time since last nappy",
+                title: "Last nappy",
+                subtitle: status.lastNappy?.detailText,
                 systemImage: BabyEventStyle.systemImage(for: .nappy),
                 iconTint: BabyEventStyle.accentColor(for: .nappy),
-                identifier: "current-status-time-since-last-nappy"
+                identifier: "current-status-last-nappy"
             ) {
-                if let lastNappyAt = status.timeSinceLastNappyAt {
-                    relativeTimeText(for: lastNappyAt)
+                if let lastNappy = status.lastNappy {
+                    relativeTimeText(for: lastNappy.occurredAt)
                 } else {
                     Text("No nappies yet")
                 }
@@ -83,6 +102,16 @@ public struct CurrentStatusCardView: View {
         .accessibilityIdentifier("current-status-card")
     }
 
+    private var lastSleepDetailText: String? {
+        guard let sleep = status.lastSleep,
+              !sleep.isActive,
+              let endedAt = sleep.endedAt else {
+            return nil
+        }
+        let minutes = max(1, Int(endedAt.timeIntervalSince(sleep.startedAt) / 60))
+        return DurationText.short(minutes: minutes, minuteStyle: .word)
+    }
+
     @ViewBuilder
     private var sleepRowValue: some View {
         if let endedAt = status.lastSleep?.endedAt {
@@ -94,21 +123,30 @@ public struct CurrentStatusCardView: View {
 
     private func statusRow<Value: View>(
         title: String,
+        subtitle: String? = nil,
         systemImage: String,
         iconTint: Color,
         identifier: String,
         @ViewBuilder value: () -> Value
     ) -> some View {
-        HStack(alignment: .firstTextBaseline, spacing: 12) {
+        HStack(alignment: subtitle == nil ? .firstTextBaseline : .top, spacing: 12) {
             Image(systemName: systemImage)
                 .font(.subheadline.weight(.semibold))
                 .foregroundStyle(iconTint)
                 .frame(width: 18)
                 .accessibilityHidden(true)
 
-            Text(title)
-                .font(.subheadline)
-                .foregroundStyle(.secondary)
+            VStack(alignment: .leading, spacing: 2) {
+                Text(title)
+                    .font(.subheadline)
+                    .foregroundStyle(.secondary)
+
+                if let subtitle {
+                    Text(subtitle)
+                        .font(.caption)
+                        .foregroundStyle(.tertiary)
+                }
+            }
 
             Spacer()
 
@@ -133,12 +171,13 @@ public struct CurrentStatusCardView: View {
     }
 }
 
-#Preview("Sleep row hidden (child asleep)") {
+#Preview("Active sleep (sleep row hidden)") {
     CurrentStatusCardView(status: CurrentStatusCardViewState(
         lastSleep: LastSleepSummaryViewState(isActive: true, startedAt: Date().addingTimeInterval(-4_500), endedAt: nil),
-        timeSinceLastFeedAt: Date().addingTimeInterval(-5_400),
+        lastBreastFeed: LastEventSummaryViewState(kind: .breastFeed, title: "Breast Feed", detailText: "20 min • Left", occurredAt: Date().addingTimeInterval(-5_400)),
+        lastBottleFeed: LastEventSummaryViewState(kind: .bottleFeed, title: "Bottle Feed", detailText: "120 mL • Formula", occurredAt: Date().addingTimeInterval(-9_000)),
         feedsTodayCount: 4,
-        timeSinceLastNappyAt: Date().addingTimeInterval(-7_200)
+        lastNappy: LastNappySummaryViewState(title: "Nappy", detailText: "Poo • Medium • Yellow", occurredAt: Date().addingTimeInterval(-7_200))
     ))
     .padding()
 }
@@ -146,9 +185,10 @@ public struct CurrentStatusCardView: View {
 #Preview("Not sleeping") {
     CurrentStatusCardView(status: CurrentStatusCardViewState(
         lastSleep: LastSleepSummaryViewState(isActive: false, startedAt: Date().addingTimeInterval(-18_000), endedAt: Date().addingTimeInterval(-10_800)),
-        timeSinceLastFeedAt: Date().addingTimeInterval(-3_600),
+        lastBreastFeed: LastEventSummaryViewState(kind: .breastFeed, title: "Breast Feed", detailText: "15 min • Right", occurredAt: Date().addingTimeInterval(-3_600)),
+        lastBottleFeed: LastEventSummaryViewState(kind: .bottleFeed, title: "Bottle Feed", detailText: "180 mL • Breast Milk", occurredAt: Date().addingTimeInterval(-6_300)),
         feedsTodayCount: 6,
-        timeSinceLastNappyAt: Date().addingTimeInterval(-5_400)
+        lastNappy: LastNappySummaryViewState(title: "Nappy", detailText: "Pee • Light", occurredAt: Date().addingTimeInterval(-5_400))
     ))
     .padding()
 }
@@ -156,9 +196,10 @@ public struct CurrentStatusCardView: View {
 #Preview("No data") {
     CurrentStatusCardView(status: CurrentStatusCardViewState(
         lastSleep: nil,
-        timeSinceLastFeedAt: nil,
+        lastBreastFeed: nil,
+        lastBottleFeed: nil,
         feedsTodayCount: 0,
-        timeSinceLastNappyAt: nil
+        lastNappy: nil
     ))
     .padding()
 }


### PR DESCRIPTION
## Summary

Closes #204

- Split the combined "Time since last feed" row into separate **Last breast feed** and **Last bottle feed** rows, each with a detail subtitle (e.g. "15 min • Left" or "120 mL • Formula")
- Updated **Last nappy** row to show the nappy type as a subtitle (e.g. "Poo • Medium • Yellow")
- Added sleep duration as a subtitle on the **Last sleep** row (e.g. "2h 30m")
- All rows continue to show live-updating relative time (e.g. "3 hours ago")

### How it works

`CurrentStatusCardViewState` now carries per-feed-type `LastEventSummaryViewState` values (instead of a single combined feed date) and the full `LastNappySummaryViewState` (instead of just the date). `BuildCurrentStatusViewStateUseCase` was extended with private helpers to find the most recent breast and bottle feed events separately and attach their formatted detail text.

`CurrentStatusCardView.statusRow` now accepts an optional `subtitle` parameter that renders detail text below the row title when present.

## Test plan

- [ ] Home screen shows separate "Last breast feed" and "Last bottle feed" rows, each with correct relative time and detail text
- [ ] "Last nappy" row shows the nappy type (e.g. "Poo") as a subtitle
- [ ] "Last sleep" row shows the sleep duration (e.g. "2h 15m") as a subtitle
- [ ] Rows show "No feeds yet" / "No nappies yet" / "No sleep yet" when no events exist
- [ ] Relative times update live without requiring a refresh
- [ ] New `BuildCurrentStatusViewStateUseCaseTests` pass

https://claude.ai/code/session_019EdVM7VqTUer8Xh1Da83Rn