### PR TITLE
Fix Live Activity bugs and improvements

### DIFF
--- a/Baby Tracker Live Activities/BabyEventKindAccentColor.swift
+++ b/Baby Tracker Live Activities/BabyEventKindAccentColor.swift
@@ -1,0 +1,17 @@
+import BabyTrackerDomain
+import SwiftUI
+
+extension BabyEventKind {
+    var accentColor: Color {
+        switch self {
+        case .breastFeed:
+            Color(red: 0.84, green: 0.29, blue: 0.42)
+        case .bottleFeed:
+            Color(red: 0.15, green: 0.56, blue: 0.72)
+        case .sleep:
+            Color(red: 0.29, green: 0.33, blue: 0.73)
+        case .nappy:
+            Color(red: 0.74, green: 0.47, blue: 0.16)
+        }
+    }
+}

--- a/Baby Tracker Live Activities/FeedLiveActivityContentView.swift
+++ b/Baby Tracker Live Activities/FeedLiveActivityContentView.swift
@@ -25,7 +25,7 @@ struct FeedLiveActivityContentView: View {
                 metricTile(
                     title: "Feed",
                     icon: symbolName(for: state.lastFeedKind),
-                    color: eventAccentColor(for: .bottleFeed)
+                    color: eventAccentColor(for: state.lastFeedKind)
                 ) {
                     Text(state.lastFeedAt, style: .timer).timerStyle()
                 }

--- a/Baby Tracker Live Activities/FeedLiveActivityContentView.swift
+++ b/Baby Tracker Live Activities/FeedLiveActivityContentView.swift
@@ -25,7 +25,7 @@ struct FeedLiveActivityContentView: View {
                 metricTile(
                     title: "Feed",
                     icon: symbolName(for: state.lastFeedKind),
-                    color: eventAccentColor(for: state.lastFeedKind)
+                    color: state.lastFeedKind.accentColor
                 ) {
                     Text(state.lastFeedAt, style: .timer).timerStyle()
                 }
@@ -33,7 +33,7 @@ struct FeedLiveActivityContentView: View {
                 metricTile(
                     title: state.activeSleepStartedAt == nil ? "Since sleep" : "Asleep",
                     icon: symbolName(for: .sleep),
-                    color: eventAccentColor(for: .sleep)
+                    color: BabyEventKind.sleep.accentColor
                 ) {
                     if let activeSleepStartedAt = state.activeSleepStartedAt {
                         Text(activeSleepStartedAt, style: .timer).timerStyle()
@@ -47,7 +47,7 @@ struct FeedLiveActivityContentView: View {
                 metricTile(
                     title: "Nappy",
                     icon: symbolName(for: .nappy),
-                    color: eventAccentColor(for: .nappy)
+                    color: BabyEventKind.nappy.accentColor
                 ) {
                     if let lastNappyAt = state.lastNappyAt {
                         Text(lastNappyAt, style: .timer).timerStyle()
@@ -64,7 +64,7 @@ struct FeedLiveActivityContentView: View {
                         .frame(maxWidth: .infinity)
                 }
                 .buttonStyle(.borderedProminent)
-                .tint(eventAccentColor(for: .sleep))
+                .tint(BabyEventKind.sleep.accentColor)
             }
         }
         .padding(.horizontal, 16)
@@ -121,18 +121,6 @@ struct FeedLiveActivityContentView: View {
         }
     }
 
-    private func eventAccentColor(for kind: BabyEventKind) -> Color {
-        switch kind {
-        case .breastFeed:
-            Color(red: 0.84, green: 0.29, blue: 0.42)
-        case .bottleFeed:
-            Color(red: 0.15, green: 0.56, blue: 0.72)
-        case .sleep:
-            Color(red: 0.29, green: 0.33, blue: 0.73)
-        case .nappy:
-            Color(red: 0.74, green: 0.47, blue: 0.16)
-        }
-    }
 }
 
 #Preview("Recent Feed") {

--- a/Baby Tracker Live Activities/FeedLiveActivityWidget.swift
+++ b/Baby Tracker Live Activities/FeedLiveActivityWidget.swift
@@ -124,14 +124,14 @@ struct FeedLiveActivityWidget: Widget {
             timerInterval: date...Date.distantFuture,
             pauseTime: nil,
             countsDown: false,
-            showsHours: false
+            showsHours: true
         )
         .font(.caption2.weight(.semibold))
         .monospacedDigit()
         .minimumScaleFactor(0.7)
         .lineLimit(1)
         .foregroundStyle(color)
-        .frame(width: 40, alignment: .trailing)
+        .frame(width: 52, alignment: .trailing)
     }
 }
 

--- a/Baby Tracker Live Activities/FeedLiveActivityWidget.swift
+++ b/Baby Tracker Live Activities/FeedLiveActivityWidget.swift
@@ -33,7 +33,7 @@ struct FeedLiveActivityWidget: Widget {
     private func compactLeadingView(for state: FeedLiveActivityAttributes.ContentState) -> some View {
         let compactMetric = compactDynamicIslandMetric(for: state)
         Image(systemName: symbolName(for: compactMetric))
-            .foregroundStyle(eventAccentColor(for: compactMetric.kind))
+            .foregroundStyle(compactMetric.kind.accentColor)
     }
 
     @ViewBuilder
@@ -41,7 +41,7 @@ struct FeedLiveActivityWidget: Widget {
         let compactMetric = compactDynamicIslandMetric(for: state)
         compactTimerText(
             since: compactMetric.date,
-            color: eventAccentColor(for: compactMetric.kind)
+            color: compactMetric.kind.accentColor
         )
     }
 
@@ -49,7 +49,7 @@ struct FeedLiveActivityWidget: Widget {
     private func minimalView(for state: FeedLiveActivityAttributes.ContentState) -> some View {
         let compactMetric = compactDynamicIslandMetric(for: state)
         Image(systemName: symbolName(for: compactMetric))
-            .foregroundStyle(eventAccentColor(for: compactMetric.kind))
+            .foregroundStyle(compactMetric.kind.accentColor)
     }
 
     private func symbolName(for metric: CompactDynamicIslandMetric) -> String {
@@ -62,19 +62,6 @@ struct FeedLiveActivityWidget: Widget {
             metric.isActiveSleep ? "zzz" : "bed.double.fill"
         case .nappy:
             "checklist"
-        }
-    }
-
-    private func eventAccentColor(for kind: BabyEventKind) -> Color {
-        switch kind {
-        case .breastFeed:
-            Color(red: 0.84, green: 0.29, blue: 0.42)
-        case .bottleFeed:
-            Color(red: 0.15, green: 0.56, blue: 0.72)
-        case .sleep:
-            Color(red: 0.29, green: 0.33, blue: 0.73)
-        case .nappy:
-            Color(red: 0.74, green: 0.47, blue: 0.16)
         }
     }
 

--- a/Baby Tracker/App/FeedLiveActivityManager.swift
+++ b/Baby Tracker/App/FeedLiveActivityManager.swift
@@ -8,6 +8,10 @@ final class FeedLiveActivityManager: FeedLiveActivityManaging {
     private var activeActivityID: String?
     private var synchronizationTask: Task<Void, Never>?
 
+    var hasRunningActivity: Bool {
+        !Activity<FeedLiveActivityAttributes>.activities.isEmpty
+    }
+
     func synchronize(with snapshot: FeedLiveActivitySnapshot?) {
         synchronizationTask?.cancel()
         synchronizationTask = Task { @MainActor [weak self] in

--- a/Baby Tracker/App/FeedLiveActivityManager.swift
+++ b/Baby Tracker/App/FeedLiveActivityManager.swift
@@ -7,6 +7,7 @@ import Foundation
 final class FeedLiveActivityManager: FeedLiveActivityManaging {
     private var activeActivityID: String?
     private var synchronizationTask: Task<Void, Never>?
+    private var stateObservationTask: Task<Void, Never>?
 
     var hasRunningActivity: Bool {
         !Activity<FeedLiveActivityAttributes>.activities.isEmpty
@@ -23,6 +24,8 @@ final class FeedLiveActivityManager: FeedLiveActivityManaging {
         let activities = Activity<FeedLiveActivityAttributes>.activities
 
         guard let snapshot else {
+            stateObservationTask?.cancel()
+            stateObservationTask = nil
             await Self.endAllActivities()
             activeActivityID = nil
             return
@@ -32,7 +35,10 @@ final class FeedLiveActivityManager: FeedLiveActivityManaging {
             activity.attributes.childID == snapshot.childID
         }) {
             activeActivityID = matchingActivity.id
+            observeActivityState(matchingActivity)
         } else if !activities.isEmpty {
+            stateObservationTask?.cancel()
+            stateObservationTask = nil
             await Self.endAllActivities()
             activeActivityID = nil
         } else {
@@ -63,8 +69,22 @@ final class FeedLiveActivityManager: FeedLiveActivityManaging {
                 pushType: nil
             )
             activeActivityID = activity.id
+            observeActivityState(activity)
         } catch {
             activeActivityID = nil
+        }
+    }
+
+    private func observeActivityState(_ activity: Activity<FeedLiveActivityAttributes>) {
+        stateObservationTask?.cancel()
+        stateObservationTask = Task { @MainActor [weak self] in
+            for await state in activity.activityStateUpdates {
+                if state == .ended || state == .dismissed {
+                    self?.activeActivityID = nil
+                    self?.stateObservationTask = nil
+                    return
+                }
+            }
         }
     }
 

--- a/Baby Tracker/App/FeedLiveActivityManager.swift
+++ b/Baby Tracker/App/FeedLiveActivityManager.swift
@@ -77,7 +77,8 @@ final class FeedLiveActivityManager: FeedLiveActivityManaging {
                 activeSleepStartedAt: snapshot.activeSleepStartedAt,
                 lastNappyAt: snapshot.lastNappyAt
             ),
-            staleDate: nil
+            staleDate: nil,
+            relevanceScore: 50
         )
     }
 

--- a/Baby Tracker/Info.plist
+++ b/Baby Tracker/Info.plist
@@ -2,6 +2,8 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>NSSupportsLiveActivitiesFrequentUpdates</key>
+	<true/>
 	<key>CKSharingSupported</key>
 	<true/>
 	<key>UIBackgroundModes</key>

--- a/Baby TrackerTests/AppModelTests.swift
+++ b/Baby TrackerTests/AppModelTests.swift
@@ -1961,6 +1961,7 @@ extension AppModelTests {
 
     @MainActor
     private final class LiveActivityManagerSpy: FeedLiveActivityManaging {
+        var hasRunningActivity: Bool = false
         private(set) var snapshots: [FeedLiveActivitySnapshot?] = []
         private var _currentSnapshot: FeedLiveActivitySnapshot?
 

--- a/Baby TrackerTests/UpdateFeedLiveActivityUseCaseTests.swift
+++ b/Baby TrackerTests/UpdateFeedLiveActivityUseCaseTests.swift
@@ -93,6 +93,7 @@ struct UpdateFeedLiveActivityUseCaseTests {
 
 @MainActor
 private final class LiveActivityManagerSpy: FeedLiveActivityManaging {
+    var hasRunningActivity: Bool = false
     private(set) var snapshots: [FeedLiveActivitySnapshot?] = []
 
     var latestSnapshot: FeedLiveActivitySnapshot? {

--- a/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/FeedLiveActivityManaging.swift
+++ b/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/FeedLiveActivityManaging.swift
@@ -2,5 +2,6 @@ import Foundation
 
 @MainActor
 public protocol FeedLiveActivityManaging: AnyObject {
+    var hasRunningActivity: Bool { get }
     func synchronize(with snapshot: FeedLiveActivitySnapshot?)
 }

--- a/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/NoOpFeedLiveActivityManager.swift
+++ b/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/NoOpFeedLiveActivityManager.swift
@@ -4,6 +4,8 @@ import Foundation
 public final class NoOpFeedLiveActivityManager: FeedLiveActivityManaging {
     public init() {}
 
+    public var hasRunningActivity: Bool { false }
+
     public func synchronize(with snapshot: FeedLiveActivitySnapshot?) {
         _ = snapshot
     }

--- a/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/UseCases/UpdateFeedLiveActivityUseCase.swift
+++ b/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/UseCases/UpdateFeedLiveActivityUseCase.swift
@@ -24,7 +24,11 @@ public enum UpdateFeedLiveActivityUseCase {
             activeSleep: activeSleep
         )
 
-        guard snapshot != snapshotCache.load() else {
+        // Bypass deduplication when no activity is running — the activity may have been
+        // ended by the system (8-hour limit, low battery, user dismissal) while the
+        // cached snapshot still matches, which would prevent a restart.
+        let activityIsDead = !liveActivityManager.hasRunningActivity
+        guard snapshot != snapshotCache.load() || activityIsDead else {
             return
         }
 

--- a/Packages/BabyTrackerFeature/Tests/BabyTrackerFeatureTests/Helpers/SpyFeedLiveActivityManager.swift
+++ b/Packages/BabyTrackerFeature/Tests/BabyTrackerFeatureTests/Helpers/SpyFeedLiveActivityManager.swift
@@ -2,6 +2,7 @@
 
 @MainActor
 final class SpyFeedLiveActivityManager: FeedLiveActivityManaging {
+    var hasRunningActivity: Bool = false
     private(set) var synchronizeCalls: [FeedLiveActivitySnapshot?] = []
 
     func synchronize(with snapshot: FeedLiveActivitySnapshot?) {


### PR DESCRIPTION
## Summary

Fixes the out-of-sync Live Activity bug and addresses several other issues identified via an audit against Apple's ActivityKit documentation.

- **Root cause fix**: The snapshot cache was preventing the Live Activity from restarting after iOS ended it (8-hour limit, low battery, user dismissal). The dedup guard in `UpdateFeedLiveActivityUseCase` was returning early when data hadn't changed, so the activity was never restarted. Fixed by checking `hasRunningActivity` before applying the cache guard.
- **Bug fix**: Feed tile on the lock screen was always showing the bottle feed accent colour regardless of actual feed type.
- **Improvement**: Manager now observes `activityStateUpdates` and clears `activeActivityID` immediately when iOS ends the activity.
- **Improvement**: Added `NSSupportsLiveActivitiesFrequentUpdates` to `Info.plist` to avoid throttling when multiple events are logged quickly.
- **Improvement**: Set `relevanceScore: 50` on `ActivityContent` so the activity competes fairly in the compact Dynamic Island.
- **Improvement**: Compact Dynamic Island timer now shows hours (`showsHours: true`) — previously showed "75:42" instead of "1:15:42".
- **Refactor**: Extracted the duplicated `eventAccentColor` helper into a shared `BabyEventKind.accentColor` extension.

## Commits

| # | Description |
|---|-------------|
| 1 | Fix feed tile color always using bottle feed accent colour |
| 2 | Extract `eventAccentColor` into a shared `BabyEventKind` extension |
| 3 | Show hours in compact Dynamic Island timer |
| 4 | Set `relevanceScore` on Live Activity content |
| 5 | Add `NSSupportsLiveActivitiesFrequentUpdates` to Info.plist |
| 6 | Fix snapshot cache preventing Live Activity restart after system termination |
| 7 | Observe `activityStateUpdates` to clear `activeActivityID` when activity ends |

## Test plan

- [ ] All 159 existing tests pass (verified locally)
- [ ] Toggle Live Activity off and on — confirm it restarts correctly
- [ ] Leave the app open for an extended period or simulate the 8-hour limit — confirm the activity restarts on next event log without needing the toggle
- [ ] Log a breast feed — confirm the feed tile shows the pink accent colour on the lock screen
- [ ] Wait more than 1 hour since last event — confirm the compact Dynamic Island shows e.g. "1:15:42" rather than "75:42"

No GitHub issue was created — this work was directly driven by a documentation audit and a reported sync bug from the developer.

Related plan document: none (this was a targeted bug fix and improvement pass, not a planned feature).

🤖 Generated with [Claude Code](https://claude.com/claude-code)