### PR TITLE
Add data drift reminder notifications for sleep and inactivity

### DIFF
--- a/Baby Tracker/App/SystemLocalNotificationManager.swift
+++ b/Baby Tracker/App/SystemLocalNotificationManager.swift
@@ -39,10 +39,7 @@ final class SystemLocalNotificationManager: NSObject, LocalNotificationManaging 
     }
 
     func scheduleRemoteSyncNotification(_ content: RemoteCaregiverNotificationContent) async {
-        let settings = await notificationCenter.notificationSettings()
-        guard settings.authorizationStatus == .authorized || settings.authorizationStatus == .provisional else {
-            return
-        }
+        guard await isAuthorized() else { return }
 
         let notificationContent = UNMutableNotificationContent()
         notificationContent.title = content.title
@@ -56,6 +53,59 @@ final class SystemLocalNotificationManager: NSObject, LocalNotificationManaging 
         )
 
         try? await notificationCenter.add(request)
+    }
+
+    func scheduleSleepDriftNotification(childID: UUID, childName: String, fireAfter: TimeInterval) async {
+        guard await isAuthorized() else { return }
+
+        let content = UNMutableNotificationContent()
+        content.title = "Still sleeping?"
+        content.body = "\(childName) has been asleep longer than usual. Tap to check."
+        content.sound = .default
+
+        let id = sleepDriftIdentifier(childID: childID)
+        let trigger = UNTimeIntervalNotificationTrigger(timeInterval: max(1, fireAfter), repeats: false)
+        let request = UNNotificationRequest(identifier: id, content: content, trigger: trigger)
+        notificationCenter.removePendingNotificationRequests(withIdentifiers: [id])
+        try? await notificationCenter.add(request)
+    }
+
+    func cancelSleepDriftNotification(childID: UUID) async {
+        notificationCenter.removePendingNotificationRequests(withIdentifiers: [sleepDriftIdentifier(childID: childID)])
+    }
+
+    func scheduleInactivityDriftNotification(childID: UUID, childName: String, fireAfter: TimeInterval) async {
+        guard await isAuthorized() else { return }
+
+        let content = UNMutableNotificationContent()
+        content.title = "Anything to log for \(childName)?"
+        content.body = "It's been a while since the last recorded event. Did you forget to log something?"
+        content.sound = .default
+
+        let id = inactivityDriftIdentifier(childID: childID)
+        let trigger = UNTimeIntervalNotificationTrigger(timeInterval: max(1, fireAfter), repeats: false)
+        let request = UNNotificationRequest(identifier: id, content: content, trigger: trigger)
+        notificationCenter.removePendingNotificationRequests(withIdentifiers: [id])
+        try? await notificationCenter.add(request)
+    }
+
+    func cancelInactivityDriftNotification(childID: UUID) async {
+        notificationCenter.removePendingNotificationRequests(withIdentifiers: [inactivityDriftIdentifier(childID: childID)])
+    }
+
+    // MARK: - Private helpers
+
+    private func isAuthorized() async -> Bool {
+        let settings = await notificationCenter.notificationSettings()
+        return settings.authorizationStatus == .authorized || settings.authorizationStatus == .provisional
+    }
+
+    private func sleepDriftIdentifier(childID: UUID) -> String {
+        "drift.sleep.\(childID.uuidString)"
+    }
+
+    private func inactivityDriftIdentifier(childID: UUID) -> String {
+        "drift.inactivity.\(childID.uuidString)"
     }
 }
 

--- a/Baby Tracker/App/SystemLocalNotificationManager.swift
+++ b/Baby Tracker/App/SystemLocalNotificationManager.swift
@@ -62,6 +62,7 @@ final class SystemLocalNotificationManager: NSObject, LocalNotificationManaging 
         content.title = "Still sleeping?"
         content.body = "\(childName) has been asleep longer than usual. Tap to check."
         content.sound = .default
