### PR TITLE
Hide avg line until user interacts with charts

### DIFF
--- a/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/CumulativeLineChartView.swift
+++ b/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/CumulativeLineChartView.swift
@@ -27,18 +27,20 @@ struct CumulativeLineChartView: View {
 
     var body: some View {
         Chart {
-            // 7-day average — dashed, secondary, full 24 hours
+            // 7-day average — dashed, secondary, full 24 hours; only shown while interacting.
             // series: groups all 24 marks into one continuous line so the
             // dash pattern is applied across the whole series, not per segment.
-            ForEach(averagePoints) { point in
-                LineMark(
-                    x: .value("Hour", point.hour),
-                    y: .value("7-Day Avg", point.value),
-                    series: .value("Series", "average")
-                )
-                .interpolationMethod(.monotone)
-                .foregroundStyle(Color.secondary.opacity(0.6))
-                .lineStyle(StrokeStyle(lineWidth: 1.5, dash: [5, 3]))
+            if selectedHour != nil {
+                ForEach(averagePoints) { point in
+                    LineMark(
+                        x: .value("Hour", point.hour),
+                        y: .value("7-Day Avg", point.value),
+                        series: .value("Series", "average")
+                    )
+                    .interpolationMethod(.monotone)
+                    .foregroundStyle(Color.secondary.opacity(0.6))
+                    .lineStyle(StrokeStyle(lineWidth: 1.5, dash: [5, 3]))
+                }
             }
 
             // Today — solid, tinted, stops at the current hour

--- a/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/TrendsBarChartView.swift
+++ b/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/TrendsBarChartView.swift
@@ -38,7 +38,7 @@ struct TrendsBarChartView: View {
                 }
             }
 
-            if let avg = averageValue {
+            if let avg = averageValue, selectedKey != nil {
                 RuleMark(y: .value("Average", avg))
                     .foregroundStyle(.orange.opacity(0.8))
                     .lineStyle(StrokeStyle(lineWidth: 1.5, dash: [5, 3]))

--- a/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/TrendsNappyChartView.swift
+++ b/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/TrendsNappyChartView.swift
@@ -26,7 +26,7 @@ struct TrendsNappyChartView: View {
                 .opacity(selectedKey == nil || selectedKey == segment.dayKey ? 1 : 0.3)
             }
 
-            if let avg = averageValue {
+            if let avg = averageValue, selectedKey != nil {
                 RuleMark(y: .value("Average", avg))
                     .foregroundStyle(.orange.opacity(0.8))
                     .lineStyle(StrokeStyle(lineWidth: 1.5, dash: [5, 3]))


### PR DESCRIPTION
Show the average line (RuleMark in Trends charts, dashed LineMark in Today
cumulative charts) only when a selection is active, so it appears on touch
and disappears when the user lifts their finger.

https://claude.ai/code/session_01F4RXKk6mkafB9AAu9dskj2