### PR TITLE
Add 100 ml quick amount option to Bottle Feed sheet

### DIFF
--- a/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/BottleFeedEditorSheetView.swift
+++ b/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/BottleFeedEditorSheetView.swift
@@ -19,7 +19,7 @@ public struct BottleFeedEditorSheetView: View {
     @State private var showCustomAmount: Bool = false
     private let initialTimePreset: QuickTimeSelectorView.TimePreset
 
-    private let quickAmountOptionsMilliliters = [10, 20, 30, 40, 50, 60, 70, 80, 90, 110, 120]
+    private let quickAmountOptionsMilliliters = [10, 20, 30, 40, 50, 60, 70, 80, 90, 100, 110, 120]
 
     private let amountColumns = [
         GridItem(.flexible(), spacing: 8),

--- a/docs/plans/096-bottle-feed-sheet-add-100ml-preset.md
+++ b/docs/plans/096-bottle-feed-sheet-add-100ml-preset.md
@@ -1,0 +1,11 @@
+# 096 - Bottle feed sheet add 100ml preset
+
+## Goal
+Add a 100 ml quick-select amount option to the bottle feed editor sheet so caregivers can log that common amount with one tap.
+
+## Approach
+1. Locate the quick amount preset list used by `BottleFeedEditorSheetView` for milliliter mode.
+2. Insert `100` into the milliliter preset options while preserving the existing ascending order.
+3. Run targeted checks to confirm the project still builds/tests cleanly for the touched module.
+
+- [x] Complete


### PR DESCRIPTION
### Motivation
- Add a 100 ml quick-select preset to the bottle feed editor sheet so caregivers can log that common amount with one tap.

### Description
- Insert `100` into `quickAmountOptionsMilliliters` in `Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/BottleFeedEditorSheetView.swift` and add the plan document `docs/plans/096-bottle-feed-sheet-add-100ml-preset.md`.

### Testing
- Ran `swift test --package-path Packages/BabyTrackerFeature`, which failed in this environment because the package requires Swift tools version `6.2.0` but the installed version is `6.1.3`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e3eb4a0a78832f9eea8f671206c1d8)