+        content.userInfo = ["childID": childID.uuidString, "childName": childName, "kind": "sleep"]
 
         let id = sleepDriftIdentifier(childID: childID)
         let trigger = UNTimeIntervalNotificationTrigger(timeInterval: max(1, fireAfter), repeats: false)
@@ -81,6 +82,7 @@ final class SystemLocalNotificationManager: NSObject, LocalNotificationManaging 
         content.title = "Anything to log for \(childName)?"
         content.body = "It's been a while since the last recorded event. Did you forget to log something?"
         content.sound = .default
+        content.userInfo = ["childID": childID.uuidString, "childName": childName, "kind": "inactivity"]
 
         let id = inactivityDriftIdentifier(childID: childID)
         let trigger = UNTimeIntervalNotificationTrigger(timeInterval: max(1, fireAfter), repeats: false)
@@ -91,6 +93,30 @@ final class SystemLocalNotificationManager: NSObject, LocalNotificationManaging 
 
     func cancelInactivityDriftNotification(childID: UUID) async {
         notificationCenter.removePendingNotificationRequests(withIdentifiers: [inactivityDriftIdentifier(childID: childID)])
+    }
+
+    func pendingDriftNotifications() async -> [PendingDriftNotification] {
+        let requests = await notificationCenter.pendingNotificationRequests()
+        return requests.compactMap { request -> PendingDriftNotification? in
+            guard request.identifier.hasPrefix("drift."),
+                  let trigger = request.trigger as? UNTimeIntervalNotificationTrigger,
+                  let fireDate = trigger.nextTriggerDate(),
+                  let kindRaw = request.content.userInfo["kind"] as? String,
+                  let childIDString = request.content.userInfo["childID"] as? String,
+                  let childID = UUID(uuidString: childIDString),
+                  let childName = request.content.userInfo["childName"] as? String
+            else { return nil }
+
+            let kind: PendingDriftNotification.Kind = kindRaw == "sleep" ? .sleep : .inactivity
+            return PendingDriftNotification(
+                id: request.identifier,
+                kind: kind,
+                childID: childID,
+                childName: childName,
+                fireDate: fireDate
+            )
+        }
+        .sorted { $0.fireDate < $1.fireDate }
     }
 
     // MARK: - Private helpers

--- a/Packages/BabyTrackerDomain/Sources/BabyTrackerDomain/UseCases/CalculateInactivityDriftThresholdUseCase.swift
+++ b/Packages/BabyTrackerDomain/Sources/BabyTrackerDomain/UseCases/CalculateInactivityDriftThresholdUseCase.swift
@@ -1,0 +1,50 @@
+import Foundation
+
+public struct CalculateInactivityDriftThresholdUseCase {
+    public static let defaultThreshold: TimeInterval = 4 * 60 * 60
+
+    public struct Input {
+        /// All non-deleted events for the child (any order — sorted internally).
+        public let events: [BabyEvent]
+        /// Number of most-recent gaps to average.
+        public let windowSize: Int
+
+        public init(events: [BabyEvent], windowSize: Int = 20) {
+            self.events = events
+            self.windowSize = windowSize
+        }
+    }
+
+    public init() {}
+
+    /// Returns the time interval after the last event at which to fire an inactivity notification.
+    public func execute(_ input: Input) -> TimeInterval {
+        let times = input.events
+            .map(\.metadata.occurredAt)
+            .sorted()
+
+        guard times.count >= 4 else {
+            return Self.defaultThreshold
+        }
+
+        var gaps: [TimeInterval] = []
+        for i in 1..<times.count {
+            let gap = times[i].timeIntervalSince(times[i - 1])
+            // Ignore sub-minute duplicates and overnight gaps (>12h) that aren't
+            // representative of normal waking-hours logging cadence
+            guard gap > 60, gap < 12 * 60 * 60 else { continue }
+            gaps.append(gap)
+        }
+
+        guard gaps.count >= 3 else {
+            return Self.defaultThreshold
+        }
+
+        let recent = Array(gaps.suffix(input.windowSize))
+        let average = recent.reduce(0, +) / Double(recent.count)
+
+        // 2x average gives one full "expected next event window" of grace before nudging
+        let threshold = min(average * 2.0, 8 * 60 * 60)
+        return max(threshold, 60 * 60)
+    }
+}

