### PR TITLE
Allow logging a past sleep while a sleep is active

### DIFF
--- a/Baby TrackerTests/AppModelTests.swift
+++ b/Baby TrackerTests/AppModelTests.swift
@@ -842,6 +842,39 @@ struct AppModelTests {
     }
 
     @Test
+    func logPastSleepSucceedsWhileAnotherSleepIsActive() throws {
+        let harness = try Harness()
+        defer { harness.cleanUp() }
+
+        _ = try harness.seedOwnerProfile()
+        let activeStart = Date(timeIntervalSince1970: 10_000)
+        let pastStart = Date(timeIntervalSince1970: 5_000)
+        let pastEnd = Date(timeIntervalSince1970: 7_000)
+
+        harness.model.load(performLaunchSync: false)
+
+        #expect(harness.model.startSleep(startedAt: activeStart))
+        #expect(harness.model.activeSleep != nil)
+
+        #expect(harness.model.logSleep(startedAt: pastStart, endedAt: pastEnd))
+
+        #expect(harness.model.activeSleep != nil, "Active sleep should still be running")
+
+        let events = try harness.eventRepository.loadTimeline(
+            for: harness.model.currentChild!.id,
+            includingDeleted: false
+        )
+        let sleepEvents = events.compactMap { event -> SleepEvent? in
+            if case let .sleep(s) = event { return s }
+            return nil
+        }
+        #expect(sleepEvents.count == 2)
+        let loggedPast = try #require(sleepEvents.first(where: { $0.endedAt != nil }))
+        #expect(loggedPast.startedAt == pastStart)
+        #expect(loggedPast.endedAt == pastEnd)
+    }
+
+    @Test
     func resumeSleepClearsEndedAtAndMakesSleepActive() throws {
         let harness = try Harness()
         defer { harness.cleanUp() }

--- a/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/ChildEventSheet.swift
+++ b/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/ChildEventSheet.swift
@@ -6,6 +6,7 @@ public enum ChildEventSheet: Identifiable {
     case quickLogBottleFeed
     case startSleep(suggestions: [(label: String, date: Date)])
     case endSleep(id: UUID, startedAt: Date)
+    case logPastSleep(suggestions: [(label: String, date: Date)])
     case quickLogNappy(NappyType)
     case editBreastFeed(
         id: UUID,
@@ -83,6 +84,8 @@ public enum ChildEventSheet: Identifiable {
             "start-sleep"
         case let .endSleep(id, _):
             "end-sleep-\(id.uuidString)"
+        case .logPastSleep:
+            "log-past-sleep"
         case let .quickLogNappy(type):
             "quick-log-nappy-\(type.rawValue)"
         case let .editBreastFeed(id, _, _, _, _, _):

--- a/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/ChildHomeView.swift
+++ b/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/ChildHomeView.swift
@@ -6,6 +6,7 @@ public struct ChildHomeView: View {
     let viewModel: HomeViewModel
     let childProfileViewModel: ChildProfileViewModel
     let stopSleep: () -> Void
+    let logPastSleep: () -> Void
     let quickLogBreastFeed: () -> Void
     let quickLogBottleFeed: () -> Void
     let quickLogSleep: () -> Void
@@ -17,6 +18,7 @@ public struct ChildHomeView: View {
         viewModel: HomeViewModel,
         childProfileViewModel: ChildProfileViewModel,
         stopSleep: @escaping () -> Void,
+        logPastSleep: @escaping () -> Void,
         quickLogBreastFeed: @escaping () -> Void,
         quickLogBottleFeed: @escaping () -> Void,
         quickLogSleep: @escaping () -> Void,
@@ -26,6 +28,7 @@ public struct ChildHomeView: View {
         self.viewModel = viewModel
         self.childProfileViewModel = childProfileViewModel
         self.stopSleep = stopSleep
+        self.logPastSleep = logPastSleep
         self.quickLogBreastFeed = quickLogBreastFeed
         self.quickLogBottleFeed = quickLogBottleFeed
         self.quickLogSleep = quickLogSleep
@@ -59,7 +62,8 @@ public struct ChildHomeView: View {
     private func currentSleepSection(_ sleep: CurrentSleepCardViewState) -> some View {
         CurrentSleepCardView(
             sleep: sleep,
-            stopSleep: stopSleep
+            stopSleep: stopSleep,
+            logPastSleep: logPastSleep
         )
     }
 
@@ -269,6 +273,7 @@ public struct ChildHomeView: View {
             viewModel: HomeViewModel(appModel: model),
             childProfileViewModel: ChildProfileViewModel(appModel: model),
             stopSleep: {},
+            logPastSleep: {},
             quickLogBreastFeed: {},
             quickLogBottleFeed: {},
             quickLogSleep: {},

--- a/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/ChildWorkspaceTabView.swift
+++ b/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/ChildWorkspaceTabView.swift
@@ -34,6 +34,7 @@ public struct ChildWorkspaceTabView: View {
                 viewModel: homeViewModel,
                 childProfileViewModel: childProfileViewModel,
                 stopSleep: showSleepSheet,
+                logPastSleep: { activeEventSheet = .logPastSleep(suggestions: model.sleepStartSuggestions()) },
                 quickLogBreastFeed: { activeEventSheet = .quickLogBreastFeed },
                 quickLogBottleFeed: { activeEventSheet = .quickLogBottleFeed },
                 quickLogSleep: showSleepSheet,
@@ -292,6 +293,22 @@ public struct ChildWorkspaceTabView: View {
                 } else {
                     didSave = model.startSleep(startedAt: startedAt)
                 }
+                if didSave {
+                    activeEventSheet = nil
+                }
+                return didSave
+            }
+        case let .logPastSleep(suggestions):
+            SleepEditorSheetView(
+                mode: .start,
+                childName: childProfileViewModel.childName,
+                initialStartedAt: Date(),
+                initialEndedAt: nil,
+                startSuggestions: suggestions,
+                initialIncludesEndTime: true
+            ) { startedAt, endedAt in
+                guard let endedAt else { return false }
+                let didSave = model.logSleep(startedAt: startedAt, endedAt: endedAt)
                 if didSave {
                     activeEventSheet = nil
                 }

--- a/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/CurrentSleepCardView.swift
+++ b/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/CurrentSleepCardView.swift
@@ -4,44 +4,57 @@ import SwiftUI
 public struct CurrentSleepCardView: View {
     let sleep: CurrentSleepCardViewState
     let stopSleep: () -> Void
+    let logPastSleep: () -> Void
 
     public init(
         sleep: CurrentSleepCardViewState,
-        stopSleep: @escaping () -> Void
+        stopSleep: @escaping () -> Void,
+        logPastSleep: @escaping () -> Void
     ) {
         self.sleep = sleep
         self.stopSleep = stopSleep
+        self.logPastSleep = logPastSleep
     }
 
     public var body: some View {
-        HStack(alignment: .center, spacing: 14) {
-            sleepIcon
+        VStack(alignment: .leading, spacing: 12) {
+            HStack(alignment: .center, spacing: 14) {
+                sleepIcon
 
-            VStack(alignment: .leading, spacing: 6) {
-                TimelineView(.periodic(from: .now, by: 1)) { context in
-                    Text(durationText(from: sleep.startedAt, to: context.date))
-                        .font(.system(size: 24, weight: .bold, design: .rounded))
-                        .monospacedDigit()
-                        .lineLimit(1)
-                        .minimumScaleFactor(0.75)
-                        .foregroundStyle(BabyEventStyle.accentColor(for: .sleep))
-                        .accessibilityIdentifier("current-sleep-duration")
+                VStack(alignment: .leading, spacing: 6) {
+                    TimelineView(.periodic(from: .now, by: 1)) { context in
+                        Text(durationText(from: sleep.startedAt, to: context.date))
+                            .font(.system(size: 24, weight: .bold, design: .rounded))
+                            .monospacedDigit()
+                            .lineLimit(1)
+                            .minimumScaleFactor(0.75)
+                            .foregroundStyle(BabyEventStyle.accentColor(for: .sleep))
+                            .accessibilityIdentifier("current-sleep-duration")
+                    }
+
+                    Text("Went to sleep \(sleep.startedAt, format: .dateTime.hour().minute())")
+                        .font(.subheadline)
+                        .foregroundStyle(.secondary)
+                        .accessibilityIdentifier("current-sleep-started-at")
                 }
 
-                Text("Went to sleep \(sleep.startedAt, format: .dateTime.hour().minute())")
-                    .font(.subheadline)
-                    .foregroundStyle(.secondary)
-                    .accessibilityIdentifier("current-sleep-started-at")
+                Spacer(minLength: 8)
+
+                Button("Stop") {
+                    stopSleep()
+                }
+                .buttonStyle(.borderedProminent)
+                .tint(BabyEventStyle.accentColor(for: .sleep))
+                .accessibilityIdentifier("current-sleep-stop-button")
             }
 
-            Spacer(minLength: 8)
-
-            Button("Stop") {
-                stopSleep()
+            Button(action: logPastSleep) {
+                Label("Log a past sleep", systemImage: "plus.circle")
+                    .font(.subheadline.weight(.medium))
+                    .foregroundStyle(BabyEventStyle.accentColor(for: .sleep))
             }
-            .buttonStyle(.borderedProminent)
-            .tint(BabyEventStyle.accentColor(for: .sleep))
-            .accessibilityIdentifier("current-sleep-stop-button")
+            .buttonStyle(.plain)
+            .accessibilityIdentifier("log-past-sleep-button")
         }
         .frame(maxWidth: .infinity, alignment: .leading)
         .padding(20)
@@ -78,4 +91,16 @@ public struct CurrentSleepCardView: View {
 
         return String(format: "%02dh %02dm %02ds", hours, minutes, remainingSeconds)
     }
+}
+
+#Preview {
+    CurrentSleepCardView(
+        sleep: CurrentSleepCardViewState(
+            sleepEventID: UUID(),
+            startedAt: Date(timeIntervalSinceNow: -4_500)
+        ),
+        stopSleep: {},
+        logPastSleep: {}
+    )
+    .padding()
 }

--- a/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/SleepEditorSheetView.swift
+++ b/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/SleepEditorSheetView.swift
@@ -24,6 +24,7 @@ public struct SleepEditorSheetView: View {
         initialEndedAt: Date?,
         startSuggestions: [(label: String, date: Date)] = [],
         endTimeInitialPreset: QuickTimeSelectorView.TimePreset = .now,
+        initialIncludesEndTime: Bool = false,
         saveAction: @escaping (_ startedAt: Date, _ endedAt: Date?) -> Bool,
         deleteAction: (() -> Void)? = nil,
         resumeAction: (() -> Void)? = nil
@@ -37,7 +38,7 @@ public struct SleepEditorSheetView: View {
         self.endTimeInitialPreset = endTimeInitialPreset
         _startedAt = State(initialValue: initialStartedAt)
         _endedAt = State(initialValue: initialEndedAt ?? Date())
-        _includesEndTime = State(initialValue: mode != .start)
+        _includesEndTime = State(initialValue: mode != .start || initialIncludesEndTime)
     }
 
     public var body: some View {

--- a/docs/plans/081-log-past-sleep-while-active.md
+++ b/docs/plans/081-log-past-sleep-while-active.md
@@ -1,0 +1,38 @@
+# 081 – Log a past sleep while a sleep is active
+
+## Goal
+
+Allow users to log a completed past sleep (with explicit start and end time) even when another sleep is currently in progress. Fixes the limitation reported in GitHub issue #205.
+
+## Background
+
+When a sleep is active, tapping the Quick Log sleep button shows the "End Sleep" sheet, which only allows ending the current active sleep. There is no path to log a missed nap or previous sleep session until the active sleep ends.
+
+The domain layer (`LogSleepUseCase`) already supports logging a completed sleep without checking for an active session. The fix is entirely in the presentation layer.
+
+## Approach
+
+1. **`SleepEditorSheetView`** – Add an `initialIncludesEndTime` parameter so the "Already ended?" toggle can be pre-checked when opening the sheet in `.start` mode.
+
+2. **`ChildEventSheet`** – Add a `.logPastSleep(suggestions:)` case that represents opening the log-past-sleep sheet.
+
+3. **`CurrentSleepCardView`** – Add a `logPastSleep` callback and a "Log a past sleep" secondary button below the active sleep timer, visible only while a sleep is running.
+
+4. **`ChildHomeView`** – Propagate the new `logPastSleep` closure down to `CurrentSleepCardView`.
+
+5. **`ChildWorkspaceTabView`** – Wire `logPastSleep` to set `activeEventSheet = .logPastSleep(suggestions:)`, and handle the new sheet case by opening `SleepEditorSheetView` in `.start` mode with `initialIncludesEndTime: true`, calling `model.logSleep` on save.
+
+## What is not changed
+
+- `LogSleepUseCase` – already correct; no active-sleep guard.
+- `StartSleepUseCase` – existing guard remains; this is a separate code path.
+- The active sleep timer is unaffected.
+
+## Tests
+
+Added `logPastSleepSucceedsWhileAnotherSleepIsActive` to `AppModelTests` to verify:
+- `logSleep` succeeds while an active sleep exists
+- The active sleep is still present after the call
+- Both sleep records exist in the repository
+
+- [x] Complete


### PR DESCRIPTION
## Summary

- Adds a **"Log a past sleep"** button to the active sleep card (`CurrentSleepCardView`) so users can record a missed nap or earlier sleep without stopping the running session
- Introduces a new `logPastSleep` sheet case that opens `SleepEditorSheetView` in start mode with the "Already ended?" toggle pre-checked, calling `logSleep` on save
- The in-progress sleep timer is completely unaffected — `LogSleepUseCase` already had no guard against an active session; this is purely a UI fix

## Changes

- `SleepEditorSheetView` – add `initialIncludesEndTime` parameter so the end-time toggle can be pre-checked
- `ChildEventSheet` – add `.logPastSleep(suggestions:)` case
- `CurrentSleepCardView` – add `logPastSleep` callback + secondary "Log a past sleep" button
- `ChildHomeView` – propagate new `logPastSleep` closure
- `ChildWorkspaceTabView` – wire up the new sheet case
- `AppModelTests` – add `logPastSleepSucceedsWhileAnotherSleepIsActive` test
- `docs/plans/081-log-past-sleep-while-active.md` – plan document

## Test plan

- [ ] With a sleep active, tap "Log a past sleep" — the log sheet opens with start and end time pickers already visible
- [ ] Save a past sleep — it appears in the event list and the active sleep timer keeps running
- [ ] The "Already ended?" toggle can still be unchecked, reverting to a normal start-sleep flow (only available when no sleep is active)
- [ ] `logPastSleepSucceedsWhileAnotherSleepIsActive` unit test passes

Closes #205
Plan: `docs/plans/081-log-past-sleep-while-active.md`

https://claude.ai/code/session_01VWyAkRNgKeVGoSLZ7cmbiU