### PR TITLE
Fix log event sheet accent color to use event color instead of global app color

### DIFF
--- a/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/BottleFeedEditorSheetView.swift
+++ b/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/BottleFeedEditorSheetView.swift
@@ -142,7 +142,6 @@ public struct BottleFeedEditorSheetView: View {
             } message: {
                 Text("This event will be permanently removed.")
             }
-            .tint(Self.eventColor)
             .scrollContentBackground(.hidden)
             .background(Self.eventColor.opacity(0.08))
             .navigationTitle(navigationTitle)
@@ -170,6 +169,7 @@ public struct BottleFeedEditorSheetView: View {
                 }
             }
         }
+        .tint(Self.eventColor)
     }
 
     private var milkTypeButtons: some View {

--- a/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/BreastFeedEditorSheetView.swift
+++ b/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/BreastFeedEditorSheetView.swift
@@ -114,7 +114,6 @@ public struct BreastFeedEditorSheetView: View {
             } message: {
                 Text("This event will be permanently removed.")
             }
-            .tint(Self.eventColor)
             .scrollContentBackground(.hidden)
             .background(Self.eventColor.opacity(0.08))
             .navigationTitle(navigationTitle)
@@ -139,6 +138,7 @@ public struct BreastFeedEditorSheetView: View {
                 }
             }
         }
+        .tint(Self.eventColor)
     }
 
     // MARK: - Timer Mode

--- a/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/NappyEditorSheetView.swift
+++ b/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/NappyEditorSheetView.swift
@@ -107,7 +107,6 @@ public struct NappyEditorSheetView: View {
             } message: {
                 Text("This event will be permanently removed.")
             }
-            .tint(Self.eventColor)
             .scrollContentBackground(.hidden)
             .background(Self.eventColor.opacity(0.08))
             .navigationTitle(navigationTitle)
@@ -148,6 +147,7 @@ public struct NappyEditorSheetView: View {
                 }
             }
         }
+        .tint(Self.eventColor)
     }
 
     private var typeSelectorButtons: some View {

--- a/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/SleepEditorSheetView.swift
+++ b/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/SleepEditorSheetView.swift
@@ -90,7 +90,6 @@ public struct SleepEditorSheetView: View {
             } message: {
                 Text("This event will be permanently removed.")
             }
-            .tint(Self.eventColor)
             .scrollContentBackground(.hidden)
             .background(Self.eventColor.opacity(0.08))
             .navigationTitle(mode.navigationTitle)
@@ -115,6 +114,7 @@ public struct SleepEditorSheetView: View {
                 }
             }
         }
+        .tint(Self.eventColor)
     }
 
     // MARK: - Start Mode


### PR DESCRIPTION
## Summary

- Moves `.tint(Self.eventColor)` from the `Form` to the `NavigationStack` in all four log event editor sheets (bottle feed, breast feed, sleep, nappy)
- Toolbar buttons (Cancel, Save) in the navigation bar are rendered at the `NavigationStack` level and inherit tint from it — not from the `Form` — so they were falling back to the global app accent color set in `AppRootView`
- Applying the tint at the `NavigationStack` boundary ensures every control on the sheet uses the event-specific color consistently

## Root cause

Each sheet had this structure:

```swift
NavigationStack {          // inherits global app tint
    Form { ... }
    .tint(Self.eventColor) // only Form children got the event color
    .toolbar { ... }       // toolbar buttons rendered by NavigationStack → global color
}
```

Fixed by moving the modifier one level up:

```swift
NavigationStack { ... }
.tint(Self.eventColor)     // all children including toolbar buttons get event color
```

## Test plan

- [ ] Open each log event sheet (bottle, breast feed, sleep, nappy) and verify the Cancel and Save toolbar buttons use the event-specific color (blue, pink, indigo, brown) rather than the global app accent color
- [ ] Confirm all other controls (steppers, toggles, pickers, sliders, text field cursor) continue to use the event color as before
- [ ] Change the global app accent color in Settings and re-open each sheet — toolbar buttons should still show the event color, not the new global color

Closes #238

---
_Generated by [Claude Code](https://claude.ai/code/session_01USE7iDRjGWpAqZvsUEpFwk)_