--- a/Packages/BabyTrackerDomain/Sources/BabyTrackerDomain/UseCases/CalculateSleepDriftThresholdUseCase.swift
+++ b/Packages/BabyTrackerDomain/Sources/BabyTrackerDomain/UseCases/CalculateSleepDriftThresholdUseCase.swift
@@ -1,0 +1,45 @@
+import Foundation
+
+public struct CalculateSleepDriftThresholdUseCase {
+    public static let defaultThreshold: TimeInterval = 3 * 60 * 60
+
+    public struct Input {
+        /// Completed sleep events in any order — sorted internally by end date.
+        public let completedSleepEvents: [SleepEvent]
+        /// Number of most-recent sessions to average.
+        public let windowSize: Int
+
+        public init(completedSleepEvents: [SleepEvent], windowSize: Int = 10) {
+            self.completedSleepEvents = completedSleepEvents
+            self.windowSize = windowSize
+        }
+    }
+
+    public init() {}
+
+    /// Returns the duration after sleep start at which to fire a drift notification.
+    public func execute(_ input: Input) -> TimeInterval {
+        let durations: [TimeInterval] = input.completedSleepEvents
+            .compactMap { sleep -> (endedAt: Date, duration: TimeInterval)? in
+                guard let ended = sleep.endedAt else { return nil }
+                let d = ended.timeIntervalSince(sleep.startedAt)
+                // Discard sub-5-minute naps (likely accidental) and 14h+ sessions (likely errors)
+                guard d >= 300, d <= 50_400 else { return nil }
+                return (ended, d)
+            }
+            .sorted { $0.endedAt > $1.endedAt }
+            .prefix(input.windowSize)
+            .map(\.duration)
+
+        guard durations.count >= 3 else {
+            return Self.defaultThreshold
+        }
+
+        let average = durations.reduce(0, +) / Double(durations.count)
+
+        // 20% buffer above average; cap at 6h to prevent outliers from creating excessive silence
+        let threshold = min(average * 1.20, 6 * 60 * 60)
+        // Always fire at least 30 minutes past the average
+        return max(threshold, average + 30 * 60)
+    }
+}

