### PR TITLE
Fix daily chart showing only current hour when viewing previous days

### DIFF
--- a/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/CumulativeLineChartView.swift
+++ b/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/CumulativeLineChartView.swift
@@ -11,6 +11,7 @@ import SwiftUI
 struct CumulativeLineChartView: View {
     let series: HourlyCumulativeSeries
     let tint: Color
+    let isToday: Bool
     let valueFormatter: (Int) -> String
 
     @State private var selectedHour: Int?
@@ -18,10 +19,12 @@ struct CumulativeLineChartView: View {
     init(
         series: HourlyCumulativeSeries,
         tint: Color,
+        isToday: Bool = true,
         valueFormatter: @escaping (Int) -> String = { "\($0)" }
     ) {
         self.series = series
         self.tint = tint
+        self.isToday = isToday
         self.valueFormatter = valueFormatter
     }
 
@@ -53,19 +56,21 @@ struct CumulativeLineChartView: View {
                 .lineStyle(StrokeStyle(lineWidth: 2, lineCap: .round, lineJoin: .round))
             }
 
-            // "Now" indicator — always visible; selection callout renders on top due to mark order.
-            RuleMark(x: .value("Now", currentHour))
-                .foregroundStyle(tint.opacity(0.25))
-                .lineStyle(StrokeStyle(lineWidth: 1))
-                .annotation(position: .top, alignment: .center, spacing: 4) {
-                    Text("Now")
-                        .font(.caption2)
-                        .fontWeight(.medium)
-                        .foregroundStyle(tint)
-                        .padding(.horizontal, 5)
-                        .padding(.vertical, 2)
-                        .background(tint.opacity(0.12), in: Capsule())
-                }
+            // "Now" indicator — only shown for today; selection callout renders on top due to mark order.
+            if isToday {
+                RuleMark(x: .value("Now", currentHour))
+                    .foregroundStyle(tint.opacity(0.25))
+                    .lineStyle(StrokeStyle(lineWidth: 1))
+                    .annotation(position: .top, alignment: .center, spacing: 4) {
+                        Text("Now")
+                            .font(.caption2)
+                            .fontWeight(.medium)
+                            .foregroundStyle(tint)
+                            .padding(.horizontal, 5)
+                            .padding(.vertical, 2)
+                            .background(tint.opacity(0.12), in: Capsule())
+                    }
+            }
 
             // Selection indicator — rendered after "Now" so it draws on top.
             if let hour = selectedHour, hour >= 0, hour < 24 {
@@ -119,9 +124,10 @@ struct CumulativeLineChartView: View {
     }
 
     private var todayPoints: [HourPoint] {
-        series.todayCumulative
+        let hourLimit = isToday ? currentHour + 1 : 24
+        return series.todayCumulative
             .enumerated()
-            .prefix(currentHour + 1)
+            .prefix(hourLimit)
             .map { HourPoint(id: $0, hour: $0, value: $1) }
     }
 
@@ -137,7 +143,7 @@ struct CumulativeLineChartView: View {
         let todayVal = series.todayCumulative[hour]
         let avgVal = series.averageCumulative[hour]
         return VStack(alignment: .leading, spacing: 2) {
-            if hour <= currentHour {
+            if !isToday || hour <= currentHour {
                 Text("Today: \(valueFormatter(todayVal))").foregroundStyle(tint)
             }
             Text("Avg: \(valueFormatter(avgVal))").foregroundStyle(.secondary)

--- a/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/SummaryScreenView.swift
+++ b/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/SummaryScreenView.swift
@@ -389,6 +389,7 @@ public struct SummaryScreenView: View {
             CumulativeLineChartView(
                 series: selectedBottleFilter.series(from: data.chartData),
                 tint: .blue,
+                isToday: isSelectedDateToday,
                 valueFormatter: { value in
                     FeedVolumePresentation.amountText(for: value, unit: preferredUnit)
                 }
@@ -447,7 +448,7 @@ public struct SummaryScreenView: View {
                     .foregroundStyle(.secondary)
             }
 
-            CumulativeLineChartView(series: data.chartData.breast, tint: .pink)
+            CumulativeLineChartView(series: data.chartData.breast, tint: .pink, isToday: isSelectedDateToday)
                 .padding(.top, 4)
         }
     }
@@ -476,7 +477,7 @@ public struct SummaryScreenView: View {
                     .foregroundStyle(.secondary)
             }
 
-            CumulativeLineChartView(series: data.chartData.sleep, tint: .indigo)
+            CumulativeLineChartView(series: data.chartData.sleep, tint: .indigo, isToday: isSelectedDateToday)
                 .padding(.top, 4)
         }
     }
@@ -529,7 +530,7 @@ public struct SummaryScreenView: View {
                     .foregroundStyle(.secondary)
             }
 
-            CumulativeLineChartView(series: selectedNappyFilter.series(from: data.chartData), tint: .green)
+            CumulativeLineChartView(series: selectedNappyFilter.series(from: data.chartData), tint: .green, isToday: isSelectedDateToday)
                 .padding(.top, 4)
         }
         .frame(maxWidth: .infinity, alignment: .leading)


### PR DESCRIPTION
CumulativeLineChartView was always using Date() to cap the visible data
at the current system hour, so charts for past days were truncated at
today's hour instead of showing the full 24 hours.

Added an isToday parameter (default true) to the chart view. When false,
all 24 hours are rendered and the "Now" rule mark is hidden. All four
call sites in SummaryScreenView now pass isSelectedDateToday.

https://claude.ai/code/session_017Cczi387vJyduYhswUU1av