### PR TITLE
Merge PRs 211-217 and fix Summary date picker layout

### DIFF
--- a/Baby TrackerTests/AppModelTests.swift
+++ b/Baby TrackerTests/AppModelTests.swift
@@ -842,6 +842,39 @@ struct AppModelTests {
     }
 
     @Test
+    func logPastSleepSucceedsWhileAnotherSleepIsActive() throws {
+        let harness = try Harness()
+        defer { harness.cleanUp() }
+
+        _ = try harness.seedOwnerProfile()
+        let activeStart = Date(timeIntervalSince1970: 10_000)
+        let pastStart = Date(timeIntervalSince1970: 5_000)
+        let pastEnd = Date(timeIntervalSince1970: 7_000)
+
+        harness.model.load(performLaunchSync: false)
+
+        #expect(harness.model.startSleep(startedAt: activeStart))
+        #expect(harness.model.activeSleep != nil)
+
+        #expect(harness.model.logSleep(startedAt: pastStart, endedAt: pastEnd))
+
+        #expect(harness.model.activeSleep != nil, "Active sleep should still be running")
+
+        let events = try harness.eventRepository.loadTimeline(
+            for: harness.model.currentChild!.id,
+            includingDeleted: false
+        )
+        let sleepEvents = events.compactMap { event -> SleepEvent? in
+            if case let .sleep(s) = event { return s }
+            return nil
+        }
+        #expect(sleepEvents.count == 2)
+        let loggedPast = try #require(sleepEvents.first(where: { $0.endedAt != nil }))
+        #expect(loggedPast.startedAt == pastStart)
+        #expect(loggedPast.endedAt == pastEnd)
+    }
+
+    @Test
     func resumeSleepClearsEndedAtAndMakesSleepActive() throws {
         let harness = try Harness()
         defer { harness.cleanUp() }

--- a/Baby TrackerTests/BuildCurrentStatusViewStateUseCaseTests.swift
+++ b/Baby TrackerTests/BuildCurrentStatusViewStateUseCaseTests.swift
@@ -1,0 +1,162 @@
+import BabyTrackerDomain
+import BabyTrackerFeature
+import Foundation
+import Testing
+
+struct BuildCurrentStatusViewStateUseCaseTests {
+    private let childID = UUID()
+    private let userID = UUID()
+
+    private func makeChild() throws -> Child {
+        try Child(id: childID, name: "Poppy", birthDate: Date(timeIntervalSince1970: 0), createdBy: userID, preferredFeedVolumeUnit: .milliliters)
+    }
+
+    @Test
+    func returnsNilsWhenNoEvents() throws {
+        let child = try makeChild()
+        let result = BuildCurrentStatusViewStateUseCase.execute(events: [], child: child)
+
+        #expect(result.lastBreastFeed == nil)
+        #expect(result.lastBottleFeed == nil)
+        #expect(result.lastNappy == nil)
+        #expect(result.lastSleep == nil)
+        #expect(result.feedsTodayCount == 0)
+    }
+
+    @Test
+    func populatesLastBreastFeedWithDetailText() throws {
+        let child = try makeChild()
+        let t = Date(timeIntervalSince1970: 10_000)
+        let events: [BabyEvent] = [
+            .breastFeed(
+                try BreastFeedEvent(
+                    metadata: EventMetadata(childID: childID, occurredAt: t, createdAt: t, createdBy: userID),
+                    side: .left,
+                    startedAt: t.addingTimeInterval(-600),
+                    endedAt: t
+                )
+            ),
+        ]
+
+        let result = BuildCurrentStatusViewStateUseCase.execute(events: events, child: child)
+
+        let breastFeed = try #require(result.lastBreastFeed)
+        #expect(breastFeed.kind == .breastFeed)
+        #expect(breastFeed.occurredAt == t)
+        #expect(breastFeed.detailText?.contains("Left") == true)
+        #expect(result.lastBottleFeed == nil)
+    }
+
+    @Test
+    func populatesLastBottleFeedWithDetailText() throws {
+        let child = try makeChild()
+        let t = Date(timeIntervalSince1970: 10_000)
+        let events: [BabyEvent] = [
+            .bottleFeed(
+                try BottleFeedEvent(
+                    metadata: EventMetadata(childID: childID, occurredAt: t, createdAt: t, createdBy: userID),
+                    amountMilliliters: 150,
+                    milkType: .formula
+                )
+            ),
+        ]
+
+        let result = BuildCurrentStatusViewStateUseCase.execute(events: events, child: child)
+
+        let bottleFeed = try #require(result.lastBottleFeed)
+        #expect(bottleFeed.kind == .bottleFeed)
+        #expect(bottleFeed.occurredAt == t)
+        #expect(bottleFeed.detailText?.contains("Formula") == true)
+        #expect(result.lastBreastFeed == nil)
+    }
+
+    @Test
+    func picksMostRecentBreastFeed() throws {
+        let child = try makeChild()
+        let earlier = Date(timeIntervalSince1970: 5_000)
+        let later = Date(timeIntervalSince1970: 10_000)
+        let events: [BabyEvent] = [
+            .breastFeed(
+                try BreastFeedEvent(
+                    metadata: EventMetadata(childID: childID, occurredAt: earlier, createdAt: earlier, createdBy: userID),
+                    side: .right,
+                    startedAt: earlier.addingTimeInterval(-300),
+                    endedAt: earlier
+                )
+            ),
+            .breastFeed(
+                try BreastFeedEvent(
+                    metadata: EventMetadata(childID: childID, occurredAt: later, createdAt: later, createdBy: userID),
+                    side: .left,
+                    startedAt: later.addingTimeInterval(-900),
+                    endedAt: later
+                )
+            ),
+        ]
+
+        let result = BuildCurrentStatusViewStateUseCase.execute(events: events, child: child)
+
+        #expect(result.lastBreastFeed?.occurredAt == later)
+        #expect(result.lastBreastFeed?.detailText?.contains("Left") == true)
+    }
+
+    @Test
+    func populatesLastNappyWithDetailText() throws {
+        let child = try makeChild()
+        let t = Date(timeIntervalSince1970: 10_000)
+        let events: [BabyEvent] = [
+            .nappy(
+                try NappyEvent(
+                    metadata: EventMetadata(childID: childID, occurredAt: t, createdAt: t, createdBy: userID),
+                    type: .poo,
+                    pooVolume: .medium,
+                    pooColor: .yellow
+                )
+            ),
+        ]
+
+        let result = BuildCurrentStatusViewStateUseCase.execute(events: events, child: child)
+
+        let nappy = try #require(result.lastNappy)
+        #expect(nappy.occurredAt == t)
+        #expect(nappy.detailText?.contains("Poo") == true)
+    }
+
+    @Test
+    func countsFeedsTodayAcrossBothTypes() throws {
+        var calendar = Calendar(identifier: .gregorian)
+        calendar.timeZone = TimeZone(secondsFromGMT: 0)!
+        let child = try makeChild()
+        let day = try #require(calendar.date(from: DateComponents(year: 2026, month: 4, day: 1, hour: 12)))
+        let morning = try #require(calendar.date(from: DateComponents(year: 2026, month: 4, day: 1, hour: 8)))
+        let midday = try #require(calendar.date(from: DateComponents(year: 2026, month: 4, day: 1, hour: 11)))
+        let yesterday = try #require(calendar.date(from: DateComponents(year: 2026, month: 3, day: 31, hour: 20)))
+
+        let events: [BabyEvent] = [
+            .breastFeed(
+                try BreastFeedEvent(
+                    metadata: EventMetadata(childID: childID, occurredAt: morning, createdAt: morning, createdBy: userID),
+                    side: .left,
+                    startedAt: morning.addingTimeInterval(-600),
+                    endedAt: morning
+                )
+            ),
+            .bottleFeed(
+                try BottleFeedEvent(
+                    metadata: EventMetadata(childID: childID, occurredAt: midday, createdAt: midday, createdBy: userID),
+                    amountMilliliters: 120
+                )
+            ),
+            .bottleFeed(
+                try BottleFeedEvent(
+                    metadata: EventMetadata(childID: childID, occurredAt: yesterday, createdAt: yesterday, createdBy: userID),
+                    amountMilliliters: 100
+                )
+            ),
+        ]
+
+        let result = BuildCurrentStatusViewStateUseCase.execute(events: events, child: child, day: day, calendar: calendar)
+
+        #expect(result.feedsTodayCount == 2)
+    }
+}

--- a/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/AdvancedSummarySelection.swift
+++ b/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/AdvancedSummarySelection.swift
@@ -34,4 +34,8 @@ public struct AdvancedSummarySelection: Equatable, Sendable {
     public static func range(_ range: SummaryTimeRange, day: Date = .now) -> AdvancedSummarySelection {
         AdvancedSummarySelection(mode: .range, range: range, day: day)
     }
+
+    public static func day(_ day: Date, range: SummaryTimeRange = .today) -> AdvancedSummarySelection {
+        AdvancedSummarySelection(mode: .day, range: range, day: day)
+    }
 }

--- a/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/CurrentStatusCardViewState.swift
+++ b/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/CurrentStatusCardViewState.swift
@@ -2,19 +2,22 @@ import Foundation
 
 public struct CurrentStatusCardViewState: Equatable, Sendable {
     public let lastSleep: LastSleepSummaryViewState?
-    public let timeSinceLastFeedAt: Date?
+    public let lastBreastFeed: LastEventSummaryViewState?
+    public let lastBottleFeed: LastEventSummaryViewState?
     public let feedsTodayCount: Int
-    public let timeSinceLastNappyAt: Date?
+    public let lastNappy: LastNappySummaryViewState?
 
     public init(
         lastSleep: LastSleepSummaryViewState?,
-        timeSinceLastFeedAt: Date?,
+        lastBreastFeed: LastEventSummaryViewState?,
+        lastBottleFeed: LastEventSummaryViewState?,
         feedsTodayCount: Int,
-        timeSinceLastNappyAt: Date?
+        lastNappy: LastNappySummaryViewState?
     ) {
         self.lastSleep = lastSleep
-        self.timeSinceLastFeedAt = timeSinceLastFeedAt
+        self.lastBreastFeed = lastBreastFeed
+        self.lastBottleFeed = lastBottleFeed
         self.feedsTodayCount = feedsTodayCount
-        self.timeSinceLastNappyAt = timeSinceLastNappyAt
+        self.lastNappy = lastNappy
     }
 }

--- a/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/CurrentStatusCardViewState.swift
+++ b/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/CurrentStatusCardViewState.swift
@@ -7,6 +7,23 @@ public struct CurrentStatusCardViewState: Equatable, Sendable {
     public let feedsTodayCount: Int
     public let lastNappy: LastNappySummaryViewState?
 
+    public var timeSinceLastFeedAt: Date? {
+        switch (lastBreastFeed?.occurredAt, lastBottleFeed?.occurredAt) {
+        case let (left?, right?):
+            return max(left, right)
+        case let (left?, nil):
+            return left
+        case let (nil, right?):
+            return right
+        case (nil, nil):
+            return nil
+        }
+    }
+
+    public var timeSinceLastNappyAt: Date? {
+        lastNappy?.occurredAt
+    }
+
     public init(
         lastSleep: LastSleepSummaryViewState?,
         lastBreastFeed: LastEventSummaryViewState?,

--- a/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/ElapsedTimeFormatter.swift
+++ b/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/ElapsedTimeFormatter.swift
@@ -1,0 +1,20 @@
+import Foundation
+
+enum ElapsedTimeFormatter {
+    static func string(from date: Date, relativeTo referenceDate: Date = Date()) -> String {
+        let interval = referenceDate.timeIntervalSince(date)
+        guard interval >= 60 else { return "just now" }
+
+        let totalMinutes = Int(interval / 60)
+        let hours = totalMinutes / 60
+        let minutes = totalMinutes % 60
+
+        if hours == 0 {
+            return "\(totalMinutes) \(totalMinutes == 1 ? "min" : "mins") ago"
+        } else if minutes == 0 {
+            return "\(hours) \(hours == 1 ? "hr" : "hrs") ago"
+        } else {
+            return "\(hours) \(hours == 1 ? "hr" : "hrs") \(minutes) \(minutes == 1 ? "min" : "mins") ago"
+        }
+    }
+}

--- a/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/UseCases/BuildCurrentStatusViewStateUseCase.swift
+++ b/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/UseCases/BuildCurrentStatusViewStateUseCase.swift
@@ -2,7 +2,7 @@ import BabyTrackerDomain
 import Foundation
 
 /// Produces the current-status card state for the home screen by composing
-/// `FeedSummaryCalculator` and `LastNappySummaryCalculator`.
+/// the per-type feed calculators, `LastNappySummaryCalculator`, and `LastSleepSummaryCalculator`.
 public enum BuildCurrentStatusViewStateUseCase {
     public static func execute(
         events: [BabyEvent],
@@ -19,12 +19,57 @@ public enum BuildCurrentStatusViewStateUseCase {
         )
         let lastNappy = LastNappySummaryCalculator.makeSummary(from: events)
         let lastSleep = LastSleepSummaryCalculator.makeSummary(from: events, activeSleep: activeSleep)
+        let lastBreastFeed = lastBreastFeedSummary(from: events)
+        let lastBottleFeed = lastBottleFeedSummary(from: events, preferredFeedVolumeUnit: child.preferredFeedVolumeUnit)
 
         return CurrentStatusCardViewState(
             lastSleep: lastSleep,
-            timeSinceLastFeedAt: feedSummary?.lastFeedAt,
+            lastBreastFeed: lastBreastFeed,
+            lastBottleFeed: lastBottleFeed,
             feedsTodayCount: feedSummary?.feedsTodayCount ?? 0,
-            timeSinceLastNappyAt: lastNappy?.occurredAt
+            lastNappy: lastNappy
+        )
+    }
+
+    private static func lastBreastFeedSummary(from events: [BabyEvent]) -> LastEventSummaryViewState? {
+        let breastFeeds = events.compactMap { event -> BreastFeedEvent? in
+            guard case let .breastFeed(feed) = event else { return nil }
+            return feed
+        }
+
+        guard let last = breastFeeds.max(by: { $0.metadata.occurredAt < $1.metadata.occurredAt }) else {
+            return nil
+        }
+
+        return LastEventSummaryViewState(
+            kind: .breastFeed,
+            title: BabyEventPresentation.title(for: .breastFeed),
+            detailText: BabyEventPresentation.detailText(for: .breastFeed(last)),
+            occurredAt: last.metadata.occurredAt
+        )
+    }
+
+    private static func lastBottleFeedSummary(
+        from events: [BabyEvent],
+        preferredFeedVolumeUnit: FeedVolumeUnit
+    ) -> LastEventSummaryViewState? {
+        let bottleFeeds = events.compactMap { event -> BottleFeedEvent? in
+            guard case let .bottleFeed(feed) = event else { return nil }
+            return feed
+        }
+
+        guard let last = bottleFeeds.max(by: { $0.metadata.occurredAt < $1.metadata.occurredAt }) else {
+            return nil
+        }
+
+        return LastEventSummaryViewState(
+            kind: .bottleFeed,
+            title: BabyEventPresentation.title(for: .bottleFeed),
+            detailText: BabyEventPresentation.detailText(
+                for: .bottleFeed(last),
+                preferredFeedVolumeUnit: preferredFeedVolumeUnit
+            ),
+            occurredAt: last.metadata.occurredAt
         )
     }
 }

--- a/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/ViewModels/HomeViewModel.swift
+++ b/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/ViewModels/HomeViewModel.swift
@@ -21,7 +21,7 @@ public final class HomeViewModel {
 
     public var currentStatus: CurrentStatusCardViewState {
         guard let child = appModel.currentChild else {
-            return CurrentStatusCardViewState(lastSleep: nil, timeSinceLastFeedAt: nil, feedsTodayCount: 0, timeSinceLastNappyAt: nil)
+            return CurrentStatusCardViewState(lastSleep: nil, lastBreastFeed: nil, lastBottleFeed: nil, feedsTodayCount: 0, lastNappy: nil)
         }
         return BuildCurrentStatusViewStateUseCase.execute(events: appModel.events, child: child, activeSleep: appModel.activeSleep)
     }

--- a/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/BottleFeedEditorSheetView.swift
+++ b/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/BottleFeedEditorSheetView.swift
@@ -9,9 +9,11 @@ public struct BottleFeedEditorSheetView: View {
     let childName: String
     let preferredVolumeUnit: FeedVolumeUnit
     let saveAction: (_ amountMilliliters: Int, _ occurredAt: Date, _ milkType: MilkType?) -> Bool
+    let deleteAction: (() -> Void)?
 
     @Environment(\.dismiss) private var dismiss
     @State private var amountText: String
+    @State private var showDeleteConfirmation = false
     @State private var occurredAt: Date
     @State private var milkType: MilkTypeChoice
     @State private var showCustomAmount: Bool = false
@@ -36,12 +38,14 @@ public struct BottleFeedEditorSheetView: View {
         initialMilkType: MilkType?,
         initialTimePreset: QuickTimeSelectorView.TimePreset = .now,
         showCustomAmountOnOpen: Bool = false,
+        deleteAction: (() -> Void)? = nil,
         saveAction: @escaping (_ amountMilliliters: Int, _ occurredAt: Date, _ milkType: MilkType?) -> Bool
     ) {
         self.navigationTitle = navigationTitle
         self.primaryActionTitle = primaryActionTitle
         self.childName = childName
         self.preferredVolumeUnit = preferredVolumeUnit
+        self.deleteAction = deleteAction
         self.saveAction = saveAction
         _amountText = State(initialValue: Self.initialAmountText(
             for: initialAmountMilliliters,
@@ -119,6 +123,24 @@ public struct BottleFeedEditorSheetView: View {
                             .foregroundStyle(.red)
                     }
                 }
+
+                if deleteAction != nil {
+                    Section {
+                        Button("Delete Bottle Feed", role: .destructive) {
+                            showDeleteConfirmation = true
+                        }
+                        .accessibilityIdentifier("delete-bottle-feed-button")
+                    }
+                }
+            }
+            .alert("Delete Bottle Feed?", isPresented: $showDeleteConfirmation) {
+                Button("Delete", role: .destructive) {
+                    deleteAction?()
+                    dismiss()
+                }
+                Button("Cancel", role: .cancel) {}
+            } message: {
+                Text("This event will be permanently removed.")
             }
             .tint(Self.eventColor)
             .scrollContentBackground(.hidden)

--- a/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/BreastFeedEditorSheetView.swift
+++ b/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/BreastFeedEditorSheetView.swift
@@ -9,9 +9,11 @@ public struct BreastFeedEditorSheetView: View {
     let childName: String
     let allowsTimerMode: Bool
     let saveAction: (_ durationMinutes: Int, _ endTime: Date, _ side: BreastSide?, _ leftDurationSeconds: Int?, _ rightDurationSeconds: Int?) -> Bool
+    let deleteAction: (() -> Void)?
     private let initialTimePreset: QuickTimeSelectorView.TimePreset
 
     @Environment(\.dismiss) private var dismiss
+    @State private var showDeleteConfirmation = false
 
     // Mode
     @State private var mode: FeedMode = .timer
@@ -46,12 +48,14 @@ public struct BreastFeedEditorSheetView: View {
         initialTimePreset: QuickTimeSelectorView.TimePreset = .now,
         initialLeftDurationSeconds: Int? = nil,
         initialRightDurationSeconds: Int? = nil,
+        deleteAction: (() -> Void)? = nil,
         saveAction: @escaping (_ durationMinutes: Int, _ endTime: Date, _ side: BreastSide?, _ leftDurationSeconds: Int?, _ rightDurationSeconds: Int?) -> Bool
     ) {
         self.navigationTitle = navigationTitle
         self.primaryActionTitle = primaryActionTitle
         self.childName = childName
         self.allowsTimerMode = allowsTimerMode
+        self.deleteAction = deleteAction
         self.saveAction = saveAction
         self.initialTimePreset = initialTimePreset
         _mode = State(initialValue: allowsTimerMode ? .timer : .manual)
@@ -91,6 +95,24 @@ public struct BreastFeedEditorSheetView: View {
                 } else {
                     manualModeContent
                 }
+
+                if deleteAction != nil {
+                    Section {
+                        Button("Delete Breast Feed", role: .destructive) {
+                            showDeleteConfirmation = true
+                        }
+                        .accessibilityIdentifier("delete-breast-feed-button")
+                    }
+                }
+            }
+            .alert("Delete Breast Feed?", isPresented: $showDeleteConfirmation) {
+                Button("Delete", role: .destructive) {
+                    deleteAction?()
+                    dismiss()
+                }
+                Button("Cancel", role: .cancel) {}
+            } message: {
+                Text("This event will be permanently removed.")
             }
             .tint(Self.eventColor)
             .scrollContentBackground(.hidden)

--- a/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/ChildEventSheet.swift
+++ b/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/ChildEventSheet.swift
@@ -6,6 +6,7 @@ public enum ChildEventSheet: Identifiable {
     case quickLogBottleFeed
     case startSleep(suggestions: [(label: String, date: Date)])
     case endSleep(id: UUID, startedAt: Date)
+    case logPastSleep(suggestions: [(label: String, date: Date)])
     case quickLogNappy(NappyType)
     case editBreastFeed(
         id: UUID,
@@ -83,6 +84,8 @@ public enum ChildEventSheet: Identifiable {
             "start-sleep"
         case let .endSleep(id, _):
             "end-sleep-\(id.uuidString)"
+        case .logPastSleep:
+            "log-past-sleep"
         case let .quickLogNappy(type):
             "quick-log-nappy-\(type.rawValue)"
         case let .editBreastFeed(id, _, _, _, _, _):

--- a/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/ChildHomeView.swift
+++ b/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/ChildHomeView.swift
@@ -6,6 +6,7 @@ public struct ChildHomeView: View {
     let viewModel: HomeViewModel
     let childProfileViewModel: ChildProfileViewModel
     let stopSleep: () -> Void
+    let logPastSleep: () -> Void
     let quickLogBreastFeed: () -> Void
     let quickLogBottleFeed: () -> Void
     let quickLogSleep: () -> Void
@@ -17,6 +18,7 @@ public struct ChildHomeView: View {
         viewModel: HomeViewModel,
         childProfileViewModel: ChildProfileViewModel,
         stopSleep: @escaping () -> Void,
+        logPastSleep: @escaping () -> Void,
         quickLogBreastFeed: @escaping () -> Void,
         quickLogBottleFeed: @escaping () -> Void,
         quickLogSleep: @escaping () -> Void,
@@ -26,6 +28,7 @@ public struct ChildHomeView: View {
         self.viewModel = viewModel
         self.childProfileViewModel = childProfileViewModel
         self.stopSleep = stopSleep
+        self.logPastSleep = logPastSleep
         self.quickLogBreastFeed = quickLogBreastFeed
         self.quickLogBottleFeed = quickLogBottleFeed
         self.quickLogSleep = quickLogSleep
@@ -59,7 +62,8 @@ public struct ChildHomeView: View {
     private func currentSleepSection(_ sleep: CurrentSleepCardViewState) -> some View {
         CurrentSleepCardView(
             sleep: sleep,
-            stopSleep: stopSleep
+            stopSleep: stopSleep,
+            logPastSleep: logPastSleep
         )
     }
 
@@ -269,6 +273,7 @@ public struct ChildHomeView: View {
             viewModel: HomeViewModel(appModel: model),
             childProfileViewModel: ChildProfileViewModel(appModel: model),
             stopSleep: {},
+            logPastSleep: {},
             quickLogBreastFeed: {},
             quickLogBottleFeed: {},
             quickLogSleep: {},

--- a/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/ChildWorkspaceTabView.swift
+++ b/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/ChildWorkspaceTabView.swift
@@ -358,7 +358,12 @@ public struct ChildWorkspaceTabView: View {
                 allowsTimerMode: false,
                 initialTimePreset: .custom,
                 initialLeftDurationSeconds: leftDurationSeconds,
-                initialRightDurationSeconds: rightDurationSeconds
+                initialRightDurationSeconds: rightDurationSeconds,
+                deleteAction: childProfileViewModel.canManageEvents ? {
+                    if model.deleteEvent(id: id) {
+                        activeEventSheet = nil
+                    }
+                } : nil
             ) { updatedDuration, updatedEndTime, updatedSide, updatedLeft, updatedRight in
                 let didSave = model.updateBreastFeed(
                     id: id,
@@ -384,6 +389,11 @@ public struct ChildWorkspaceTabView: View {
                 initialMilkType: milkType,
                 initialTimePreset: .custom,
                 showCustomAmountOnOpen: true,
+                deleteAction: childProfileViewModel.canManageEvents ? {
+                    if model.deleteEvent(id: id) {
+                        activeEventSheet = nil
+                    }
+                } : nil
             ) { updatedAmount, updatedOccurredAt, updatedMilkType in
                 let didSave = model.updateBottleFeed(
                     id: id,
@@ -418,6 +428,11 @@ public struct ChildWorkspaceTabView: View {
                     }
                     return didSave
                 },
+                deleteAction: childProfileViewModel.canManageEvents ? {
+                    if model.deleteEvent(id: id) {
+                        activeEventSheet = nil
+                    }
+                } : nil,
                 resumeAction: {
                     let didResume = model.resumeSleep(id: id, startedAt: startedAt)
                     if didResume {
@@ -435,7 +450,12 @@ public struct ChildWorkspaceTabView: View {
                 initialPeeVolume: peeVolume,
                 initialPooVolume: pooVolume,
                 initialPooColor: pooColor,
-                initialTimePreset: .custom
+                initialTimePreset: .custom,
+                deleteAction: childProfileViewModel.canManageEvents ? {
+                    if model.deleteEvent(id: id) {
+                        activeEventSheet = nil
+                    }
+                } : nil
             ) { updatedType, updatedOccurredAt, updatedPeeVolume, updatedPooVolume, updatedPooColor in
                 let didSave = model.updateNappy(
                     id: id,

--- a/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/ChildWorkspaceTabView.swift
+++ b/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/ChildWorkspaceTabView.swift
@@ -34,6 +34,7 @@ public struct ChildWorkspaceTabView: View {
                 viewModel: homeViewModel,
                 childProfileViewModel: childProfileViewModel,
                 stopSleep: showSleepSheet,
+                logPastSleep: { activeEventSheet = .logPastSleep(suggestions: model.sleepStartSuggestions()) },
                 quickLogBreastFeed: { activeEventSheet = .quickLogBreastFeed },
                 quickLogBottleFeed: { activeEventSheet = .quickLogBottleFeed },
                 quickLogSleep: showSleepSheet,
@@ -292,6 +293,22 @@ public struct ChildWorkspaceTabView: View {
                 } else {
                     didSave = model.startSleep(startedAt: startedAt)
                 }
+                if didSave {
+                    activeEventSheet = nil
+                }
+                return didSave
+            }
+        case let .logPastSleep(suggestions):
+            SleepEditorSheetView(
+                mode: .start,
+                childName: childProfileViewModel.childName,
+                initialStartedAt: Date(),
+                initialEndedAt: nil,
+                startSuggestions: suggestions,
+                initialIncludesEndTime: true
+            ) { startedAt, endedAt in
+                guard let endedAt else { return false }
+                let didSave = model.logSleep(startedAt: startedAt, endedAt: endedAt)
                 if didSave {
                     activeEventSheet = nil
                 }

--- a/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/CurrentSleepCardView.swift
+++ b/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/CurrentSleepCardView.swift
@@ -4,44 +4,57 @@ import SwiftUI
 public struct CurrentSleepCardView: View {
     let sleep: CurrentSleepCardViewState
     let stopSleep: () -> Void
+    let logPastSleep: () -> Void
 
     public init(
         sleep: CurrentSleepCardViewState,
-        stopSleep: @escaping () -> Void
+        stopSleep: @escaping () -> Void,
+        logPastSleep: @escaping () -> Void
     ) {
         self.sleep = sleep
         self.stopSleep = stopSleep
+        self.logPastSleep = logPastSleep
     }
 
     public var body: some View {
-        HStack(alignment: .center, spacing: 14) {
-            sleepIcon
+        VStack(alignment: .leading, spacing: 12) {
+            HStack(alignment: .center, spacing: 14) {
+                sleepIcon
 
-            VStack(alignment: .leading, spacing: 6) {
-                TimelineView(.periodic(from: .now, by: 1)) { context in
-                    Text(durationText(from: sleep.startedAt, to: context.date))
-                        .font(.system(size: 24, weight: .bold, design: .rounded))
-                        .monospacedDigit()
-                        .lineLimit(1)
-                        .minimumScaleFactor(0.75)
-                        .foregroundStyle(BabyEventStyle.accentColor(for: .sleep))
-                        .accessibilityIdentifier("current-sleep-duration")
+                VStack(alignment: .leading, spacing: 6) {
+                    TimelineView(.periodic(from: .now, by: 1)) { context in
+                        Text(durationText(from: sleep.startedAt, to: context.date))
+                            .font(.system(size: 24, weight: .bold, design: .rounded))
+                            .monospacedDigit()
+                            .lineLimit(1)
+                            .minimumScaleFactor(0.75)
+                            .foregroundStyle(BabyEventStyle.accentColor(for: .sleep))
+                            .accessibilityIdentifier("current-sleep-duration")
+                    }
+
+                    Text("Went to sleep \(sleep.startedAt, format: .dateTime.hour().minute())")
+                        .font(.subheadline)
+                        .foregroundStyle(.secondary)
+                        .accessibilityIdentifier("current-sleep-started-at")
                 }
 
-                Text("Went to sleep \(sleep.startedAt, format: .dateTime.hour().minute())")
-                    .font(.subheadline)
-                    .foregroundStyle(.secondary)
-                    .accessibilityIdentifier("current-sleep-started-at")
+                Spacer(minLength: 8)
+
+                Button("Stop") {
+                    stopSleep()
+                }
+                .buttonStyle(.borderedProminent)
+                .tint(BabyEventStyle.accentColor(for: .sleep))
+                .accessibilityIdentifier("current-sleep-stop-button")
             }
 
-            Spacer(minLength: 8)
-
-            Button("Stop") {
-                stopSleep()
+            Button(action: logPastSleep) {
+                Label("Log a past sleep", systemImage: "plus.circle")
+                    .font(.subheadline.weight(.medium))
+                    .foregroundStyle(BabyEventStyle.accentColor(for: .sleep))
             }
-            .buttonStyle(.borderedProminent)
-            .tint(BabyEventStyle.accentColor(for: .sleep))
-            .accessibilityIdentifier("current-sleep-stop-button")
+            .buttonStyle(.plain)
+            .accessibilityIdentifier("log-past-sleep-button")
         }
         .frame(maxWidth: .infinity, alignment: .leading)
         .padding(20)
@@ -78,4 +91,16 @@ public struct CurrentSleepCardView: View {
 
         return String(format: "%02dh %02dm %02ds", hours, minutes, remainingSeconds)
     }
+}
+
+#Preview {
+    CurrentSleepCardView(
+        sleep: CurrentSleepCardViewState(
+            sleepEventID: UUID(),
+            startedAt: Date(timeIntervalSinceNow: -4_500)
+        ),
+        stopSleep: {},
+        logPastSleep: {}
+    )
+    .padding()
 }

--- a/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/CurrentStateCardView.swift
+++ b/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/CurrentStateCardView.swift
@@ -188,15 +188,8 @@ public struct CurrentStateCardView: View {
     }
 
     private func relativeTimeText(for date: Date) -> some View {
-        TimelineView(.everyMinute) { context in
-            Text(relativeText(for: date, relativeTo: Date()))
+        TimelineView(.everyMinute) { _ in
+            Text(ElapsedTimeFormatter.string(from: date))
         }
-    }
-
-    private func relativeText(
-        for date: Date,
-        relativeTo referenceDate: Date
-    ) -> String {
-        RelativeDateTimeFormatter().localizedString(for: date, relativeTo: referenceDate)
     }
 }

--- a/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/CurrentStatusCardView.swift
+++ b/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/CurrentStatusCardView.swift
@@ -17,6 +17,7 @@ public struct CurrentStatusCardView: View {
             if showSleepRow {
                 statusRow(
                     title: "Last sleep",
+                    subtitle: lastSleepDetailText,
                     systemImage: BabyEventStyle.systemImage(for: .sleep),
                     iconTint: BabyEventStyle.accentColor(for: .sleep),
                     identifier: "current-status-sleep"
@@ -30,13 +31,30 @@ public struct CurrentStatusCardView: View {
             }
 
             statusRow(
-                title: "Time since last feed",
-                systemImage: "drop.fill",
-                iconTint: BabyEventStyle.accentColor(for: .bottleFeed),
-                identifier: "current-status-time-since-last-feed"
+                title: "Last breast feed",
+                subtitle: status.lastBreastFeed?.detailText,
+                systemImage: BabyEventStyle.systemImage(for: .breastFeed),
+                iconTint: BabyEventStyle.accentColor(for: .breastFeed),
+                identifier: "current-status-last-breast-feed"
             ) {
-                if let lastFeedAt = status.timeSinceLastFeedAt {
-                    relativeTimeText(for: lastFeedAt)
+                if let lastBreastFeed = status.lastBreastFeed {
+                    relativeTimeText(for: lastBreastFeed.occurredAt)
+                } else {
+                    Text("No feeds yet")
+                }
+            }
+
+            Divider()
+
+            statusRow(
+                title: "Last bottle feed",
+                subtitle: status.lastBottleFeed?.detailText,
+                systemImage: BabyEventStyle.systemImage(for: .bottleFeed),
+                iconTint: BabyEventStyle.accentColor(for: .bottleFeed),
+                identifier: "current-status-last-bottle-feed"
+            ) {
+                if let lastBottleFeed = status.lastBottleFeed {
+                    relativeTimeText(for: lastBottleFeed.occurredAt)
                 } else {
                     Text("No feeds yet")
                 }
@@ -56,13 +74,14 @@ public struct CurrentStatusCardView: View {
             Divider()
 
             statusRow(
-                title: "Time since last nappy",
+                title: "Last nappy",
+                subtitle: status.lastNappy?.detailText,
                 systemImage: BabyEventStyle.systemImage(for: .nappy),
                 iconTint: BabyEventStyle.accentColor(for: .nappy),
-                identifier: "current-status-time-since-last-nappy"
+                identifier: "current-status-last-nappy"
             ) {
-                if let lastNappyAt = status.timeSinceLastNappyAt {
-                    relativeTimeText(for: lastNappyAt)
+                if let lastNappy = status.lastNappy {
+                    relativeTimeText(for: lastNappy.occurredAt)
                 } else {
                     Text("No nappies yet")
                 }
@@ -83,6 +102,16 @@ public struct CurrentStatusCardView: View {
         .accessibilityIdentifier("current-status-card")
     }
 
+    private var lastSleepDetailText: String? {
+        guard let sleep = status.lastSleep,
+              !sleep.isActive,
+              let endedAt = sleep.endedAt else {
+            return nil
+        }
+        let minutes = max(1, Int(endedAt.timeIntervalSince(sleep.startedAt) / 60))
+        return DurationText.short(minutes: minutes, minuteStyle: .word)
+    }
+
     @ViewBuilder
     private var sleepRowValue: some View {
         if let endedAt = status.lastSleep?.endedAt {
@@ -94,21 +123,30 @@ public struct CurrentStatusCardView: View {
 
     private func statusRow<Value: View>(
         title: String,
+        subtitle: String? = nil,
         systemImage: String,
         iconTint: Color,
         identifier: String,
         @ViewBuilder value: () -> Value
     ) -> some View {
-        HStack(alignment: .firstTextBaseline, spacing: 12) {
+        HStack(alignment: subtitle == nil ? .firstTextBaseline : .top, spacing: 12) {
             Image(systemName: systemImage)
                 .font(.subheadline.weight(.semibold))
                 .foregroundStyle(iconTint)
                 .frame(width: 18)
                 .accessibilityHidden(true)
 
-            Text(title)
-                .font(.subheadline)
-                .foregroundStyle(.secondary)
+            VStack(alignment: .leading, spacing: 2) {
+                Text(title)
+                    .font(.subheadline)
+                    .foregroundStyle(.secondary)
+
+                if let subtitle {
+                    Text(subtitle)
+                        .font(.caption)
+                        .foregroundStyle(.tertiary)
+                }
+            }
 
             Spacer()
 
@@ -133,12 +171,13 @@ public struct CurrentStatusCardView: View {
     }
 }
 
-#Preview("Sleep row hidden (child asleep)") {
+#Preview("Active sleep (sleep row hidden)") {
     CurrentStatusCardView(status: CurrentStatusCardViewState(
         lastSleep: LastSleepSummaryViewState(isActive: true, startedAt: Date().addingTimeInterval(-4_500), endedAt: nil),
-        timeSinceLastFeedAt: Date().addingTimeInterval(-5_400),
+        lastBreastFeed: LastEventSummaryViewState(kind: .breastFeed, title: "Breast Feed", detailText: "20 min • Left", occurredAt: Date().addingTimeInterval(-5_400)),
+        lastBottleFeed: LastEventSummaryViewState(kind: .bottleFeed, title: "Bottle Feed", detailText: "120 mL • Formula", occurredAt: Date().addingTimeInterval(-9_000)),
         feedsTodayCount: 4,
-        timeSinceLastNappyAt: Date().addingTimeInterval(-7_200)
+        lastNappy: LastNappySummaryViewState(title: "Nappy", detailText: "Poo • Medium • Yellow", occurredAt: Date().addingTimeInterval(-7_200))
     ))
     .padding()
 }
@@ -146,9 +185,10 @@ public struct CurrentStatusCardView: View {
 #Preview("Not sleeping") {
     CurrentStatusCardView(status: CurrentStatusCardViewState(
         lastSleep: LastSleepSummaryViewState(isActive: false, startedAt: Date().addingTimeInterval(-18_000), endedAt: Date().addingTimeInterval(-10_800)),
-        timeSinceLastFeedAt: Date().addingTimeInterval(-3_600),
+        lastBreastFeed: LastEventSummaryViewState(kind: .breastFeed, title: "Breast Feed", detailText: "15 min • Right", occurredAt: Date().addingTimeInterval(-3_600)),
+        lastBottleFeed: LastEventSummaryViewState(kind: .bottleFeed, title: "Bottle Feed", detailText: "180 mL • Breast Milk", occurredAt: Date().addingTimeInterval(-6_300)),
         feedsTodayCount: 6,
-        timeSinceLastNappyAt: Date().addingTimeInterval(-5_400)
+        lastNappy: LastNappySummaryViewState(title: "Nappy", detailText: "Pee • Light", occurredAt: Date().addingTimeInterval(-5_400))
     ))
     .padding()
 }
@@ -156,9 +196,10 @@ public struct CurrentStatusCardView: View {
 #Preview("No data") {
     CurrentStatusCardView(status: CurrentStatusCardViewState(
         lastSleep: nil,
-        timeSinceLastFeedAt: nil,
+        lastBreastFeed: nil,
+        lastBottleFeed: nil,
         feedsTodayCount: 0,
-        timeSinceLastNappyAt: nil
+        lastNappy: nil
     ))
     .padding()
 }

--- a/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/CurrentStatusCardView.swift
+++ b/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/CurrentStatusCardView.swift
@@ -120,16 +120,9 @@ public struct CurrentStatusCardView: View {
     }
 
     private func relativeTimeText(for date: Date) -> some View {
-        TimelineView(.periodic(from: .now, by: 1)) { context in
-            Text(relativeText(for: date, relativeTo: Date()))
+        TimelineView(.everyMinute) { _ in
+            Text(ElapsedTimeFormatter.string(from: date))
         }
-    }
-
-    private func relativeText(
-        for date: Date,
-        relativeTo referenceDate: Date
-    ) -> String {
-        RelativeDateTimeFormatter().localizedString(for: date, relativeTo: referenceDate)
     }
 }
 

--- a/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/NappyEditorSheetView.swift
+++ b/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/NappyEditorSheetView.swift
@@ -8,9 +8,11 @@ public struct NappyEditorSheetView: View {
     let primaryActionTitle: String
     let childName: String
     let saveAction: (_ type: NappyType, _ occurredAt: Date, _ peeVolume: NappyVolume?, _ pooVolume: NappyVolume?, _ pooColor: PooColor?) -> Bool
+    let deleteAction: (() -> Void)?
 
     @Environment(\.dismiss) private var dismiss
     @State private var type: NappyTypeChoice
+    @State private var showDeleteConfirmation = false
     @State private var occurredAt: Date
     @State private var peeVolume: NappyVolumeChoice
     @State private var pooVolume: NappyVolumeChoice
@@ -27,11 +29,13 @@ public struct NappyEditorSheetView: View {
         initialPooVolume: NappyVolume?,
         initialPooColor: PooColor?,
         initialTimePreset: QuickTimeSelectorView.TimePreset = .now,
+        deleteAction: (() -> Void)? = nil,
         saveAction: @escaping (_ type: NappyType, _ occurredAt: Date, _ peeVolume: NappyVolume?, _ pooVolume: NappyVolume?, _ pooColor: PooColor?) -> Bool
     ) {
         self.navigationTitle = navigationTitle
         self.primaryActionTitle = primaryActionTitle
         self.childName = childName
+        self.deleteAction = deleteAction
         self.saveAction = saveAction
         _type = State(initialValue: NappyTypeChoice(type: initialType))
         _occurredAt = State(initialValue: initialOccurredAt)
@@ -84,6 +88,24 @@ public struct NappyEditorSheetView: View {
                         pooColorButtons
                     }
                 }
+
+                if deleteAction != nil {
+                    Section {
+                        Button("Delete Nappy", role: .destructive) {
+                            showDeleteConfirmation = true
+                        }
+                        .accessibilityIdentifier("delete-nappy-button")
+                    }
+                }
+            }
+            .alert("Delete Nappy?", isPresented: $showDeleteConfirmation) {
+                Button("Delete", role: .destructive) {
+                    deleteAction?()
+                    dismiss()
+                }
+                Button("Cancel", role: .cancel) {}
+            } message: {
+                Text("This event will be permanently removed.")
             }
             .tint(Self.eventColor)
             .scrollContentBackground(.hidden)

--- a/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/SleepEditorSheetView.swift
+++ b/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/SleepEditorSheetView.swift
@@ -14,6 +14,7 @@ public struct SleepEditorSheetView: View {
 
     @Environment(\.dismiss) private var dismiss
     @State private var startedAt: Date
+    @State private var showDeleteConfirmation = false
     @State private var endedAt: Date
     @State private var includesEndTime: Bool
 
@@ -70,15 +71,23 @@ public struct SleepEditorSheetView: View {
                     }
                 }
 
-                if let deleteAction {
+                if deleteAction != nil {
                     Section {
                         Button("Delete Sleep", role: .destructive) {
-                            deleteAction()
-                            dismiss()
+                            showDeleteConfirmation = true
                         }
                         .accessibilityIdentifier("delete-sleep-button")
                     }
                 }
+            }
+            .alert("Delete Sleep?", isPresented: $showDeleteConfirmation) {
+                Button("Delete", role: .destructive) {
+                    deleteAction?()
+                    dismiss()
+                }
+                Button("Cancel", role: .cancel) {}
+            } message: {
+                Text("This event will be permanently removed.")
             }
             .tint(Self.eventColor)
             .scrollContentBackground(.hidden)

--- a/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/SleepEditorSheetView.swift
+++ b/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/SleepEditorSheetView.swift
@@ -24,6 +24,7 @@ public struct SleepEditorSheetView: View {
         initialEndedAt: Date?,
         startSuggestions: [(label: String, date: Date)] = [],
         endTimeInitialPreset: QuickTimeSelectorView.TimePreset = .now,
+        initialIncludesEndTime: Bool = false,
         saveAction: @escaping (_ startedAt: Date, _ endedAt: Date?) -> Bool,
         deleteAction: (() -> Void)? = nil,
         resumeAction: (() -> Void)? = nil
@@ -37,7 +38,7 @@ public struct SleepEditorSheetView: View {
         self.endTimeInitialPreset = endTimeInitialPreset
         _startedAt = State(initialValue: initialStartedAt)
         _endedAt = State(initialValue: initialEndedAt ?? Date())
-        _includesEndTime = State(initialValue: mode != .start)
+        _includesEndTime = State(initialValue: mode != .start || initialIncludesEndTime)
     }
 
     public var body: some View {

--- a/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/SummaryScreenView.swift
+++ b/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/SummaryScreenView.swift
@@ -330,8 +330,10 @@ public struct SummaryScreenView: View {
                     .padding()
 
                     Button("Done") { showDatePicker = false }
+                        .frame(maxWidth: .infinity)
                         .padding(.bottom, 16)
                 }
+                .frame(width: 340, height: 420)
                 .presentationCompactAdaptation(.popover)
             }
 

--- a/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/SummaryScreenView.swift
+++ b/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/SummaryScreenView.swift
@@ -195,11 +195,30 @@ public struct SummaryScreenView: View {
     let viewModel: SummaryViewModel
 
     @State private var selectedTab: SummaryTab = .today
+    @State private var selectedDate: Date = .now
+    @State private var showDatePicker: Bool = false
     @State private var selectedTrendsRange: TrendsTimeRange = .sevenDays
     @State private var selectedNappyFilter: TodayNappyChartFilter = .all
     @State private var selectedBottleFilter: TodayBottleChartFilter = .all
     @State private var selectedTrendsNappyFilter: TrendsNappyChartFilter = .all
     @State private var selectedTrendsBottleFilter: TrendsBottleChartFilter = .all
+
+    private var isSelectedDateToday: Bool {
+        Calendar.autoupdatingCurrent.isDateInToday(selectedDate)
+    }
+
+    private var dateLabel: String {
+        if isSelectedDateToday {
+            return "Today"
+        } else if Calendar.autoupdatingCurrent.isDateInYesterday(selectedDate) {
+            return "Yesterday"
+        } else {
+            let formatter = DateFormatter()
+            formatter.dateStyle = .medium
+            formatter.timeStyle = .none
+            return formatter.string(from: selectedDate)
+        }
+    }
 
     public init(viewModel: SummaryViewModel) {
         self.viewModel = viewModel
@@ -242,7 +261,7 @@ public struct SummaryScreenView: View {
     // MARK: - Today Tab
 
     private var todayTabContent: some View {
-        let data = TodaySummaryCalculator.makeData(from: viewModel.events)
+        let data = TodaySummaryCalculator.makeData(from: viewModel.events, now: selectedDate)
 
         return Group {
             if viewModel.events.isEmpty {
@@ -252,6 +271,7 @@ public struct SummaryScreenView: View {
                 )
             } else {
                 VStack(alignment: .leading, spacing: 12) {
+                    dateNavigationRow
                     sleepSectionCard(data: data)
                     bottleSectionCard(data: data)
                     breastSectionCard(data: data)
@@ -261,6 +281,70 @@ public struct SummaryScreenView: View {
                 }
             }
         }
+    }
+
+    // MARK: - Date Navigation
+
+    private var dateNavigationRow: some View {
+        HStack(spacing: 0) {
+            Button {
+                let calendar = Calendar.autoupdatingCurrent
+                selectedDate = calendar.date(byAdding: .day, value: -1, to: selectedDate) ?? selectedDate
+            } label: {
+                Image(systemName: "chevron.left")
+                    .font(.body.weight(.semibold))
+                    .frame(width: 44, height: 36)
+                    .contentShape(Rectangle())
+            }
+
+            Spacer(minLength: 0)
+
+            Button {
+                showDatePicker = true
+            } label: {
+                HStack(spacing: 6) {
+                    Image(systemName: "calendar")
+                        .font(.subheadline)
+                    Text(dateLabel)
+                        .font(.subheadline.weight(.semibold))
+                }
+                .foregroundStyle(.primary)
+            }
+            .popover(isPresented: $showDatePicker) {
+                VStack(spacing: 0) {
+                    DatePicker(
+                        "Select date",
+                        selection: $selectedDate,
+                        in: ...Date.now,
+                        displayedComponents: .date
+                    )
+                    .datePickerStyle(.graphical)
+                    .padding()
+
+                    Button("Done") { showDatePicker = false }
+                        .padding(.bottom, 16)
+                }
+                .presentationCompactAdaptation(.popover)
+            }
+
+            Spacer(minLength: 0)
+
+            Button {
+                let calendar = Calendar.autoupdatingCurrent
+                if let next = calendar.date(byAdding: .day, value: 1, to: selectedDate), next <= .now {
+                    selectedDate = next
+                }
+            } label: {
+                Image(systemName: "chevron.right")
+                    .font(.body.weight(.semibold))
+                    .frame(width: 44, height: 36)
+                    .contentShape(Rectangle())
+            }
+            .disabled(isSelectedDateToday)
+        }
+        .padding(.horizontal, 8)
+        .padding(.vertical, 4)
+        .background(cardBackground)
     }
 
     // MARK: - Today Section Cards
@@ -326,12 +410,15 @@ public struct SummaryScreenView: View {
     }
 
     private func bottleFeedTimingRow(data: TodaySummaryData) -> some View {
-        let parts: [String] = [
-            data.minutesSinceLastFeed.map { "Last \(DurationText.short(minutes: $0)) ago" },
-            data.averageFeedIntervalMinutes.map { "Avg interval \(DurationText.short(minutes: $0))" },
-        ].compactMap { $0 }
-
-        guard !parts.isEmpty else { return Text("No bottle feeds today").font(.caption).foregroundStyle(.secondary) }
+        var parts: [String] = []
+        if isSelectedDateToday, let mins = data.minutesSinceLastFeed {
+            parts.append("Last \(DurationText.short(minutes: mins)) ago")
+        }
+        if let avg = data.averageFeedIntervalMinutes {
+            parts.append("Avg interval \(DurationText.short(minutes: avg))")
+        }
+        let noFeedsText = isSelectedDateToday ? "No bottle feeds today" : "No bottle feeds on this day"
+        guard !parts.isEmpty else { return Text(noFeedsText).font(.caption).foregroundStyle(.secondary) }
         return Text(parts.joined(separator: " • ")).font(.caption).foregroundStyle(.secondary)
     }
 
@@ -345,7 +432,7 @@ public struct SummaryScreenView: View {
             if data.breastFeedCount > 0 {
                 breastMetricsRow(data: data)
             } else {
-                Text("No breast feeds today")
+                Text(isSelectedDateToday ? "No breast feeds today" : "No breast feeds on this day")
                     .font(.caption)
                     .foregroundStyle(.secondary)
             }
@@ -374,7 +461,7 @@ public struct SummaryScreenView: View {
                 sleepSessionMetricsRow(data: data)
                 sleepTimingRow(data: data)
             } else {
-                Text("No sleep logged today")
+                Text(isSelectedDateToday ? "No sleep logged today" : "No sleep logged on this day")
                     .font(.caption)
                     .foregroundStyle(.secondary)
             }
@@ -398,7 +485,7 @@ public struct SummaryScreenView: View {
 
     private func sleepTimingRow(data: TodaySummaryData) -> some View {
         Group {
-            if let mins = data.minutesSinceLastSleep {
+            if isSelectedDateToday, let mins = data.minutesSinceLastSleep {
                 Text("Last sleep \(DurationText.short(minutes: mins)) ago")
                     .font(.caption)
                     .foregroundStyle(.secondary)
@@ -427,7 +514,7 @@ public struct SummaryScreenView: View {
             if data.totalNappies > 0 {
                 nappyBreakdownRow(data: data)
             } else {
-                Text("No nappy changes today")
+                Text(isSelectedDateToday ? "No nappy changes today" : "No nappy changes on this day")
                     .font(.caption)
                     .foregroundStyle(.secondary)
             }
@@ -706,7 +793,9 @@ public struct SummaryScreenView: View {
         NavigationLink {
             AdvancedSummaryView(
                 viewModel: viewModel,
-                initialSelection: .range(selectedTrendsRange.asSummaryTimeRange)
+                initialSelection: isSelectedDateToday
+                    ? .range(selectedTrendsRange.asSummaryTimeRange)
+                    : .day(selectedDate)
             )
         } label: {
             HStack(alignment: .center, spacing: 12) {

--- a/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/SummaryScreenView.swift
+++ b/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/SummaryScreenView.swift
@@ -116,11 +116,15 @@ private enum TrendsNappyChartFilter: String, TodayChartFilter {
     }
 
     func averageText(from data: [DailyNappyData]) -> String? {
+        guard let average = averageValue(from: data) else { return nil }
+        return "Avg \(average)/day"
+    }
+
+    func averageValue(from data: [DailyNappyData]) -> Int? {
         let values = data.map(count(for:))
         let nonZeroValues = values.filter { $0 > 0 }
         guard !nonZeroValues.isEmpty else { return nil }
-        let average = Int((Double(nonZeroValues.reduce(0, +)) / Double(nonZeroValues.count)).rounded())
-        return "Avg \(average)/day"
+        return Int((Double(nonZeroValues.reduce(0, +)) / Double(nonZeroValues.count)).rounded())
     }
 
     private func count(for day: DailyNappyData) -> Int {
@@ -172,11 +176,15 @@ private enum TrendsBottleChartFilter: String, TodayChartFilter {
     }
 
     func averageText(from data: [DailyBottleData], unit: FeedVolumeUnit) -> String? {
+        guard let average = averageValue(from: data) else { return nil }
+        return "Avg \(FeedVolumePresentation.perDayText(for: average, unit: unit))"
+    }
+
+    func averageValue(from data: [DailyBottleData]) -> Int? {
         let values = data.map(value(for:))
         let nonZeroValues = values.filter { $0 > 0 }
         guard !nonZeroValues.isEmpty else { return nil }
-        let average = Int((Double(nonZeroValues.reduce(0, +)) / Double(nonZeroValues.count)).rounded())
-        return "Avg \(FeedVolumePresentation.perDayText(for: average, unit: unit))"
+        return Int((Double(nonZeroValues.reduce(0, +)) / Double(nonZeroValues.count)).rounded())
     }
 
     private func value(for day: DailyBottleData) -> Int {
@@ -533,6 +541,7 @@ public struct SummaryScreenView: View {
         let preferredUnit = viewModel.preferredFeedVolumeUnit
         let points = selectedTrendsBottleFilter.points(from: data.dailyBottle)
         let avgText = selectedTrendsBottleFilter.averageText(from: data.dailyBottle, unit: preferredUnit)
+        let avgValue = selectedTrendsBottleFilter.averageValue(from: data.dailyBottle)
 
         return chartCard(
             title: "Bottle Feeds",
@@ -551,7 +560,8 @@ public struct SummaryScreenView: View {
                 tint: selectedTrendsBottleFilter.tint,
                 valueFormatter: { value in
                     FeedVolumePresentation.amountText(for: value, unit: preferredUnit)
-                }
+                },
+                averageValue: avgValue
             )
         }
     }
@@ -566,7 +576,11 @@ public struct SummaryScreenView: View {
             tint: .pink,
             subtitle: avgText ?? "No breast feeds in this period"
         ) {
-            TrendsBarChartView(points: points, tint: .pink)
+            TrendsBarChartView(
+                points: points,
+                tint: .pink,
+                averageValue: data.avgDailyBreastFeedSessions
+            )
         }
     }
 
@@ -580,12 +594,18 @@ public struct SummaryScreenView: View {
             tint: .indigo,
             subtitle: avgText ?? "No sleep logged in this period"
         ) {
-            TrendsBarChartView(points: points, tint: .indigo, valueFormatter: { DurationText.short(minutes: $0) })
+            TrendsBarChartView(
+                points: points,
+                tint: .indigo,
+                valueFormatter: { DurationText.short(minutes: $0) },
+                averageValue: data.avgDailySleepMinutes
+            )
         }
     }
 
     private func nappyChartCard(data: TrendsSummaryData) -> some View {
         let avgText = selectedTrendsNappyFilter.averageText(from: data.dailyNappy)
+        let avgValue = selectedTrendsNappyFilter.averageValue(from: data.dailyNappy)
 
         return chartCard(
             title: "Nappies",
@@ -600,11 +620,12 @@ public struct SummaryScreenView: View {
             }
         ) {
             if selectedTrendsNappyFilter == .all {
-                TrendsNappyChartView(data: data.dailyNappy)
+                TrendsNappyChartView(data: data.dailyNappy, averageValue: avgValue)
             } else {
                 TrendsBarChartView(
                     points: selectedTrendsNappyFilter.points(from: data.dailyNappy),
-                    tint: selectedTrendsNappyFilter.tint
+                    tint: selectedTrendsNappyFilter.tint,
+                    averageValue: avgValue
                 )
             }
         }

--- a/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/TimelineDayGridPageView.swift
+++ b/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/TimelineDayGridPageView.swift
@@ -80,7 +80,7 @@ public struct TimelineDayGridPageView: View {
         let visibleHour = page.isToday ? calendar.component(.hour, from: .now) : 6
 
         DispatchQueue.main.async {
-            proxy.scrollTo("timeline-day-grid-hour-\(visibleHour)", anchor: .top)
+            proxy.scrollTo("timeline-day-grid-hour-\(visibleHour)", anchor: .bottom)
         }
     }
 }

--- a/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/TrendsBarChartView.swift
+++ b/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/TrendsBarChartView.swift
@@ -9,6 +9,7 @@ struct TrendsBarChartView: View {
     let points: [(String, Int)]
     let tint: Color
     var valueFormatter: ((Int) -> String)? = nil
+    var averageValue: Int? = nil
 
     @State private var selectedKey: String?
 
@@ -35,6 +36,17 @@ struct TrendsBarChartView: View {
                             .foregroundStyle(.secondary)
                     }
                 }
+            }
+
+            if let avg = averageValue {
+                RuleMark(y: .value("Average", avg))
+                    .foregroundStyle(.orange.opacity(0.8))
+                    .lineStyle(StrokeStyle(lineWidth: 1.5, dash: [5, 3]))
+                    .annotation(position: .top, alignment: .trailing, spacing: 2) {
+                        Text("Avg")
+                            .font(.system(size: 9).weight(.medium))
+                            .foregroundStyle(.orange.opacity(0.9))
+                    }
             }
 
             if let selectedPoint {
@@ -91,7 +103,9 @@ struct TrendsBarChartView: View {
     }
 
     private var yAxisUpperBound: Int {
-        TrendsChartLayout.yDomainUpperBound(for: points.map(\.1))
+        var values = points.map(\.1)
+        if let avg = averageValue { values.append(avg) }
+        return TrendsChartLayout.yDomainUpperBound(for: values)
     }
 }
 

--- a/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/TrendsNappyChartView.swift
+++ b/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/TrendsNappyChartView.swift
@@ -7,6 +7,7 @@ import SwiftUI
 /// for that day. The chart generates its own legend.
 struct TrendsNappyChartView: View {
     let data: [DailyNappyData]
+    var averageValue: Int? = nil
 
     @State private var selectedKey: String?
 
@@ -23,6 +24,17 @@ struct TrendsNappyChartView: View {
                 )
                 .foregroundStyle(by: .value("Type", segment.type))
                 .opacity(selectedKey == nil || selectedKey == segment.dayKey ? 1 : 0.3)
+            }
+
+            if let avg = averageValue {
+                RuleMark(y: .value("Average", avg))
+                    .foregroundStyle(.orange.opacity(0.8))
+                    .lineStyle(StrokeStyle(lineWidth: 1.5, dash: [5, 3]))
+                    .annotation(position: .top, alignment: .trailing, spacing: 2) {
+                        Text("Avg")
+                            .font(.system(size: 9).weight(.medium))
+                            .foregroundStyle(.orange.opacity(0.9))
+                    }
             }
 
             if let selectedDay {
@@ -101,7 +113,9 @@ struct TrendsNappyChartView: View {
     }
 
     private var yAxisUpperBound: Int {
-        TrendsChartLayout.yDomainUpperBound(for: data.map(\.totalCount))
+        var values = data.map(\.totalCount)
+        if let avg = averageValue { values.append(avg) }
+        return TrendsChartLayout.yDomainUpperBound(for: values)
     }
 }
 

--- a/Packages/BabyTrackerFeature/Tests/BabyTrackerFeatureTests/ElapsedTimeFormatterTests.swift
+++ b/Packages/BabyTrackerFeature/Tests/BabyTrackerFeatureTests/ElapsedTimeFormatterTests.swift
@@ -1,0 +1,39 @@
+@testable import BabyTrackerFeature
+import Foundation
+import Testing
+
+struct ElapsedTimeFormatterTests {
+    @Test func justNow_whenUnderOneMinute() {
+        let date = Date().addingTimeInterval(-30)
+        #expect(ElapsedTimeFormatter.string(from: date) == "just now")
+    }
+
+    @Test func justNow_whenExactlyNow() {
+        #expect(ElapsedTimeFormatter.string(from: Date()) == "just now")
+    }
+
+    @Test func minutesOnly_whenUnderOneHour() {
+        let date = Date().addingTimeInterval(-45 * 60)
+        #expect(ElapsedTimeFormatter.string(from: date) == "45 mins ago")
+    }
+
+    @Test func singularMinute() {
+        let date = Date().addingTimeInterval(-60)
+        #expect(ElapsedTimeFormatter.string(from: date) == "1 min ago")
+    }
+
+    @Test func hoursAndMinutes() {
+        let date = Date().addingTimeInterval(-(90 * 60))
+        #expect(ElapsedTimeFormatter.string(from: date) == "1 hr 30 mins ago")
+    }
+
+    @Test func hoursOnly_whenExactHours() {
+        let date = Date().addingTimeInterval(-(2 * 60 * 60))
+        #expect(ElapsedTimeFormatter.string(from: date) == "2 hrs ago")
+    }
+
+    @Test func singularHour_withMinutes() {
+        let date = Date().addingTimeInterval(-(61 * 60))
+        #expect(ElapsedTimeFormatter.string(from: date) == "1 hr 1 min ago")
+    }
+}

--- a/docs/plans/081-log-past-sleep-while-active.md
+++ b/docs/plans/081-log-past-sleep-while-active.md
@@ -1,0 +1,38 @@
+# 081 – Log a past sleep while a sleep is active
+
+## Goal
+
+Allow users to log a completed past sleep (with explicit start and end time) even when another sleep is currently in progress. Fixes the limitation reported in GitHub issue #205.
+
+## Background
+
+When a sleep is active, tapping the Quick Log sleep button shows the "End Sleep" sheet, which only allows ending the current active sleep. There is no path to log a missed nap or previous sleep session until the active sleep ends.
+
+The domain layer (`LogSleepUseCase`) already supports logging a completed sleep without checking for an active session. The fix is entirely in the presentation layer.
+
+## Approach
+
+1. **`SleepEditorSheetView`** – Add an `initialIncludesEndTime` parameter so the "Already ended?" toggle can be pre-checked when opening the sheet in `.start` mode.
+
+2. **`ChildEventSheet`** – Add a `.logPastSleep(suggestions:)` case that represents opening the log-past-sleep sheet.
+
+3. **`CurrentSleepCardView`** – Add a `logPastSleep` callback and a "Log a past sleep" secondary button below the active sleep timer, visible only while a sleep is running.
+
+4. **`ChildHomeView`** – Propagate the new `logPastSleep` closure down to `CurrentSleepCardView`.
+
+5. **`ChildWorkspaceTabView`** – Wire `logPastSleep` to set `activeEventSheet = .logPastSleep(suggestions:)`, and handle the new sheet case by opening `SleepEditorSheetView` in `.start` mode with `initialIncludesEndTime: true`, calling `model.logSleep` on save.
+
+## What is not changed
+
+- `LogSleepUseCase` – already correct; no active-sleep guard.
+- `StartSleepUseCase` – existing guard remains; this is a separate code path.
+- The active sleep timer is unaffected.
+
+## Tests
+
+Added `logPastSleepSucceedsWhileAnotherSleepIsActive` to `AppModelTests` to verify:
+- `logSleep` succeeds while an active sleep exists
+- The active sleep is still present after the call
+- Both sleep records exist in the repository
+
+- [x] Complete

--- a/docs/plans/081-merge-prs-211-through-217.md
+++ b/docs/plans/081-merge-prs-211-through-217.md
@@ -1,0 +1,15 @@
+# 081 Merge PRs 211 Through 217
+
+## Goal
+
+Merge pull requests 217, 216, 215, 214, 213, 212, and 211 into the current local branch and resolve any merge conflicts so the branch is left in a buildable, testable state.
+
+## Approach
+
+1. Fetch each pull request branch locally from the remote repository.
+2. Merge the PRs into the current branch one at a time in the requested order.
+3. Resolve merge conflicts as they appear, favoring the simplest clear integration that preserves intended behavior from both sides.
+4. Run targeted verification after conflict resolution and broader verification once all merges are complete.
+5. Update this plan to reflect completion once the branch is fully integrated and verified.
+
+- [x] Complete

--- a/docs/plans/082-summary-today-date-picker-layout-fix.md
+++ b/docs/plans/082-summary-today-date-picker-layout-fix.md
@@ -1,0 +1,15 @@
+# 082 Summary Today Date Picker Layout Fix
+
+## Goal
+
+Fix the squashed day picker shown from the Today tab on the Summary screen so the date picker presents at a readable, usable size.
+
+## Approach
+
+1. Inspect the current Today tab date picker presentation in `SummaryScreenView`.
+2. Update the popover content to use an explicit container size that suits the graphical date picker on iPhone.
+3. Run the relevant unit test plan to confirm the screen still builds after the layout change.
+
+Tiny UI polish only, so no GitHub issue is needed for this change.
+
+- [x] Complete


### PR DESCRIPTION
## Summary
- merge the work from PRs #211 through #217 into `feature/multiple-features`
- apply the post-merge integration fix from `b1f7a28`
- fix the squished day picker popover on the Summary Today tab in `7e90746`

## Plans
- `docs/plans/081-merge-prs-211-through-217.md`
- `docs/plans/082-summary-today-date-picker-layout-fix.md`

## Notes
- This PR supersedes #211, #212, #213, #214, #215, #216, and #217.
- No separate GitHub issue was created for the date picker layout tweak because it was a small follow-up fix on the merged branch.
