### PR TITLE
Refine summary calculations, time labels, and reminder notifications

### DIFF
--- a/Baby Tracker/App/AppContainer.swift
+++ b/Baby Tracker/App/AppContainer.swift
@@ -23,6 +23,7 @@ struct AppContainer {
         let syncStateRepository = SwiftDataSyncStateRepository(store: store)
         let recordMetadataRepository = SwiftDataCloudKitRecordMetadataRepository(store: store)
         let liveActivityPreferenceStore = UserDefaultsLiveActivityPreferenceStore(userDefaults: userDefaults)
+        let reminderNotificationPreferenceStore = UserDefaultsReminderNotificationPreferenceStore(userDefaults: userDefaults)
         let appReviewPromptStateStore = UserDefaultsAppReviewPromptStateStore(userDefaults: userDefaults)
 
         if let scenario = launchConfiguration.scenario {
@@ -69,6 +70,7 @@ struct AppContainer {
             liveActivityManager: liveActivityManager,
             liveActivitySnapshotCache: liveActivitySnapshotCache,
             liveActivityPreferenceStore: liveActivityPreferenceStore,
+            reminderNotificationPreferenceStore: reminderNotificationPreferenceStore,
             localNotificationManager: localNotificationManager,
             hapticFeedbackProvider: hapticFeedbackProvider,
             appReviewPromptStateStore: appReviewPromptStateStore,
@@ -111,6 +113,7 @@ struct AppContainer {
         let syncStateRepository = SwiftDataSyncStateRepository(store: store)
         let recordMetadataRepository = SwiftDataCloudKitRecordMetadataRepository(store: store)
         let liveActivityPreferenceStore = UserDefaultsLiveActivityPreferenceStore(userDefaults: userDefaults)
+        let reminderNotificationPreferenceStore = UserDefaultsReminderNotificationPreferenceStore(userDefaults: userDefaults)
 
         try? seed(
             scenario: .mixedEventsPreview,
@@ -139,6 +142,7 @@ struct AppContainer {
             syncEngine: syncEngine,
             liveActivityManager: NoOpFeedLiveActivityManager(),
             liveActivityPreferenceStore: liveActivityPreferenceStore,
+            reminderNotificationPreferenceStore: reminderNotificationPreferenceStore,
             localNotificationManager: NoOpLocalNotificationManager(),
             hapticFeedbackProvider: NoOpHapticFeedbackProvider()
         )

--- a/Baby Tracker/App/SystemLocalNotificationManager.swift
+++ b/Baby Tracker/App/SystemLocalNotificationManager.swift
@@ -14,28 +14,33 @@ final class SystemLocalNotificationManager: NSObject, LocalNotificationManaging 
         self.notificationCenter.delegate = self
     }
 
-    func requestAuthorizationIfNeeded() async {
+    func isAuthorizedForNotifications() async -> Bool {
+        await isAuthorized()
+    }
+
+    func requestAuthorizationIfNeeded() async -> Bool {
         let settings = await notificationCenter.notificationSettings()
         switch settings.authorizationStatus {
         case .authorized, .provisional:
             await MainActor.run {
                 UIApplication.shared.registerForRemoteNotifications()
             }
-            return
+            return true
         case .notDetermined:
             break
         default:
-            return
+            return false
         }
 
         let isAuthorized = (try? await notificationCenter.requestAuthorization(options: [.alert, .sound, .badge])) == true
         guard isAuthorized else {
-            return
+            return false
         }
 
         await MainActor.run {
             UIApplication.shared.registerForRemoteNotifications()
         }
+        return true
     }
 
     func scheduleRemoteSyncNotification(_ content: RemoteCaregiverNotificationContent) async {

--- a/Baby Tracker/App/UserDefaultsReminderNotificationPreferenceStore.swift
+++ b/Baby Tracker/App/UserDefaultsReminderNotificationPreferenceStore.swift
@@ -1,0 +1,27 @@
+import BabyTrackerFeature
+import Foundation
+
+@MainActor
+final class UserDefaultsReminderNotificationPreferenceStore: ReminderNotificationPreferenceStore {
+    private enum DefaultsKey {
+        static let isReminderNotificationsEnabled = "reminderNotifications.isEnabled"
+    }
+
+    private let userDefaults: UserDefaults
+
+    var isReminderNotificationsEnabled: Bool {
+        if userDefaults.object(forKey: DefaultsKey.isReminderNotificationsEnabled) == nil {
+            return true
+        }
+
+        return userDefaults.bool(forKey: DefaultsKey.isReminderNotificationsEnabled)
+    }
+
+    init(userDefaults: UserDefaults = .standard) {
+        self.userDefaults = userDefaults
+    }
+
+    func setReminderNotificationsEnabled(_ isEnabled: Bool) {
+        userDefaults.set(isEnabled, forKey: DefaultsKey.isReminderNotificationsEnabled)
+    }
+}

--- a/Baby TrackerTests/TodaySummaryCalculatorTests.swift
+++ b/Baby TrackerTests/TodaySummaryCalculatorTests.swift
@@ -393,8 +393,8 @@ struct TodaySummaryCalculatorTests {
 
         let data = TodaySummaryCalculator.makeData(from: events, now: now, calendar: calendar)
 
-        // 4 hours total (10pm→2am) should be in the total
-        #expect(data.totalSleepMinutes == 240)
+        // Only the selected day's overlap counts: midnight→2am = 120 minutes.
+        #expect(data.totalSleepMinutes == 120)
         #expect(data.minutesSinceLastSleep == nil)
     }
 
@@ -485,6 +485,99 @@ struct TodaySummaryCalculatorTests {
         #expect(today[1] == 120)
         // Hour 2 onwards: still 120 (nothing beyond now)
         #expect(today[2] == 120)
+    }
+
+    @Test
+    func historicalDayUsesSelectedDateInsteadOfFollowingMidnightBoundary() throws {
+        var calendar = Calendar(identifier: .gregorian)
+        calendar.timeZone = TimeZone(secondsFromGMT: 0)!
+
+        let childID = UUID()
+        let userID = UUID()
+        let referenceNow = try #require(calendar.date(from: DateComponents(year: 2026, month: 4, day: 18, hour: 12)))
+        let selectedDay = try #require(calendar.date(from: DateComponents(year: 2026, month: 4, day: 17, hour: 9)))
+
+        let selectedSleepStart = try #require(calendar.date(from: DateComponents(year: 2026, month: 4, day: 17, hour: 9)))
+        let selectedSleepEnd = try #require(calendar.date(from: DateComponents(year: 2026, month: 4, day: 17, hour: 10, minute: 30)))
+        let followingDayBottleTime = try #require(calendar.date(from: DateComponents(year: 2026, month: 4, day: 18, hour: 8)))
+
+        let events: [BabyEvent] = [
+            .sleep(try SleepEvent(
+                metadata: EventMetadata(
+                    childID: childID,
+                    occurredAt: selectedSleepEnd,
+                    createdAt: selectedSleepEnd,
+                    createdBy: userID
+                ),
+                startedAt: selectedSleepStart,
+                endedAt: selectedSleepEnd
+            )),
+            .bottleFeed(try BottleFeedEvent(
+                metadata: EventMetadata(
+                    childID: childID,
+                    occurredAt: followingDayBottleTime,
+                    createdAt: followingDayBottleTime,
+                    createdBy: userID
+                ),
+                amountMilliliters: 120,
+                milkType: .formula
+            )),
+        ]
+
+        let data = TodaySummaryCalculator.makeData(
+            from: events,
+            day: selectedDay,
+            referenceNow: referenceNow,
+            calendar: calendar
+        )
+
+        #expect(data.totalSleepMinutes == 90)
+        #expect(data.bottleCount == 0)
+        #expect(data.chartData.sleep.todayCumulative[9] == 60)
+        #expect(data.chartData.sleep.todayCumulative[10] == 90)
+        #expect(data.chartData.sleep.todayCumulative[23] == 90)
+        #expect(data.chartData.bottle.todayCumulative[23] == 0)
+    }
+
+    @Test
+    func historicalDaySleepTotalsCountOnlyMinutesWithinThatDay() throws {
+        var calendar = Calendar(identifier: .gregorian)
+        calendar.timeZone = TimeZone(secondsFromGMT: 0)!
+
+        let childID = UUID()
+        let userID = UUID()
+        let referenceNow = try #require(calendar.date(from: DateComponents(year: 2026, month: 4, day: 18, hour: 12)))
+        let selectedDay = try #require(calendar.date(from: DateComponents(year: 2026, month: 4, day: 17, hour: 9)))
+
+        let overnightSleepStart = try #require(calendar.date(from: DateComponents(year: 2026, month: 4, day: 16, hour: 20)))
+        let overnightSleepEnd = try #require(calendar.date(from: DateComponents(year: 2026, month: 4, day: 17, hour: 10)))
+
+        let events: [BabyEvent] = [
+            .sleep(try SleepEvent(
+                metadata: EventMetadata(
+                    childID: childID,
+                    occurredAt: overnightSleepEnd,
+                    createdAt: overnightSleepEnd,
+                    createdBy: userID
+                ),
+                startedAt: overnightSleepStart,
+                endedAt: overnightSleepEnd
+            )),
+        ]
+
+        let data = TodaySummaryCalculator.makeData(
+            from: events,
+            day: selectedDay,
+            referenceNow: referenceNow,
+            calendar: calendar
+        )
+
+        #expect(data.totalSleepMinutes == 600)
+        #expect(data.longestSleepBlockMinutes == 600)
+        #expect(data.shortestSleepBlockMinutes == 600)
+        #expect(data.averageSleepBlockMinutes == 600)
+        #expect(data.chartData.sleep.todayCumulative[9] == 600)
+        #expect(data.chartData.sleep.todayCumulative[23] == 600)
     }
 
     // MARK: - Existing tests

--- a/Packages/BabyTrackerDomain/Sources/BabyTrackerDomain/UseCases/CalculateInactivityDriftThresholdUseCase.swift
+++ b/Packages/BabyTrackerDomain/Sources/BabyTrackerDomain/UseCases/CalculateInactivityDriftThresholdUseCase.swift
@@ -1,7 +1,10 @@
 import Foundation
 
 public struct CalculateInactivityDriftThresholdUseCase {
-    public static let defaultThreshold: TimeInterval = 4 * 60 * 60
+    public static let daytimeThreshold: TimeInterval = 6 * 60 * 60
+    public static let defaultThreshold: TimeInterval = 12 * 60 * 60
+    private static let daytimeStartHour = 5
+    private static let nighttimeStartHour = 18
 
     public struct Input {
         /// All non-deleted events for the child (any order — sorted internally).
@@ -19,32 +22,15 @@ public struct CalculateInactivityDriftThresholdUseCase {
 
     /// Returns the time interval after the last event at which to fire an inactivity notification.
     public func execute(_ input: Input) -> TimeInterval {
-        let times = input.events
-            .map(\.metadata.occurredAt)
-            .sorted()
-
-        guard times.count >= 4 else {
+        guard let lastEvent = input.events.max(by: { $0.metadata.occurredAt < $1.metadata.occurredAt }) else {
             return Self.defaultThreshold
         }
 
-        var gaps: [TimeInterval] = []
-        for i in 1..<times.count {
-            let gap = times[i].timeIntervalSince(times[i - 1])
-            // Ignore sub-minute duplicates and overnight gaps (>12h) that aren't
-            // representative of normal waking-hours logging cadence
-            guard gap > 60, gap < 12 * 60 * 60 else { continue }
-            gaps.append(gap)
+        let hour = Calendar.autoupdatingCurrent.component(.hour, from: lastEvent.metadata.occurredAt)
+        if hour >= Self.daytimeStartHour, hour < Self.nighttimeStartHour {
+            return Self.daytimeThreshold
         }
 
-        guard gaps.count >= 3 else {
-            return Self.defaultThreshold
-        }
-
-        let recent = Array(gaps.suffix(input.windowSize))
-        let average = recent.reduce(0, +) / Double(recent.count)
-
-        // 2x average gives one full "expected next event window" of grace before nudging
-        let threshold = min(average * 2.0, 8 * 60 * 60)
-        return max(threshold, 60 * 60)
+        return Self.defaultThreshold
     }
 }

--- a/Packages/BabyTrackerDomain/Sources/BabyTrackerDomain/UseCases/CalculateSleepDriftThresholdUseCase.swift
+++ b/Packages/BabyTrackerDomain/Sources/BabyTrackerDomain/UseCases/CalculateSleepDriftThresholdUseCase.swift
@@ -1,17 +1,17 @@
 import Foundation
 
 public struct CalculateSleepDriftThresholdUseCase {
-    public static let defaultThreshold: TimeInterval = 3 * 60 * 60
+    public static let daytimeThreshold: TimeInterval = 6 * 60 * 60
+    public static let defaultThreshold: TimeInterval = 12 * 60 * 60
+    private static let daytimeStartHour = 5
+    private static let nighttimeStartHour = 18
 
     public struct Input {
-        /// Completed sleep events in any order — sorted internally by end date.
-        public let completedSleepEvents: [SleepEvent]
-        /// Number of most-recent sessions to average.
-        public let windowSize: Int
+        /// Start time for the currently active sleep session.
+        public let activeSleepStartedAt: Date
 
-        public init(completedSleepEvents: [SleepEvent], windowSize: Int = 10) {
-            self.completedSleepEvents = completedSleepEvents
-            self.windowSize = windowSize
+        public init(activeSleepStartedAt: Date) {
+            self.activeSleepStartedAt = activeSleepStartedAt
         }
     }
 
@@ -19,27 +19,11 @@ public struct CalculateSleepDriftThresholdUseCase {
 
     /// Returns the duration after sleep start at which to fire a drift notification.
     public func execute(_ input: Input) -> TimeInterval {
-        let durations: [TimeInterval] = input.completedSleepEvents
-            .compactMap { sleep -> (endedAt: Date, duration: TimeInterval)? in
-                guard let ended = sleep.endedAt else { return nil }
-                let d = ended.timeIntervalSince(sleep.startedAt)
-                // Discard sub-5-minute naps (likely accidental) and 14h+ sessions (likely errors)
-                guard d >= 300, d <= 50_400 else { return nil }
-                return (ended, d)
-            }
-            .sorted { $0.endedAt > $1.endedAt }
-            .prefix(input.windowSize)
-            .map(\.duration)
-
-        guard durations.count >= 3 else {
-            return Self.defaultThreshold
+        let hour = Calendar.autoupdatingCurrent.component(.hour, from: input.activeSleepStartedAt)
+        if hour >= Self.daytimeStartHour, hour < Self.nighttimeStartHour {
+            return Self.daytimeThreshold
         }
 
-        let average = durations.reduce(0, +) / Double(durations.count)
-
-        // 20% buffer above average; cap at 6h to prevent outliers from creating excessive silence
-        let threshold = min(average * 1.20, 6 * 60 * 60)
-        // Always fire at least 30 minutes past the average
-        return max(threshold, average + 30 * 60)
+        return Self.defaultThreshold
     }
 }

--- a/Packages/BabyTrackerDomain/Tests/BabyTrackerDomainTests/DriftThresholdUseCaseTests.swift
+++ b/Packages/BabyTrackerDomain/Tests/BabyTrackerDomainTests/DriftThresholdUseCaseTests.swift
@@ -1,0 +1,116 @@
+import BabyTrackerDomain
+import Foundation
+import Testing
+
+struct DriftThresholdUseCaseTests {
+    private let childID = UUID()
+    private let userID = UUID()
+    private let now = Date(timeIntervalSince1970: 1_700_000_000)
+    private let calendar = Calendar(identifier: .gregorian)
+
+    @Test
+    func inactivityThresholdUsesFixedTwelveHoursWithoutHistory() {
+        let useCase = CalculateInactivityDriftThresholdUseCase()
+
+        let threshold = useCase.execute(.init(events: []))
+
+        #expect(threshold == 12 * 60 * 60)
+    }
+
+    @Test
+    func inactivityThresholdUsesSixHoursForDaytimeEvents() throws {
+        let useCase = CalculateInactivityDriftThresholdUseCase()
+        let events = try [
+            bottleFeed(atHour: 9),
+            bottleFeed(atHour: 11),
+            bottleFeed(atHour: 14),
+        ]
+
+        let threshold = useCase.execute(.init(events: events))
+
+        #expect(threshold == 6 * 60 * 60)
+    }
+
+    @Test
+    func inactivityThresholdUsesTwelveHoursForNighttimeEvents() throws {
+        let useCase = CalculateInactivityDriftThresholdUseCase()
+        let events = try [
+            bottleFeed(atHour: 1),
+            bottleFeed(atHour: 3),
+            bottleFeed(atHour: 18),
+        ]
+
+        let threshold = useCase.execute(.init(events: events))
+
+        #expect(threshold == 12 * 60 * 60)
+    }
+
+    @Test
+    func sleepThresholdUsesFixedTwelveHoursWithoutHistory() {
+        let useCase = CalculateSleepDriftThresholdUseCase()
+        let startedAt = dateAtHour(1)
+
+        let threshold = useCase.execute(.init(activeSleepStartedAt: startedAt))
+
+        #expect(threshold == 12 * 60 * 60)
+    }
+
+    @Test
+    func sleepThresholdUsesSixHoursForDaytimeSleepStarts() throws {
+        let useCase = CalculateSleepDriftThresholdUseCase()
+        let startedAt = dateAtHour(14)
+
+        let threshold = useCase.execute(.init(activeSleepStartedAt: startedAt))
+
+        #expect(threshold == 6 * 60 * 60)
+    }
+
+    @Test
+    func sleepThresholdUsesTwelveHoursForNighttimeSleepStarts() {
+        let useCase = CalculateSleepDriftThresholdUseCase()
+        let startedAt = dateAtHour(18)
+
+        let threshold = useCase.execute(.init(activeSleepStartedAt: startedAt))
+
+        #expect(threshold == 12 * 60 * 60)
+    }
+
+    @Test
+    func sleepThresholdUsesSixHoursAtFiveAmBoundary() {
+        let useCase = CalculateSleepDriftThresholdUseCase()
+        let startedAt = dateAtHour(5)
+
+        let threshold = useCase.execute(.init(activeSleepStartedAt: startedAt))
+
+        #expect(threshold == 6 * 60 * 60)
+    }
+
+    @Test
+    func inactivityThresholdUsesTwelveHoursAtSixPmBoundary() throws {
+        let useCase = CalculateInactivityDriftThresholdUseCase()
+        let events = try [bottleFeed(atHour: 18)]
+
+        let threshold = useCase.execute(.init(events: events))
+
+        #expect(threshold == 12 * 60 * 60)
+    }
+
+    private func bottleFeed(atHour hour: Int) throws -> BabyEvent {
+        let occurredAt = dateAtHour(hour)
+        let event = try BottleFeedEvent(
+            metadata: EventMetadata(childID: childID, occurredAt: occurredAt, createdBy: userID),
+            amountMilliliters: 120
+        )
+        return .bottleFeed(event)
+    }
+
+    private func dateAtHour(_ hour: Int) -> Date {
+        calendar.date(
+            bySettingHour: hour,
+            minute: 0,
+            second: 0,
+            of: now
+        )!
+    }
+
+}

--- a/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/AppModel.swift
+++ b/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/AppModel.swift
@@ -116,9 +116,10 @@ public final class AppModel {
         self.appReviewPromptStateStore = appReviewPromptStateStore
         self.appReviewRequester = appReviewRequester
         self.isLiveActivityEnabled = liveActivityPreferenceStore.isLiveActivityEnabled
-        self.storedReminderNotificationsEnabled = reminderNotificationPreferenceStore.isReminderNotificationsEnabled
+        let storedReminderNotificationsEnabled = reminderNotificationPreferenceStore.isReminderNotificationsEnabled
+        self.storedReminderNotificationsEnabled = storedReminderNotificationsEnabled
         self.hasReminderNotificationPermission = true
-        self.isReminderNotificationsEnabled = self.storedReminderNotificationsEnabled
+        self.isReminderNotificationsEnabled = storedReminderNotificationsEnabled
     }
 
     public func load(performLaunchSync: Bool = true) {

--- a/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/AppModel.swift
+++ b/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/AppModel.swift
@@ -15,6 +15,7 @@ public final class AppModel {
     public private(set) var errorMessage: String?
     public private(set) var undoDeleteMessage: String?
     public private(set) var isLiveActivityEnabled: Bool
+    public private(set) var isReminderNotificationsEnabled: Bool
     public private(set) var transientMessage: String?
     public private(set) var navigationResetToken: Int = 0
     public private(set) var shareAcceptanceLoadingState: ShareAcceptanceLoadingState?
@@ -67,6 +68,7 @@ public final class AppModel {
     private let liveActivityManager: any FeedLiveActivityManaging
     private let liveActivitySnapshotCache: any FeedLiveActivitySnapshotCaching
     private let liveActivityPreferenceStore: any LiveActivityPreferenceStore
+    private let reminderNotificationPreferenceStore: any ReminderNotificationPreferenceStore
     private let localNotificationManager: any LocalNotificationManaging
     private let hapticFeedbackProvider: any HapticFeedbackProviding
     private let appReviewPromptStateStore: any AppReviewPromptStateStoring
@@ -75,6 +77,8 @@ public final class AppModel {
     private let buildTimelineDayGridDatasetUseCase = BuildTimelineDayGridDatasetUseCase()
     private let buildRemoteNotificationUseCase = BuildRemoteCaregiverNotificationUseCase()
     private let calendar = Calendar.autoupdatingCurrent
+    private var storedReminderNotificationsEnabled: Bool
+    private var hasReminderNotificationPermission: Bool
     private var timelineChildID: UUID?
     private var pendingUndoDeletedEvent: BabyEvent?
     private var undoDeleteTask: Task<Void, Never>?
@@ -91,6 +95,7 @@ public final class AppModel {
         liveActivityManager: any FeedLiveActivityManaging = NoOpFeedLiveActivityManager(),
         liveActivitySnapshotCache: any FeedLiveActivitySnapshotCaching = InMemoryFeedLiveActivitySnapshotCache(),
         liveActivityPreferenceStore: any LiveActivityPreferenceStore = InMemoryLiveActivityPreferenceStore(),
+        reminderNotificationPreferenceStore: any ReminderNotificationPreferenceStore = InMemoryReminderNotificationPreferenceStore(),
         localNotificationManager: any LocalNotificationManaging = NoOpLocalNotificationManager(),
         hapticFeedbackProvider: any HapticFeedbackProviding = NoOpHapticFeedbackProvider(),
         appReviewPromptStateStore: any AppReviewPromptStateStoring = NoOpAppReviewPromptStateStore(),
@@ -105,16 +110,23 @@ public final class AppModel {
         self.liveActivityManager = liveActivityManager
         self.liveActivitySnapshotCache = liveActivitySnapshotCache
         self.liveActivityPreferenceStore = liveActivityPreferenceStore
+        self.reminderNotificationPreferenceStore = reminderNotificationPreferenceStore
         self.localNotificationManager = localNotificationManager
         self.hapticFeedbackProvider = hapticFeedbackProvider
         self.appReviewPromptStateStore = appReviewPromptStateStore
         self.appReviewRequester = appReviewRequester
         self.isLiveActivityEnabled = liveActivityPreferenceStore.isLiveActivityEnabled
+        self.storedReminderNotificationsEnabled = reminderNotificationPreferenceStore.isReminderNotificationsEnabled
+        self.hasReminderNotificationPermission = true
+        self.isReminderNotificationsEnabled = self.storedReminderNotificationsEnabled
     }
 
     public func load(performLaunchSync: Bool = true) {
         refresh(selecting: nil)
         rescheduleAllDriftNotifications()
+        Task { @MainActor in
+            await refreshReminderNotificationAuthorization()
+        }
 
         guard performLaunchSync else {
             return
@@ -175,6 +187,54 @@ public final class AppModel {
         }
     }
 
+    @discardableResult
+    public func setReminderNotificationsEnabled(_ isEnabled: Bool) async -> Bool {
+        if storedReminderNotificationsEnabled == isEnabled {
+            await refreshReminderNotificationAuthorization()
+            return isReminderNotificationsEnabled == isEnabled
+        }
+
+        if isEnabled {
+            let isAuthorized = await localNotificationManager.requestAuthorizationIfNeeded()
+            hasReminderNotificationPermission = isAuthorized
+            guard isAuthorized else {
+                isReminderNotificationsEnabled = false
+                return false
+            }
+        }
+
+        storedReminderNotificationsEnabled = isEnabled
+        reminderNotificationPreferenceStore.setReminderNotificationsEnabled(isEnabled)
+        let isAuthorized = await localNotificationManager.isAuthorizedForNotifications()
+        hasReminderNotificationPermission = isAuthorized
+        isReminderNotificationsEnabled = storedReminderNotificationsEnabled && hasReminderNotificationPermission
+
+        if isEnabled {
+            await rescheduleAllDriftNotificationsAsync()
+        } else {
+            await cancelAllDriftNotificationsAsync()
+        }
+        return isReminderNotificationsEnabled == isEnabled
+    }
+
+    public func refreshReminderNotificationAuthorization() async {
+        let isAuthorized = await localNotificationManager.isAuthorizedForNotifications()
+        let previousValue = isReminderNotificationsEnabled
+
+        hasReminderNotificationPermission = isAuthorized
+        isReminderNotificationsEnabled = storedReminderNotificationsEnabled && hasReminderNotificationPermission
+
+        guard previousValue != isReminderNotificationsEnabled else {
+            return
+        }
+
+        if isReminderNotificationsEnabled {
+            await rescheduleAllDriftNotificationsAsync()
+        } else {
+            await cancelAllDriftNotificationsAsync()
+        }
+    }
+
     public func refreshAfterShareSheet() {
         Task { @MainActor in
             await runSyncRefresh { await self.syncEngine.refreshForeground() }
@@ -208,7 +268,7 @@ public final class AppModel {
 
     public func requestNotificationAuthorizationIfNeeded() {
         Task { @MainActor in
-            await localNotificationManager.requestAuthorizationIfNeeded()
+            _ = await localNotificationManager.requestAuthorizationIfNeeded()
         }
     }
 
@@ -925,6 +985,13 @@ public final class AppModel {
     }
 
     private func scheduleSleepDriftNotificationIfNeeded() {
+        Task { @MainActor in
+            await scheduleSleepDriftNotificationIfNeededAsync()
+        }
+    }
+
+    private func scheduleSleepDriftNotificationIfNeededAsync() async {
+        guard isReminderNotificationsEnabled else { return }
         guard let child = currentChild, let activeSleep else { return }
         let completedSleeps = events
             .compactMap { event -> SleepEvent? in
@@ -932,47 +999,85 @@ public final class AppModel {
                 return s
             }
             .sorted { ($0.endedAt ?? $0.startedAt) > ($1.endedAt ?? $1.startedAt) }
-        Task { @MainActor in
-            await ScheduleSleepDriftNotificationUseCase.execute(
-                input: .init(
-                    childID: child.id,
-                    childName: child.name,
-                    activeSleepStartedAt: activeSleep.startedAt,
-                    completedSleepEvents: completedSleeps
-                ),
-                notificationManager: localNotificationManager
-            )
-        }
+        await ScheduleSleepDriftNotificationUseCase.execute(
+            input: .init(
+                childID: child.id,
+                childName: child.name,
+                activeSleepStartedAt: activeSleep.startedAt,
+                completedSleepEvents: completedSleeps
+            ),
+            notificationManager: localNotificationManager
+        )
     }
 
     private func scheduleInactivityDriftNotificationIfNeeded() {
+        Task { @MainActor in
+            await scheduleInactivityDriftNotificationIfNeededAsync()
+        }
+    }
+
+    private func scheduleInactivityDriftNotificationIfNeededAsync() async {
+        guard isReminderNotificationsEnabled else { return }
         guard let child = currentChild else { return }
         guard let lastEvent = events.max(by: { $0.metadata.occurredAt < $1.metadata.occurredAt }) else { return }
-        Task { @MainActor in
-            await ScheduleInactivityDriftNotificationUseCase.execute(
-                input: .init(
-                    childID: child.id,
-                    childName: child.name,
-                    lastEventOccurredAt: lastEvent.metadata.occurredAt,
-                    allEvents: events
-                ),
-                notificationManager: localNotificationManager
-            )
-        }
+        await ScheduleInactivityDriftNotificationUseCase.execute(
+            input: .init(
+                childID: child.id,
+                childName: child.name,
+                lastEventOccurredAt: lastEvent.metadata.occurredAt,
+                allEvents: events
+            ),
+            notificationManager: localNotificationManager
+        )
     }
 
     private func cancelSleepDriftNotification() {
-        guard let child = currentChild else { return }
         Task { @MainActor in
-            await localNotificationManager.cancelSleepDriftNotification(childID: child.id)
+            await cancelSleepDriftNotificationAsync()
         }
     }
 
-    private func rescheduleAllDriftNotifications() {
-        if activeSleep != nil {
-            scheduleSleepDriftNotificationIfNeeded()
+    private func cancelSleepDriftNotificationAsync() async {
+        guard let child = currentChild else { return }
+        await localNotificationManager.cancelSleepDriftNotification(childID: child.id)
+    }
+
+    private func cancelInactivityDriftNotification() {
+        Task { @MainActor in
+            await cancelInactivityDriftNotificationAsync()
         }
-        scheduleInactivityDriftNotificationIfNeeded()
+    }
+
+    private func cancelInactivityDriftNotificationAsync() async {
+        guard let child = currentChild else { return }
+        await localNotificationManager.cancelInactivityDriftNotification(childID: child.id)
+    }
+
+    private func cancelAllDriftNotifications() {
+        cancelSleepDriftNotification()
+        cancelInactivityDriftNotification()
+    }
+
+    private func cancelAllDriftNotificationsAsync() async {
+        await cancelSleepDriftNotificationAsync()
+        await cancelInactivityDriftNotificationAsync()
+    }
+
+    private func rescheduleAllDriftNotifications() {
+        Task { @MainActor in
+            await rescheduleAllDriftNotificationsAsync()
+        }
+    }
+
+    private func rescheduleAllDriftNotificationsAsync() async {
+        guard isReminderNotificationsEnabled else {
+            await cancelAllDriftNotificationsAsync()
+            return
+        }
+        if activeSleep != nil {
+            await scheduleSleepDriftNotificationIfNeededAsync()
+        }
+        await scheduleInactivityDriftNotificationIfNeededAsync()
     }
 
     private func refresh(selecting selectedChildID: UUID?) {

--- a/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/ChildProfilePreviewFactory.swift
+++ b/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/ChildProfilePreviewFactory.swift
@@ -36,6 +36,7 @@ enum ChildProfilePreviewFactory {
             syncEngine: syncEngine,
             liveActivityManager: NoOpFeedLiveActivityManager(),
             liveActivityPreferenceStore: InMemoryLiveActivityPreferenceStore(),
+            reminderNotificationPreferenceStore: InMemoryReminderNotificationPreferenceStore(),
             localNotificationManager: NoOpLocalNotificationManager(),
             hapticFeedbackProvider: NoOpHapticFeedbackProvider()
         )

--- a/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/ElapsedTimeFormatter.swift
+++ b/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/ElapsedTimeFormatter.swift
@@ -1,20 +1,83 @@
 import Foundation
 
 enum ElapsedTimeFormatter {
-    static func string(from date: Date, relativeTo referenceDate: Date = Date()) -> String {
+    static func string(
+        from date: Date,
+        relativeTo referenceDate: Date = Date(),
+        calendar: Calendar = .autoupdatingCurrent,
+        locale: Locale = .autoupdatingCurrent
+    ) -> String {
         let interval = referenceDate.timeIntervalSince(date)
-        guard interval >= 60 else { return "just now" }
+        guard interval >= 60 else { return "Just now" }
 
         let totalMinutes = Int(interval / 60)
+        if totalMinutes >= 24 * 60 {
+            return olderThanDayString(
+                from: date,
+                relativeTo: referenceDate,
+                calendar: calendar,
+                locale: locale
+            )
+        }
+
         let hours = totalMinutes / 60
         let minutes = totalMinutes % 60
 
         if hours == 0 {
-            return "\(totalMinutes) \(totalMinutes == 1 ? "min" : "mins") ago"
+            return "\(totalMinutes)m"
         } else if minutes == 0 {
-            return "\(hours) \(hours == 1 ? "hr" : "hrs") ago"
+            return "\(hours)h"
         } else {
-            return "\(hours) \(hours == 1 ? "hr" : "hrs") \(minutes) \(minutes == 1 ? "min" : "mins") ago"
+            return "\(hours)h \(minutes)m"
         }
+    }
+
+    private static func olderThanDayString(
+        from date: Date,
+        relativeTo referenceDate: Date,
+        calendar: Calendar,
+        locale: Locale
+    ) -> String {
+        if calendar.isDateInYesterday(date) || isYesterday(date, relativeTo: referenceDate, calendar: calendar) {
+            return "Yesterday at \(timeText(for: date, calendar: calendar, locale: locale))"
+        }
+
+        if let sevenDaysAgo = calendar.date(byAdding: .day, value: -6, to: calendar.startOfDay(for: referenceDate)),
+           date >= sevenDaysAgo {
+            return "\(weekdayText(for: date, locale: locale)) \(timeText(for: date, calendar: calendar, locale: locale))"
+        }
+
+        return "\(dateText(for: date, calendar: calendar, locale: locale)) \(timeText(for: date, calendar: calendar, locale: locale))"
+    }
+
+    private static func isYesterday(_ date: Date, relativeTo referenceDate: Date, calendar: Calendar) -> Bool {
+        guard let yesterday = calendar.date(byAdding: .day, value: -1, to: referenceDate) else {
+            return false
+        }
+
+        return calendar.isDate(date, inSameDayAs: yesterday)
+    }
+
+    private static func timeText(for date: Date, calendar: Calendar, locale: Locale) -> String {
+        let formatter = DateFormatter()
+        formatter.calendar = calendar
+        formatter.locale = locale
+        formatter.setLocalizedDateFormatFromTemplate("jm")
+        return formatter.string(from: date)
+    }
+
+    private static func weekdayText(for date: Date, locale: Locale) -> String {
+        let formatter = DateFormatter()
+        formatter.locale = locale
+        formatter.setLocalizedDateFormatFromTemplate("EEE")
+        return formatter.string(from: date)
+    }
+
+    private static func dateText(for date: Date, calendar: Calendar, locale: Locale) -> String {
+        let formatter = DateFormatter()
+        formatter.calendar = calendar
+        formatter.locale = locale
+        formatter.setLocalizedDateFormatFromTemplate("MMM d")
+        return formatter.string(from: date)
     }
 }

--- a/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/InMemoryReminderNotificationPreferenceStore.swift
+++ b/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/InMemoryReminderNotificationPreferenceStore.swift
@@ -1,0 +1,14 @@
+import Foundation
+
+@MainActor
+public final class InMemoryReminderNotificationPreferenceStore: ReminderNotificationPreferenceStore {
+    public var isReminderNotificationsEnabled: Bool
+
+    public init(isReminderNotificationsEnabled: Bool = true) {
+        self.isReminderNotificationsEnabled = isReminderNotificationsEnabled
+    }
+
+    public func setReminderNotificationsEnabled(_ isEnabled: Bool) {
+        isReminderNotificationsEnabled = isEnabled
+    }
+}

--- a/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/LocalNotificationManaging.swift
+++ b/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/LocalNotificationManaging.swift
@@ -3,7 +3,8 @@ import Foundation
 
 @MainActor
 public protocol LocalNotificationManaging: AnyObject {
-    func requestAuthorizationIfNeeded() async
+    func isAuthorizedForNotifications() async -> Bool
+    func requestAuthorizationIfNeeded() async -> Bool
     func scheduleRemoteSyncNotification(_ content: RemoteCaregiverNotificationContent) async
     func scheduleSleepDriftNotification(childID: UUID, childName: String, fireAfter: TimeInterval) async
     func cancelSleepDriftNotification(childID: UUID) async

--- a/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/NoOpLocalNotificationManager.swift
+++ b/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/NoOpLocalNotificationManager.swift
@@ -5,7 +5,8 @@ import Foundation
 public final class NoOpLocalNotificationManager: LocalNotificationManaging {
     public init() {}
 
-    public func requestAuthorizationIfNeeded() async {}
+    public func isAuthorizedForNotifications() async -> Bool { true }
+    public func requestAuthorizationIfNeeded() async -> Bool { true }
 
     public func scheduleRemoteSyncNotification(_ content: RemoteCaregiverNotificationContent) async {
         _ = content

--- a/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/ReminderNotificationPreferenceStore.swift
+++ b/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/ReminderNotificationPreferenceStore.swift
@@ -1,0 +1,7 @@
+import Foundation
+
+@MainActor
+public protocol ReminderNotificationPreferenceStore: AnyObject {
+    var isReminderNotificationsEnabled: Bool { get }
+    func setReminderNotificationsEnabled(_ isEnabled: Bool)
+}

--- a/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/TodaySummaryCalculator.swift
+++ b/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/TodaySummaryCalculator.swift
@@ -7,8 +7,30 @@ public enum TodaySummaryCalculator {
         now: Date = .now,
         calendar: Calendar = .autoupdatingCurrent
     ) -> TodaySummaryData {
+        makeData(
+            from: allEvents,
+            day: now,
+            referenceNow: now,
+            calendar: calendar
+        )
+    }
+
+    public static func makeData(
+        from allEvents: [BabyEvent],
+        day: Date,
+        referenceNow: Date = .now,
+        calendar: Calendar = .autoupdatingCurrent
+    ) -> TodaySummaryData {
+        let selectedDay = calendar.startOfDay(for: day)
+        let isSelectedDayToday = calendar.isDate(selectedDay, inSameDayAs: referenceNow)
+        let effectiveNow = if isSelectedDayToday {
+            referenceNow
+        } else {
+            calendar.date(byAdding: .day, value: 1, to: selectedDay) ?? selectedDay
+        }
+
         let todayEvents = allEvents.filter {
-            calendar.isDate($0.metadata.occurredAt, inSameDayAs: now)
+            calendar.isDate($0.metadata.occurredAt, inSameDayAs: selectedDay)
         }
 
         // Bottle feeds
@@ -50,23 +72,46 @@ public enum TodaySummaryCalculator {
         // Time since last feed
         let lastFeedDate = allFeedEvents.map(\.metadata.occurredAt).max()
         let minutesSinceLastFeed = lastFeedDate.map {
-            max(0, Int(now.timeIntervalSince($0) / 60))
+            max(0, Int(effectiveNow.timeIntervalSince($0) / 60))
         }
 
-        // Sleep - find active (in-progress) session from all events; it may have started before today
+        // Sleep - current active session state is only meaningful for the actual current day.
         let activeSleep = allEvents.compactMap { event -> SleepEvent? in
             guard case let .sleep(sleep) = event, sleep.endedAt == nil else { return nil }
             return sleep
-        }.sorted { $0.startedAt > $1.startedAt }.first
+        }
+        .filter { sleep in
+            sleep.startedAt < effectiveNow
+        }
+        .sorted { $0.startedAt > $1.startedAt }
+        .first
 
         let completedSleeps = todayEvents.compactMap { event -> SleepEvent? in
             guard case let .sleep(sleep) = event, sleep.endedAt != nil else { return nil }
             return sleep
         }
 
-        let completedDurations = completedSleeps.compactMap { sleepDurationMinutes(for: $0) }
-        let activeDuration = activeSleep.map { max(1, Int(now.timeIntervalSince($0.startedAt) / 60)) }
-        let allSleepDurations = completedDurations + (activeDuration.map { [$0] } ?? [])
+        let overlappingSleeps = allEvents.compactMap { event -> SleepEvent? in
+            guard case let .sleep(sleep) = event else { return nil }
+            return sleep
+        }
+        .filter { sleep in
+            sleepMinutesOnSelectedDay(
+                for: sleep,
+                day: selectedDay,
+                effectiveNow: effectiveNow,
+                calendar: calendar
+            ) > 0
+        }
+
+        let allSleepDurations = overlappingSleeps.map { sleep in
+            sleepMinutesOnSelectedDay(
+                for: sleep,
+                day: selectedDay,
+                effectiveNow: effectiveNow,
+                calendar: calendar
+            )
+        }
 
         let totalSleepMinutes = allSleepDurations.reduce(0, +)
         let longestSleepBlock = allSleepDurations.max()
@@ -75,24 +120,24 @@ public enum TodaySummaryCalculator {
 
         // Time since last sleep - nil while actively sleeping
         let minutesSinceLastSleep: Int?
-        if activeSleep != nil {
+        if isSelectedDayToday && activeSleep != nil {
             minutesSinceLastSleep = nil
         } else {
             let lastSleepEndDate = completedSleeps.compactMap(\.endedAt).max()
             minutesSinceLastSleep = lastSleepEndDate.map {
-                max(0, Int(now.timeIntervalSince($0) / 60))
+                max(0, Int(effectiveNow.timeIntervalSince($0) / 60))
             }
         }
 
         var daytimeSleepMinutes = 0
         var nighttimeSleepMinutes = 0
-        for sleep in completedSleeps {
-            let (daytime, nighttime) = splitSleepDuration(sleep, calendar: calendar)
-            daytimeSleepMinutes += daytime
-            nighttimeSleepMinutes += nighttime
-        }
-        if let active = activeSleep {
-            let (daytime, nighttime) = splitSleepDuration(active, effectiveEnd: now, calendar: calendar)
+        for sleep in overlappingSleeps {
+            let (daytime, nighttime) = splitSleepDurationOnSelectedDay(
+                sleep,
+                day: selectedDay,
+                effectiveNow: effectiveNow,
+                calendar: calendar
+            )
             daytimeSleepMinutes += daytime
             nighttimeSleepMinutes += nighttime
         }
@@ -108,10 +153,15 @@ public enum TodaySummaryCalculator {
         let dryCount = nappies.filter { $0.type == .dry }.count
 
         // Logging streak (uses all events, not just today)
-        let streak = loggingStreakDays(from: allEvents, now: now, calendar: calendar)
+        let streak = loggingStreakDays(from: allEvents, now: effectiveNow, calendar: calendar)
 
         // Hourly cumulative chart data
-        let chartData = makeChartData(from: allEvents, now: now, calendar: calendar)
+        let chartData = makeChartData(
+            from: allEvents,
+            selectedDay: selectedDay,
+            effectiveNow: effectiveNow,
+            calendar: calendar
+        )
 
         return TodaySummaryData(
             bottleTotalMilliliters: bottleTotalMilliliters,
@@ -147,10 +197,11 @@ public enum TodaySummaryCalculator {
 
     private static func makeChartData(
         from allEvents: [BabyEvent],
-        now: Date,
+        selectedDay: Date,
+        effectiveNow: Date,
         calendar: Calendar
     ) -> TodayChartData {
-        let today = calendar.startOfDay(for: now)
+        let today = calendar.startOfDay(for: selectedDay)
         let todayEvents = allEvents.filter { calendar.isDate($0.metadata.occurredAt, inSameDayAs: today) }
 
         // Collect the 7 complete days before today
@@ -215,7 +266,12 @@ public enum TodaySummaryCalculator {
                 historicalAmounts: historicalDays.map { breastHourlyAmounts(events: $0, calendar: calendar) }
             ),
             sleep: buildCumulativeSeries(
-                todayAmounts: sleepHourlyAmounts(allEvents: allEvents, day: today, now: now, calendar: calendar),
+                todayAmounts: sleepHourlyAmounts(
+                    allEvents: allEvents,
+                    day: today,
+                    now: effectiveNow,
+                    calendar: calendar
+                ),
                 historicalAmounts: (1...7).compactMap { offset -> [Int]? in
                     guard let day = calendar.date(byAdding: .day, value: -offset, to: today),
                           let dayEnd = calendar.date(byAdding: .day, value: 1, to: day) else { return nil }
@@ -398,6 +454,26 @@ public enum TodaySummaryCalculator {
         return max(1, Int(endedAt.timeIntervalSince(event.startedAt) / 60))
     }
 
+    private static func sleepMinutesOnSelectedDay(
+        for sleep: SleepEvent,
+        day: Date,
+        effectiveNow: Date,
+        calendar: Calendar
+    ) -> Int {
+        guard let dayEnd = calendar.date(byAdding: .day, value: 1, to: day) else { return 0 }
+
+        let effectiveEnd = sleep.endedAt ?? effectiveNow
+        let cap = min(effectiveNow, dayEnd)
+
+        guard effectiveEnd > day && sleep.startedAt < cap else { return 0 }
+
+        let overlapStart = max(sleep.startedAt, day)
+        let overlapEnd = min(effectiveEnd, cap)
+        guard overlapEnd > overlapStart else { return 0 }
+
+        return max(0, Int(overlapEnd.timeIntervalSince(overlapStart) / 60))
+    }
+
     /// Splits a sleep block into daytime (6am–10pm) and nighttime (10pm–6am) minutes.
     /// Pass `effectiveEnd` for active (in-progress) sessions; otherwise `sleep.endedAt` is used.
     private static func splitSleepDuration(
@@ -437,6 +513,42 @@ public enum TodaySummaryCalculator {
         }
 
         let daytimeMinutes = max(0, totalMinutes - nighttimeMinutes)
+        return (daytimeMinutes, nighttimeMinutes)
+    }
+
+    private static func splitSleepDurationOnSelectedDay(
+        _ sleep: SleepEvent,
+        day: Date,
+        effectiveNow: Date,
+        calendar: Calendar
+    ) -> (daytime: Int, nighttime: Int) {
+        guard let dayEnd = calendar.date(byAdding: .day, value: 1, to: day) else { return (0, 0) }
+
+        let effectiveEnd = sleep.endedAt ?? effectiveNow
+        let cap = min(effectiveNow, dayEnd)
+        let overlapStart = max(sleep.startedAt, day)
+        let overlapEnd = min(effectiveEnd, cap)
+
+        guard overlapEnd > overlapStart else { return (0, 0) }
+
+        var daytimeMinutes = 0
+        var nighttimeMinutes = 0
+        var cursor = overlapStart
+
+        while cursor < overlapEnd {
+            guard let nextBoundary = calendar.date(byAdding: .minute, value: 1, to: cursor) else { break }
+            let minuteEnd = min(nextBoundary, overlapEnd)
+            let hour = calendar.component(.hour, from: cursor)
+
+            if (6..<22).contains(hour) {
+                daytimeMinutes += Int(minuteEnd.timeIntervalSince(cursor) / 60)
+            } else {
+                nighttimeMinutes += Int(minuteEnd.timeIntervalSince(cursor) / 60)
+            }
+
+            cursor = minuteEnd
+        }
+
         return (daytimeMinutes, nighttimeMinutes)
     }
 

--- a/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/UseCases/ScheduleSleepDriftNotificationUseCase.swift
+++ b/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/UseCases/ScheduleSleepDriftNotificationUseCase.swift
@@ -28,7 +28,7 @@ public enum ScheduleSleepDriftNotificationUseCase {
     @MainActor
     public static func execute(input: Input, notificationManager: any LocalNotificationManaging) async {
         let threshold = CalculateSleepDriftThresholdUseCase().execute(
-            .init(completedSleepEvents: input.completedSleepEvents)
+            .init(activeSleepStartedAt: input.activeSleepStartedAt)
         )
 
         let elapsed = input.now.timeIntervalSince(input.activeSleepStartedAt)

--- a/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/AppSettingsView.swift
+++ b/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/AppSettingsView.swift
@@ -59,16 +59,6 @@ public struct AppSettingsView: View {
                         accessibilityIdentifier: "app-settings-logs-row"
                     )
                 }
-
-                NavigationLink {
-                    DriftNotificationDebugView(model: model)
-                } label: {
-                    settingsRow(
-                        title: "Drift Reminders",
-                        value: nil,
-                        accessibilityIdentifier: "app-settings-drift-reminders-row"
-                    )
-                }
             }
 
             Section("Help") {

--- a/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/ChildProfileView.swift
+++ b/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/ChildProfileView.swift
@@ -58,6 +58,16 @@ public struct ChildProfileView: View {
                 )
                 .accessibilityIdentifier("live-activities-toggle")
 
+                NavigationLink {
+                    DriftNotificationDebugView(model: model)
+                } label: {
+                    settingsRow(
+                        title: "Reminder Notifications",
+                        value: model.isReminderNotificationsEnabled ? "On" : "Off",
+                        accessibilityIdentifier: "profile-reminder-notifications-row"
+                    )
+                }
+
                 if showsManageChild {
                     NavigationLink {
                         ChildProfileManageView(

--- a/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/CumulativeLineChartView.swift
+++ b/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/CumulativeLineChartView.swift
@@ -33,17 +33,15 @@ struct CumulativeLineChartView: View {
             // 7-day average — dashed, secondary, full 24 hours; only shown while interacting.
             // series: groups all 24 marks into one continuous line so the
             // dash pattern is applied across the whole series, not per segment.
-            if selectedHour != nil {
-                ForEach(averagePoints) { point in
-                    LineMark(
-                        x: .value("Hour", point.hour),
-                        y: .value("7-Day Avg", point.value),
-                        series: .value("Series", "average")
-                    )
-                    .interpolationMethod(.monotone)
-                    .foregroundStyle(Color.secondary.opacity(0.6))
-                    .lineStyle(StrokeStyle(lineWidth: 1.5, dash: [5, 3]))
-                }
+            ForEach(averagePoints) { point in
+                LineMark(
+                    x: .value("Hour", point.hour),
+                    y: .value("7-Day Avg", point.value),
+                    series: .value("Series", "average")
+                )
+                .interpolationMethod(.monotone)
+                .foregroundStyle(Color.secondary.opacity(0.6))
+                .lineStyle(StrokeStyle(lineWidth: 1.5, dash: [5, 3]))
             }
 
             // Today — solid, tinted, stops at the current hour

--- a/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/DriftNotificationDebugView.swift
+++ b/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/DriftNotificationDebugView.swift
@@ -1,11 +1,15 @@
+import UIKit
 import SwiftUI
 
 public struct DriftNotificationDebugView: View {
+    @Environment(\.openURL) private var openURL
+
     let model: AppModel
 
     @State private var notifications: [PendingDriftNotification] = []
     @State private var isLoading = false
     @State private var now: Date = .now
+    @State private var isShowingPermissionAlert = false
 
     public init(model: AppModel) {
         self.model = model
@@ -13,15 +17,38 @@ public struct DriftNotificationDebugView: View {
 
     public var body: some View {
         List {
+            Section {
+                Toggle(
+                    "Send Reminder Notifications",
+                    isOn: Binding(
+                        get: { model.isReminderNotificationsEnabled },
+                        set: { isEnabled in
+                            Task {
+                                let didUpdate = await model.setReminderNotificationsEnabled(isEnabled)
+                                await load()
+                                if !didUpdate, isEnabled {
+                                    isShowingPermissionAlert = true
+                                }
+                            }
+                        }
+                    )
+                )
+                .accessibilityIdentifier("reminder-notifications-toggle")
+
+                Text("We’ll let you know if it’s been a while since you last logged something, so it’s easier to keep your timeline up to date.")
+                    .font(.footnote)
+                    .foregroundStyle(.secondary)
+            }
+
             if isLoading {
                 ProgressView()
                     .frame(maxWidth: .infinity)
                     .listRowBackground(Color.clear)
-            } else if notifications.isEmpty {
+            } else if !model.isReminderNotificationsEnabled || notifications.isEmpty {
                 ContentUnavailableView(
-                    "No Pending Reminders",
+                    model.isReminderNotificationsEnabled ? "No Pending Reminders" : "Reminder Notifications Off",
                     systemImage: "bell.slash",
-                    description: Text("Start a sleep or log an event to schedule drift reminders.")
+                    description: Text(emptyStateDescription)
                 )
                 .listRowBackground(Color.clear)
             } else {
@@ -31,8 +58,17 @@ public struct DriftNotificationDebugView: View {
             }
         }
         .listStyle(.insetGrouped)
-        .navigationTitle("Drift Reminders")
+        .navigationTitle("Reminder Notifications")
         .navigationBarTitleDisplayMode(.inline)
+        .alert("Enable Notifications", isPresented: $isShowingPermissionAlert) {
+            Button("Open Settings") {
+                guard let url = URL(string: UIApplication.openSettingsURLString) else { return }
+                openURL(url)
+            }
+            Button("Not Now", role: .cancel) {}
+        } message: {
+            Text("Turn on notifications in Settings to use reminder notifications.")
+        }
         .toolbar {
             ToolbarItem(placement: .navigationBarTrailing) {
                 Button {
@@ -43,7 +79,10 @@ public struct DriftNotificationDebugView: View {
                 .disabled(isLoading)
             }
         }
-        .task { await load() }
+        .task {
+            await model.refreshReminderNotificationAuthorization()
+            await load()
+        }
         .onReceive(Timer.publish(every: 1, on: .main, in: .common).autoconnect()) { date in
             now = date
         }
@@ -54,6 +93,14 @@ public struct DriftNotificationDebugView: View {
         notifications = await model.fetchPendingDriftNotifications()
         now = .now
         isLoading = false
+    }
+
+    private var emptyStateDescription: String {
+        if model.isReminderNotificationsEnabled {
+            return "Start a sleep or log an event to schedule reminder notifications."
+        }
+
+        return "Turn reminder notifications on to schedule future reminders."
     }
 }
 
@@ -122,8 +169,8 @@ private struct NotificationRow: View {
 private extension PendingDriftNotification.Kind {
     var label: String {
         switch self {
-        case .sleep: return "Sleep Drift"
-        case .inactivity: return "Inactivity"
+        case .sleep: return "Long Sleep Reminder"
+        case .inactivity: return "No Activity Reminder"
         }
     }
 
@@ -139,5 +186,11 @@ private extension PendingDriftNotification.Kind {
         case .sleep: return .indigo
         case .inactivity: return .orange
         }
+    }
+}
+
+#Preview {
+    NavigationStack {
+        DriftNotificationDebugView(model: ChildProfilePreviewFactory.makeModel())
     }
 }

--- a/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/IdentityOnboardingView.swift
+++ b/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/IdentityOnboardingView.swift
@@ -416,6 +416,7 @@ private enum IdentityOnboardingPreviewFactory {
             syncEngine: syncEngine,
             liveActivityManager: NoOpFeedLiveActivityManager(),
             liveActivityPreferenceStore: InMemoryLiveActivityPreferenceStore(),
+            reminderNotificationPreferenceStore: InMemoryReminderNotificationPreferenceStore(),
             localNotificationManager: NoOpLocalNotificationManager(),
             hapticFeedbackProvider: NoOpHapticFeedbackProvider()
         )

--- a/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/SummaryScreenView.swift
+++ b/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/SummaryScreenView.swift
@@ -269,7 +269,7 @@ public struct SummaryScreenView: View {
     // MARK: - Today Tab
 
     private var todayTabContent: some View {
-        let data = TodaySummaryCalculator.makeData(from: viewModel.events, now: selectedDate)
+        let data = TodaySummaryCalculator.makeData(from: viewModel.events, now: todaySummaryCalculationDate)
 
         return Group {
             if viewModel.events.isEmpty {
@@ -289,6 +289,18 @@ public struct SummaryScreenView: View {
                 }
             }
         }
+    }
+
+
+    private var todaySummaryCalculationDate: Date {
+        let calendar = Calendar.autoupdatingCurrent
+        let selectedDayStart = calendar.startOfDay(for: selectedDate)
+
+        guard !calendar.isDateInToday(selectedDate) else {
+            return .now
+        }
+
+        return calendar.date(byAdding: .day, value: 1, to: selectedDayStart) ?? selectedDate
     }
 
     // MARK: - Date Navigation

--- a/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/SummaryScreenView.swift
+++ b/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/SummaryScreenView.swift
@@ -269,7 +269,10 @@ public struct SummaryScreenView: View {
     // MARK: - Today Tab
 
     private var todayTabContent: some View {
-        let data = TodaySummaryCalculator.makeData(from: viewModel.events, now: todaySummaryCalculationDate)
+        let data = TodaySummaryCalculator.makeData(
+            from: viewModel.events,
+            day: selectedDate
+        )
 
         return Group {
             if viewModel.events.isEmpty {
@@ -289,18 +292,6 @@ public struct SummaryScreenView: View {
                 }
             }
         }
-    }
-
-
-    private var todaySummaryCalculationDate: Date {
-        let calendar = Calendar.autoupdatingCurrent
-        let selectedDayStart = calendar.startOfDay(for: selectedDate)
-
-        guard !calendar.isDateInToday(selectedDate) else {
-            return .now
-        }
-
-        return calendar.date(byAdding: .day, value: 1, to: selectedDayStart) ?? selectedDate
     }
 
     // MARK: - Date Navigation

--- a/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/TimelineDayGridPageView.swift
+++ b/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/TimelineDayGridPageView.swift
@@ -80,7 +80,7 @@ public struct TimelineDayGridPageView: View {
         let visibleHour = page.isToday ? calendar.component(.hour, from: .now) : 6
 
         DispatchQueue.main.async {
-            proxy.scrollTo("timeline-day-grid-hour-\(visibleHour)", anchor: .bottom)
+            proxy.scrollTo("timeline-day-grid-hour-offset-\(visibleHour)", anchor: .bottom)
         }
     }
 }

--- a/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/TimelineDayGridView.swift
+++ b/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/TimelineDayGridView.swift
@@ -12,6 +12,7 @@ public struct TimelineDayGridView: View {
     private let columnSpacing: CGFloat = 8
     private let slotHeight: CGFloat = 30
     private let itemVerticalInset: CGFloat = 3
+    private let initialScrollBottomOffset: CGFloat = 150
 
     public init(
         day: Date,
@@ -128,6 +129,13 @@ public struct TimelineDayGridView: View {
                         .frame(width: columnWidth, height: slotHeight)
                     }
                 }
+                .overlay(alignment: .topLeading) {
+                    if slotIndex.isMultiple(of: slotsPerHour) {
+                        Color.clear
+                            .frame(width: 1, height: initialScrollBottomOffset)
+                            .id(initialScrollAnchorID(for: slotIndex / slotsPerHour))
+                    }
+                }
             }
         }
     }
@@ -199,6 +207,10 @@ public struct TimelineDayGridView: View {
 
     private func hourAnchorID(for hour: Int) -> String {
         "timeline-day-grid-hour-\(hour)"
+    }
+
+    private func initialScrollAnchorID(for hour: Int) -> String {
+        "timeline-day-grid-hour-offset-\(hour)"
     }
 
     private var isToday: Bool {

--- a/Packages/BabyTrackerFeature/Tests/BabyTrackerFeatureTests/ElapsedTimeFormatterTests.swift
+++ b/Packages/BabyTrackerFeature/Tests/BabyTrackerFeatureTests/ElapsedTimeFormatterTests.swift
@@ -3,37 +3,134 @@ import Foundation
 import Testing
 
 struct ElapsedTimeFormatterTests {
+    private var calendar: Calendar {
+        var calendar = Calendar(identifier: .gregorian)
+        calendar.timeZone = TimeZone(secondsFromGMT: 0)!
+        return calendar
+    }
+
+    private var locale: Locale { Locale(identifier: "en_US_POSIX") }
+
+    private var referenceDate: Date {
+        calendar.date(from: DateComponents(year: 2026, month: 4, day: 18, hour: 12, minute: 0))!
+    }
+
     @Test func justNow_whenUnderOneMinute() {
-        let date = Date().addingTimeInterval(-30)
-        #expect(ElapsedTimeFormatter.string(from: date) == "just now")
+        let date = referenceDate.addingTimeInterval(-30)
+        #expect(
+            ElapsedTimeFormatter.string(
+                from: date,
+                relativeTo: referenceDate,
+                calendar: calendar,
+                locale: locale
+            ) == "Just now"
+        )
     }
 
     @Test func justNow_whenExactlyNow() {
-        #expect(ElapsedTimeFormatter.string(from: Date()) == "just now")
+        #expect(
+            ElapsedTimeFormatter.string(
+                from: referenceDate,
+                relativeTo: referenceDate,
+                calendar: calendar,
+                locale: locale
+            ) == "Just now"
+        )
     }
 
     @Test func minutesOnly_whenUnderOneHour() {
-        let date = Date().addingTimeInterval(-45 * 60)
-        #expect(ElapsedTimeFormatter.string(from: date) == "45 mins ago")
+        let date = referenceDate.addingTimeInterval(-45 * 60)
+        #expect(
+            ElapsedTimeFormatter.string(
+                from: date,
+                relativeTo: referenceDate,
+                calendar: calendar,
+                locale: locale
+            ) == "45m"
+        )
     }
 
     @Test func singularMinute() {
-        let date = Date().addingTimeInterval(-60)
-        #expect(ElapsedTimeFormatter.string(from: date) == "1 min ago")
+        let date = referenceDate.addingTimeInterval(-60)
+        #expect(
+            ElapsedTimeFormatter.string(
+                from: date,
+                relativeTo: referenceDate,
+                calendar: calendar,
+                locale: locale
+            ) == "1m"
+        )
     }
 
     @Test func hoursAndMinutes() {
-        let date = Date().addingTimeInterval(-(90 * 60))
-        #expect(ElapsedTimeFormatter.string(from: date) == "1 hr 30 mins ago")
+        let date = referenceDate.addingTimeInterval(-(90 * 60))
+        #expect(
+            ElapsedTimeFormatter.string(
+                from: date,
+                relativeTo: referenceDate,
+                calendar: calendar,
+                locale: locale
+            ) == "1h 30m"
+        )
     }
 
     @Test func hoursOnly_whenExactHours() {
-        let date = Date().addingTimeInterval(-(2 * 60 * 60))
-        #expect(ElapsedTimeFormatter.string(from: date) == "2 hrs ago")
+        let date = referenceDate.addingTimeInterval(-(2 * 60 * 60))
+        #expect(
+            ElapsedTimeFormatter.string(
+                from: date,
+                relativeTo: referenceDate,
+                calendar: calendar,
+                locale: locale
+            ) == "2h"
+        )
     }
 
     @Test func singularHour_withMinutes() {
-        let date = Date().addingTimeInterval(-(61 * 60))
-        #expect(ElapsedTimeFormatter.string(from: date) == "1 hr 1 min ago")
+        let date = referenceDate.addingTimeInterval(-(61 * 60))
+        #expect(
+            ElapsedTimeFormatter.string(
+                from: date,
+                relativeTo: referenceDate,
+                calendar: calendar,
+                locale: locale
+            ) == "1h 1m"
+        )
+    }
+
+    @Test func yesterdayUsesYesterdayAtFormat() {
+        let date = calendar.date(from: DateComponents(year: 2026, month: 4, day: 17, hour: 8, minute: 42))!
+        #expect(
+            ElapsedTimeFormatter.string(
+                from: date,
+                relativeTo: referenceDate,
+                calendar: calendar,
+                locale: locale
+            ) == "Yesterday at 8:42 AM"
+        )
+    }
+
+    @Test func olderThanYesterdayWithinWeekUsesWeekdayAndTime() {
+        let date = calendar.date(from: DateComponents(year: 2026, month: 4, day: 15, hour: 21, minute: 15))!
+        #expect(
+            ElapsedTimeFormatter.string(
+                from: date,
+                relativeTo: referenceDate,
+                calendar: calendar,
+                locale: locale
+            ) == "Wed 9:15 PM"
+        )
+    }
+
+    @Test func olderThanWeekUsesMonthDayAndTime() {
+        let date = calendar.date(from: DateComponents(year: 2026, month: 4, day: 8, hour: 6, minute: 5))!
+        #expect(
+            ElapsedTimeFormatter.string(
+                from: date,
+                relativeTo: referenceDate,
+                calendar: calendar,
+                locale: locale
+            ) == "Apr 8 6:05 AM"
+        )
     }
 }

--- a/docs/plans/081-fix-sleep-today-chart-historical-cap.md
+++ b/docs/plans/081-fix-sleep-today-chart-historical-cap.md
@@ -1,0 +1,11 @@
+# 081 Fix sleep today-chart historical truncation
+
+## Goal
+Fix the Today tab sleep chart so historical days use the full day of sleep data instead of truncating at the current clock hour.
+
+## Approach
+1. Inspect how the Summary screen builds `TodaySummaryData` for selected days.
+2. Update date handling so non-today selections calculate chart data through the end of the selected day.
+3. Verify the feature package tests still pass.
+
+- [x] Complete

--- a/docs/plans/083-fix-summary-historical-today-data.md
+++ b/docs/plans/083-fix-summary-historical-today-data.md
@@ -1,0 +1,12 @@
+# 083 Fix summary historical Today data
+
+## Goal
+Fix the Summary -> Today view so historical days, including Yesterday, calculate metrics and charts for the selected calendar day instead of drifting onto the following midnight boundary.
+
+## Approach
+1. Add an explicit selected-day path to `TodaySummaryCalculator` so historical summaries do not depend on a synthetic `now` timestamp.
+2. Update `SummaryScreenView` to pass the selected day directly to the calculator.
+3. Add regression tests covering historical-day summaries, with focused coverage on the sleep chart behavior.
+4. Run the relevant feature tests to verify the fix.
+
+- [x] Complete

--- a/docs/plans/084-align-summary-and-trends-sleep-totals.md
+++ b/docs/plans/084-align-summary-and-trends-sleep-totals.md
@@ -1,0 +1,12 @@
+# 084 Align summary and trends sleep totals
+
+## Goal
+Make the Summary -> Today sleep totals for a selected day match the Trends tab by counting only the minutes that actually overlap that calendar day.
+
+## Approach
+1. Update `TodaySummaryCalculator` sleep aggregation so selected-day totals are based on day-overlap minutes, not whole sessions keyed by `occurredAt`.
+2. Keep the hourly sleep chart and day-level totals driven by the same overlap logic.
+3. Add regression tests covering overnight sleep that spans two days and verify Today and Trends now agree for the selected day.
+4. Run the focused summary calculator tests.
+
+- [x] Complete

--- a/docs/plans/085-today-chart-average-visibility.md
+++ b/docs/plans/085-today-chart-average-visibility.md
@@ -1,0 +1,11 @@
+# 085 Today chart average visibility
+
+## Goal
+Show the average trendline continuously on Today charts, while keeping it interaction-only for historical-day charts.
+
+## Approach
+1. Update the cumulative chart view so average-line visibility depends on whether the chart is rendering Today or a historical day.
+2. Keep the current interaction-driven callout behavior unchanged.
+3. Verify the project still builds through the targeted test command already used for the summary calculators.
+
+- [x] Complete

--- a/docs/plans/086-line-chart-average-always-visible.md
+++ b/docs/plans/086-line-chart-average-always-visible.md
@@ -1,0 +1,11 @@
+# 086 Line chart average always visible
+
+## Goal
+Always show the average trendline on line charts, while keeping bar-chart averages interaction-only.
+
+## Approach
+1. Update the shared cumulative line chart view so its average series is always rendered.
+2. Leave bar-chart behavior unchanged.
+3. Run the targeted summary calculator test command to verify the change still compiles cleanly.
+
+- [x] Complete

--- a/docs/plans/087-home-relative-time-compaction.md
+++ b/docs/plans/087-home-relative-time-compaction.md
@@ -1,0 +1,12 @@
+# 087 Home relative time compaction
+
+## Goal
+Make home-screen elapsed times more compact by using short relative strings for recent events and a day-aware fallback for older events.
+
+## Approach
+1. Update `ElapsedTimeFormatter` to use compact strings like `5m`, `1h`, and `1h 12m` for events under one day old.
+2. Fall back to calendar-aware text for older events, such as `Yesterday at …` or weekday/time text.
+3. Update the dedicated formatter tests to cover the new output.
+4. Run the formatter test target to verify the change.
+
+- [x] Complete

--- a/docs/plans/088-simplify-drift-reminder-thresholds.md
+++ b/docs/plans/088-simplify-drift-reminder-thresholds.md
@@ -1,0 +1,12 @@
+## Goal
+
+Simplify drift reminder timing so reminders no longer fire based on short historical averages.
+
+## Approach
+
+1. Keep drift threshold logic inside the existing domain use cases.
+2. Replace the adaptive inactivity threshold with a fixed 12-hour threshold.
+3. Replace the adaptive sleep threshold with a fixed 16-hour threshold.
+4. Add domain tests that verify both use cases return the new fixed thresholds regardless of event history.
+
+- [x] Complete

--- a/docs/plans/089-reminder-notifications-toggle-and-profile-entry.md
+++ b/docs/plans/089-reminder-notifications-toggle-and-profile-entry.md
@@ -1,0 +1,13 @@
+## Goal
+
+Make reminder notifications easier to understand and control.
+
+## Approach
+
+1. Add a persisted reminder notification preference using the same pattern as live activities.
+2. Update `AppModel` so reminder scheduling only runs when the preference is enabled and cancels pending reminders when disabled.
+3. Rename the user-facing feature from "Drift Reminders" to "Reminder Notifications".
+4. Move the navigation entry from App Settings to the main Profile screen under Live Activities.
+5. Update the reminders screen to include a toggle and clearer explanatory copy.
+
+- [x] Complete

--- a/docs/plans/090-adjust-inactivity-reminders-day-night.md
+++ b/docs/plans/090-adjust-inactivity-reminders-day-night.md
@@ -1,0 +1,13 @@
+## Goal
+
+Adjust inactivity reminders so they nudge sooner during the day and stay less aggressive overnight.
+
+## Approach
+
+1. Keep the inactivity timing rule inside the existing domain use case.
+2. Reuse the app's existing daytime window of 6am to 10pm.
+3. Fire inactivity reminders after 6 hours for events logged during daytime.
+4. Fire inactivity reminders after 12 hours for events logged during nighttime.
+5. Update domain tests to cover both day and night cases.
+
+- [x] Complete

--- a/docs/plans/091-adjust-sleep-reminders-day-night.md
+++ b/docs/plans/091-adjust-sleep-reminders-day-night.md
@@ -1,0 +1,13 @@
+## Goal
+
+Adjust sleep reminders so they use a simpler day/night timing rule instead of a single fixed threshold.
+
+## Approach
+
+1. Keep the sleep timing rule inside the existing domain use case.
+2. Reuse the app's existing daytime window of 6am to 10pm.
+3. Fire sleep reminders after 6 hours for sleeps that start during daytime.
+4. Fire sleep reminders after 12 hours for sleeps that start during nighttime.
+5. Update domain tests to cover both day and night sleep cases.
+
+- [x] Complete

--- a/docs/plans/092-adjust-reminder-day-night-boundary.md
+++ b/docs/plans/092-adjust-reminder-day-night-boundary.md
@@ -1,0 +1,11 @@
+## Goal
+
+Align reminder timing boundaries with the intended product definition of day and night.
+
+## Approach
+
+1. Update both inactivity and sleep reminder use cases to treat daytime as 5am to 6pm.
+2. Treat nighttime as 6pm to 5am.
+3. Update drift threshold tests so the boundary behavior is covered by the new rule.
+
+- [x] Complete

--- a/docs/plans/093-adjust-timeline-initial-scroll-offset.md
+++ b/docs/plans/093-adjust-timeline-initial-scroll-offset.md
@@ -1,0 +1,12 @@
+## Goal
+
+Move the timeline screen's initial viewport slightly upward so the current time is not positioned too close to the bottom edge on first load.
+
+## Approach
+
+- Keep the existing initial-scroll behavior based on the visible hour.
+- Add a dedicated invisible scroll target slightly below each hour anchor in the day grid.
+- Update the page view to use that offset target for initial scrolling so the viewport lands about 50 points higher.
+- Verify the app still builds and the full test suite still passes.
+
+- [x] Complete


### PR DESCRIPTION
### Motivation
- This branch no longer only fixes the historical Today summary sleep chart cap. It now also includes follow-on summary/chart corrections, more compact home relative time text, and a substantial rework of reminder notifications.

### Description
- Fix historical Today summary calculation boundaries so selected past days use the full selected calendar day instead of drifting onto the current clock boundary.
- Align summary and trend sleep totals and related chart behavior, including average-line visibility refinements.
- Compact relative time labels on Home.
- Rework reminder notifications:
- simplify inactivity and sleep thresholds into day/night rules
- rename the user-facing feature from `Drift Reminders` to `Reminder Notifications`
- add a persisted on/off preference
- move the entry point to the main Profile screen under `Live Activities`
- add a toggle and clearer user-facing copy on the reminders screen
- make the effective enabled state depend on both saved preference and current notification permission
- prompt users to open Settings when they try to enable reminders without notification permission
- Add and update plan documents in `docs/plans/081-092` for the work captured in this branch.

### Testing
- Not fully verified in this environment.
- `swift test` / `swift build` for the affected packages are currently blocked by unrelated existing macOS availability issues in `BabyTrackerDomain`.
- I did not have a clean package-level verification path available here after the branch evolved.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e31f687c78832f8f98c5aac2c8530b)