--- a/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/AppModel.swift
+++ b/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/AppModel.swift
@@ -114,6 +114,7 @@ public final class AppModel {
 
     public func load(performLaunchSync: Bool = true) {
         refresh(selecting: nil)
+        rescheduleAllDriftNotifications()
 
         guard performLaunchSync else {
             return
@@ -631,7 +632,7 @@ public final class AppModel {
 
     @discardableResult
     public func startSleep(startedAt: Date) -> Bool {
-        perform(onSuccess: handleSuccessfulEventLog) {
+        let succeeded = perform(onSuccess: handleSuccessfulEventLog) {
             guard let currentChild, let currentMembership else { throw ChildProfileValidationError.insufficientPermissions }
             guard let localUser else { throw ChildProfileValidationError.insufficientPermissions }
             _ = try StartSleepUseCase(
@@ -645,6 +646,10 @@ public final class AppModel {
                     membership: currentMembership
                 ))
         }
+        if succeeded {
+            scheduleSleepDriftNotificationIfNeeded()
+        }
+        return succeeded
     }
 
     @discardableResult
@@ -672,7 +677,7 @@ public final class AppModel {
         startedAt: Date,
         endedAt: Date
     ) -> Bool {
-        perform {
+        let succeeded = perform {
             guard let currentMembership else { throw ChildProfileValidationError.insufficientPermissions }
             guard let localUser else { throw ChildProfileValidationError.insufficientPermissions }
             _ = try EndSleepUseCase(
@@ -687,6 +692,11 @@ public final class AppModel {
                     membership: currentMembership
                 ))
         }
+        if succeeded {
+            cancelSleepDriftNotification()
+            scheduleInactivityDriftNotificationIfNeeded()
+        }
+        return succeeded
     }
 
     @discardableResult
@@ -819,7 +829,7 @@ public final class AppModel {
 
     @discardableResult
     public func resumeSleep(id: UUID, startedAt: Date) -> Bool {
-        perform {
+        let succeeded = perform {
             guard let currentMembership else { throw ChildProfileValidationError.insufficientPermissions }
             guard let localUser else { throw ChildProfileValidationError.insufficientPermissions }
             _ = try ResumeSleepUseCase(
@@ -833,6 +843,11 @@ public final class AppModel {
                     membership: currentMembership
                 ))
         }
+        if succeeded {
+            cancelSleepDriftNotification()
+            scheduleSleepDriftNotificationIfNeeded()
+        }
+        return succeeded
     }
 
     @discardableResult
@@ -898,11 +913,62 @@ public final class AppModel {
         )
         .execute(.init(minimumLoggedEventsBeforePrompt: 5))
 
-        guard shouldRequestReview else {
-            return
+        if shouldRequestReview {
+            appReviewRequester.requestReview()
         }
 
-        appReviewRequester.requestReview()
+        scheduleInactivityDriftNotificationIfNeeded()
+    }
+
+    private func scheduleSleepDriftNotificationIfNeeded() {
+        guard let child = currentChild, let activeSleep else { return }
+        let completedSleeps = events
+            .compactMap { event -> SleepEvent? in
+                guard case let .sleep(s) = event, s.endedAt != nil else { return nil }
+                return s
+            }
+            .sorted { ($0.endedAt ?? $0.startedAt) > ($1.endedAt ?? $1.startedAt) }
+        Task { @MainActor in
+            await ScheduleSleepDriftNotificationUseCase.execute(
+                input: .init(
+                    childID: child.id,
+                    childName: child.name,
+                    activeSleepStartedAt: activeSleep.startedAt,
+                    completedSleepEvents: completedSleeps
+                ),
+                notificationManager: localNotificationManager
+            )
+        }
+    }
+
+    private func scheduleInactivityDriftNotificationIfNeeded() {
+        guard let child = currentChild else { return }
+        guard let lastEvent = events.max(by: { $0.metadata.occurredAt < $1.metadata.occurredAt }) else { return }
+        Task { @MainActor in
+            await ScheduleInactivityDriftNotificationUseCase.execute(
+                input: .init(
+                    childID: child.id,
+                    childName: child.name,
+                    lastEventOccurredAt: lastEvent.metadata.occurredAt,
+                    allEvents: events
+                ),
+                notificationManager: localNotificationManager
+            )
+        }
+    }
+
+    private func cancelSleepDriftNotification() {
+        guard let child = currentChild else { return }
+        Task { @MainActor in
+            await localNotificationManager.cancelSleepDriftNotification(childID: child.id)
+        }
+    }
+
+    private func rescheduleAllDriftNotifications() {
+        if activeSleep != nil {
+            scheduleSleepDriftNotificationIfNeeded()
+        }
+        scheduleInactivityDriftNotificationIfNeeded()
     }
 
     private func refresh(selecting selectedChildID: UUID?) {

--- a/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/AppModel.swift
+++ b/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/AppModel.swift
@@ -212,6 +212,10 @@ public final class AppModel {
         }
     }
 
+    public func fetchPendingDriftNotifications() async -> [PendingDriftNotification] {
+        await localNotificationManager.pendingDriftNotifications()
+    }
+
     public func hardDeleteCurrentChild() {
         guard let currentChild, let currentMembership else { return }
         let childID = currentChild.id

--- a/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/LocalNotificationManaging.swift
+++ b/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/LocalNotificationManaging.swift
@@ -9,4 +9,5 @@ public protocol LocalNotificationManaging: AnyObject {
     func cancelSleepDriftNotification(childID: UUID) async
     func scheduleInactivityDriftNotification(childID: UUID, childName: String, fireAfter: TimeInterval) async
     func cancelInactivityDriftNotification(childID: UUID) async
+    func pendingDriftNotifications() async -> [PendingDriftNotification]
 }

--- a/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/LocalNotificationManaging.swift
+++ b/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/LocalNotificationManaging.swift
@@ -5,4 +5,8 @@ import Foundation
 public protocol LocalNotificationManaging: AnyObject {
     func requestAuthorizationIfNeeded() async
     func scheduleRemoteSyncNotification(_ content: RemoteCaregiverNotificationContent) async
+    func scheduleSleepDriftNotification(childID: UUID, childName: String, fireAfter: TimeInterval) async
+    func cancelSleepDriftNotification(childID: UUID) async
+    func scheduleInactivityDriftNotification(childID: UUID, childName: String, fireAfter: TimeInterval) async
+    func cancelInactivityDriftNotification(childID: UUID) async
 }

--- a/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/NoOpLocalNotificationManager.swift
+++ b/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/NoOpLocalNotificationManager.swift
@@ -15,4 +15,5 @@ public final class NoOpLocalNotificationManager: LocalNotificationManaging {
     public func cancelSleepDriftNotification(childID: UUID) async {}
     public func scheduleInactivityDriftNotification(childID: UUID, childName: String, fireAfter: TimeInterval) async {}
     public func cancelInactivityDriftNotification(childID: UUID) async {}
+    public func pendingDriftNotifications() async -> [PendingDriftNotification] { [] }
 }

--- a/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/NoOpLocalNotificationManager.swift
+++ b/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/NoOpLocalNotificationManager.swift
@@ -10,4 +10,9 @@ public final class NoOpLocalNotificationManager: LocalNotificationManaging {
     public func scheduleRemoteSyncNotification(_ content: RemoteCaregiverNotificationContent) async {
         _ = content
     }
+
+    public func scheduleSleepDriftNotification(childID: UUID, childName: String, fireAfter: TimeInterval) async {}
+    public func cancelSleepDriftNotification(childID: UUID) async {}
+    public func scheduleInactivityDriftNotification(childID: UUID, childName: String, fireAfter: TimeInterval) async {}
+    public func cancelInactivityDriftNotification(childID: UUID) async {}
 }

--- a/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/PendingDriftNotification.swift
+++ b/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/PendingDriftNotification.swift
@@ -1,0 +1,22 @@
+import Foundation
+
+public struct PendingDriftNotification: Identifiable, Sendable {
+    public enum Kind: Sendable {
+        case sleep
+        case inactivity
+    }
+
+    public let id: String
+    public let kind: Kind
+    public let childID: UUID
+    public let childName: String
+    public let fireDate: Date
+
+    public init(id: String, kind: Kind, childID: UUID, childName: String, fireDate: Date) {
+        self.id = id
+        self.kind = kind
+        self.childID = childID
+        self.childName = childName
+        self.fireDate = fireDate
+    }
+}

--- a/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/UseCases/ScheduleInactivityDriftNotificationUseCase.swift
+++ b/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/UseCases/ScheduleInactivityDriftNotificationUseCase.swift
@@ -1,0 +1,45 @@
+import BabyTrackerDomain
+import Foundation
+
+public enum ScheduleInactivityDriftNotificationUseCase {
+    public struct Input {
+        public let childID: UUID
+        public let childName: String
+        public let lastEventOccurredAt: Date
+        public let allEvents: [BabyEvent]
+        public let now: Date
+
+        public init(
+            childID: UUID,
+            childName: String,
+            lastEventOccurredAt: Date,
+            allEvents: [BabyEvent],
+            now: Date = .now
+        ) {
+            self.childID = childID
+            self.childName = childName
+            self.lastEventOccurredAt = lastEventOccurredAt
+            self.allEvents = allEvents
+            self.now = now
+        }
+    }
+
+    @MainActor
+    public static func execute(input: Input, notificationManager: any LocalNotificationManaging) async {
+        let threshold = CalculateInactivityDriftThresholdUseCase().execute(
+            .init(events: input.allEvents)
+        )
+
+        let targetFireDate = input.lastEventOccurredAt.addingTimeInterval(threshold)
+        let fireAfter = targetFireDate.timeIntervalSince(input.now)
+        // If already past threshold (e.g. app relaunched hours later), give a short grace
+        // period rather than firing immediately on launch.
+        let resolvedFireAfter = fireAfter > 0 ? fireAfter : 5 * 60
+
+        await notificationManager.scheduleInactivityDriftNotification(
+            childID: input.childID,
+            childName: input.childName,
+            fireAfter: resolvedFireAfter
+        )
+    }
+}

--- a/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/UseCases/ScheduleSleepDriftNotificationUseCase.swift
+++ b/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/UseCases/ScheduleSleepDriftNotificationUseCase.swift
@@ -1,0 +1,46 @@
+import BabyTrackerDomain
+import Foundation
+
+public enum ScheduleSleepDriftNotificationUseCase {
+    public struct Input {
+        public let childID: UUID
+        public let childName: String
+        public let activeSleepStartedAt: Date
+        /// Recent completed sleeps, most recent first.
+        public let completedSleepEvents: [SleepEvent]
+        public let now: Date
+
+        public init(
+            childID: UUID,
+            childName: String,
+            activeSleepStartedAt: Date,
+            completedSleepEvents: [SleepEvent],
+            now: Date = .now
+        ) {
+            self.childID = childID
+            self.childName = childName
+            self.activeSleepStartedAt = activeSleepStartedAt
+            self.completedSleepEvents = completedSleepEvents
+            self.now = now
+        }
+    }
+
+    @MainActor
+    public static func execute(input: Input, notificationManager: any LocalNotificationManaging) async {
+        let threshold = CalculateSleepDriftThresholdUseCase().execute(
+            .init(completedSleepEvents: input.completedSleepEvents)
+        )
+
+        let elapsed = input.now.timeIntervalSince(input.activeSleepStartedAt)
+        let remaining = threshold - elapsed
+        // If sleep already exceeds threshold (e.g. app relaunched mid-sleep), give a short
+        // grace period rather than firing immediately on launch.
+        let fireAfter = remaining > 0 ? remaining : 5 * 60
+
+        await notificationManager.scheduleSleepDriftNotification(
+            childID: input.childID,
+            childName: input.childName,
+            fireAfter: fireAfter
+        )
+    }
+}

--- a/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/AppSettingsView.swift
+++ b/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/AppSettingsView.swift
@@ -59,6 +59,16 @@ public struct AppSettingsView: View {
                         accessibilityIdentifier: "app-settings-logs-row"
                     )
                 }
+
+                NavigationLink {
+                    DriftNotificationDebugView(model: model)
+                } label: {
+                    settingsRow(
+                        title: "Drift Reminders",
+                        value: nil,
+                        accessibilityIdentifier: "app-settings-drift-reminders-row"
+                    )
+                }
             }
 
             Section("Help") {

--- a/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/DriftNotificationDebugView.swift
+++ b/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/DriftNotificationDebugView.swift
@@ -1,0 +1,143 @@
+import SwiftUI
+
+public struct DriftNotificationDebugView: View {
+    let model: AppModel
+
+    @State private var notifications: [PendingDriftNotification] = []
+    @State private var isLoading = false
+    @State private var now: Date = .now
+
+    public init(model: AppModel) {
+        self.model = model
+    }
+
+    public var body: some View {
+        List {
+            if isLoading {
+                ProgressView()
+                    .frame(maxWidth: .infinity)
+                    .listRowBackground(Color.clear)
+            } else if notifications.isEmpty {
+                ContentUnavailableView(
+                    "No Pending Reminders",
+                    systemImage: "bell.slash",
+                    description: Text("Start a sleep or log an event to schedule drift reminders.")
+                )
+                .listRowBackground(Color.clear)
+            } else {
+                ForEach(notifications) { notification in
+                    NotificationRow(notification: notification, now: now)
+                }
+            }
+        }
+        .listStyle(.insetGrouped)
+        .navigationTitle("Drift Reminders")
+        .navigationBarTitleDisplayMode(.inline)
+        .toolbar {
+            ToolbarItem(placement: .navigationBarTrailing) {
+                Button {
+                    Task { await load() }
+                } label: {
+                    Image(systemName: "arrow.clockwise")
+                }
+                .disabled(isLoading)
+            }
+        }
+        .task { await load() }
+        .onReceive(Timer.publish(every: 1, on: .main, in: .common).autoconnect()) { date in
+            now = date
+        }
+    }
+
+    private func load() async {
+        isLoading = true
+        notifications = await model.fetchPendingDriftNotifications()
+        now = .now
+        isLoading = false
+    }
+}
+
+private struct NotificationRow: View {
+    let notification: PendingDriftNotification
+    let now: Date
+
+    var body: some View {
+        HStack(spacing: 12) {
+            Image(systemName: notification.kind.symbolName)
+                .foregroundStyle(notification.kind.color)
+                .imageScale(.large)
+                .frame(width: 28)
+
+            VStack(alignment: .leading, spacing: 3) {
+                HStack {
+                    Text(notification.kind.label)
+                        .font(.subheadline)
+                        .fontWeight(.medium)
+
+                    Spacer()
+
+                    Text(countdownText)
+                        .font(.subheadline)
+                        .fontWeight(.semibold)
+                        .monospacedDigit()
+                        .foregroundStyle(countdownColor)
+                }
+
+                Text(notification.childName)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+
+                Text(notification.fireDate.formatted(date: .omitted, time: .standard))
+                    .font(.caption2)
+                    .foregroundStyle(.tertiary)
+            }
+        }
+        .padding(.vertical, 2)
+    }
+
+    private var secondsRemaining: TimeInterval {
+        notification.fireDate.timeIntervalSince(now)
+    }
+
+    private var countdownText: String {
+        let seconds = max(0, secondsRemaining)
+        let h = Int(seconds) / 3600
+        let m = (Int(seconds) % 3600) / 60
+        let s = Int(seconds) % 60
+        if h > 0 {
+            return String(format: "%dh %02dm %02ds", h, m, s)
+        } else {
+            return String(format: "%dm %02ds", m, s)
+        }
+    }
+
+    private var countdownColor: Color {
+        let seconds = secondsRemaining
+        if seconds < 60 { return .red }
+        if seconds < 300 { return .orange }
+        return .primary
+    }
+}
+
+private extension PendingDriftNotification.Kind {
+    var label: String {
+        switch self {
+        case .sleep: return "Sleep Drift"
+        case .inactivity: return "Inactivity"
+        }
+    }
+
+    var symbolName: String {
+        switch self {
+        case .sleep: return "moon.zzz.fill"
+        case .inactivity: return "clock.badge.exclamationmark.fill"
+        }
+    }
+
+    var color: Color {
+        switch self {
+        case .sleep: return .indigo
+        case .inactivity: return .orange
+        }
+    }
+}


### PR DESCRIPTION
Schedules local notifications when a sleep runs longer than usual
(based on rolling average of recent sessions) and when no event has
been logged for longer than the typical inter-event gap. Reminders are
automatically cancelled/rescheduled as the user logs events and persist
across app restarts via UNTimeIntervalNotificationTrigger.

https://claude.ai/code/session_014Gfe5Dwb1GPfKpoeY1hcTS