### PR TITLE
Show today's events as markers on summary charts

### DIFF
--- a/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/HourlyEventMarkers.swift
+++ b/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/HourlyEventMarkers.swift
@@ -1,0 +1,24 @@
+import BabyTrackerDomain
+import Foundation
+
+public struct BottleEventMarker: Equatable, Sendable {
+    public let amountMilliliters: Int
+    public let milkType: MilkType?
+    public let time: String
+}
+
+public struct BreastEventMarker: Equatable, Sendable {
+    public let side: BreastSide?
+    public let durationMinutes: Int
+    public let time: String
+}
+
+public struct SleepEventMarker: Equatable, Sendable {
+    public let durationMinutes: Int
+    public let wakeTime: String
+}
+
+public struct NappyEventMarker: Equatable, Sendable {
+    public let type: NappyType
+    public let time: String
+}

--- a/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/TodayChartData.swift
+++ b/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/TodayChartData.swift
@@ -44,6 +44,18 @@ public struct TodayChartData: Equatable, Sendable {
     /// Cumulative poo-inclusive nappy count per hour (poo + mixed).
     public let nappyPooIncludingMixed: HourlyCumulativeSeries
 
+    /// Individual bottle feed events per hour for the selected day.
+    public let bottleHourlyMarkers: [[BottleEventMarker]]
+
+    /// Individual breast feed events per hour for the selected day.
+    public let breastHourlyMarkers: [[BreastEventMarker]]
+
+    /// Completed sleep end events per hour for the selected day.
+    public let sleepHourlyMarkers: [[SleepEventMarker]]
+
+    /// Individual nappy change events per hour for the selected day.
+    public let nappyHourlyMarkers: [[NappyEventMarker]]
+
     public init(
         bottle: HourlyCumulativeSeries,
         bottleFormula: HourlyCumulativeSeries,
@@ -58,7 +70,11 @@ public struct TodayChartData: Equatable, Sendable {
         nappyPoo: HourlyCumulativeSeries,
         nappyMixed: HourlyCumulativeSeries,
         nappyPeeIncludingMixed: HourlyCumulativeSeries,
-        nappyPooIncludingMixed: HourlyCumulativeSeries
+        nappyPooIncludingMixed: HourlyCumulativeSeries,
+        bottleHourlyMarkers: [[BottleEventMarker]],
+        breastHourlyMarkers: [[BreastEventMarker]],
+        sleepHourlyMarkers: [[SleepEventMarker]],
+        nappyHourlyMarkers: [[NappyEventMarker]]
     ) {
         self.bottle = bottle
         self.bottleFormula = bottleFormula
@@ -74,5 +90,9 @@ public struct TodayChartData: Equatable, Sendable {
         self.nappyMixed = nappyMixed
         self.nappyPeeIncludingMixed = nappyPeeIncludingMixed
         self.nappyPooIncludingMixed = nappyPooIncludingMixed
+        self.bottleHourlyMarkers = bottleHourlyMarkers
+        self.breastHourlyMarkers = breastHourlyMarkers
+        self.sleepHourlyMarkers = sleepHourlyMarkers
+        self.nappyHourlyMarkers = nappyHourlyMarkers
     }
 }

--- a/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/TodaySummaryCalculator.swift
+++ b/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/TodaySummaryCalculator.swift
@@ -327,8 +327,82 @@ public enum TodaySummaryCalculator {
                         includes: { $0.type == .poo || $0.type == .mixed }
                     )
                 }
-            )
+            ),
+            bottleHourlyMarkers: makeBottleHourlyMarkers(events: todayEvents, calendar: calendar),
+            breastHourlyMarkers: makeBreastHourlyMarkers(events: todayEvents, calendar: calendar),
+            sleepHourlyMarkers: makeSleepHourlyMarkers(events: todayEvents, calendar: calendar),
+            nappyHourlyMarkers: makeNappyHourlyMarkers(events: todayEvents, calendar: calendar)
         )
+    }
+
+    // MARK: - Hourly event markers
+
+    private static let markerTimeFormatter: DateFormatter = {
+        let f = DateFormatter()
+        f.dateStyle = .none
+        f.timeStyle = .short
+        return f
+    }()
+
+    private static func makeBottleHourlyMarkers(events: [BabyEvent], calendar: Calendar) -> [[BottleEventMarker]] {
+        var result = [[BottleEventMarker]](repeating: [], count: 24)
+        let sorted = events.sorted { $0.metadata.occurredAt < $1.metadata.occurredAt }
+        for event in sorted {
+            guard case let .bottleFeed(feed) = event else { continue }
+            let h = calendar.component(.hour, from: feed.metadata.occurredAt)
+            result[h].append(BottleEventMarker(
+                amountMilliliters: feed.amountMilliliters,
+                milkType: feed.milkType,
+                time: markerTimeFormatter.string(from: feed.metadata.occurredAt)
+            ))
+        }
+        return result
+    }
+
+    private static func makeBreastHourlyMarkers(events: [BabyEvent], calendar: Calendar) -> [[BreastEventMarker]] {
+        var result = [[BreastEventMarker]](repeating: [], count: 24)
+        let sorted = events.sorted { $0.metadata.occurredAt < $1.metadata.occurredAt }
+        for event in sorted {
+            guard case let .breastFeed(feed) = event else { continue }
+            let h = calendar.component(.hour, from: feed.endedAt)
+            let durationMinutes = max(1, Int(feed.endedAt.timeIntervalSince(feed.startedAt) / 60))
+            result[h].append(BreastEventMarker(
+                side: feed.side,
+                durationMinutes: durationMinutes,
+                time: markerTimeFormatter.string(from: feed.endedAt)
+            ))
+        }
+        return result
+    }
+
+    private static func makeSleepHourlyMarkers(events: [BabyEvent], calendar: Calendar) -> [[SleepEventMarker]] {
+        var result = [[SleepEventMarker]](repeating: [], count: 24)
+        let sorted = events.sorted { $0.metadata.occurredAt < $1.metadata.occurredAt }
+        for event in sorted {
+            guard case let .sleep(sleep) = event, let endedAt = sleep.endedAt else { continue }
+            let h = calendar.component(.hour, from: endedAt)
+            guard h < 24 else { continue }
+            let durationMinutes = max(0, Int(endedAt.timeIntervalSince(sleep.startedAt) / 60))
+            result[h].append(SleepEventMarker(
+                durationMinutes: durationMinutes,
+                wakeTime: markerTimeFormatter.string(from: endedAt)
+            ))
+        }
+        return result
+    }
+
+    private static func makeNappyHourlyMarkers(events: [BabyEvent], calendar: Calendar) -> [[NappyEventMarker]] {
+        var result = [[NappyEventMarker]](repeating: [], count: 24)
+        let sorted = events.sorted { $0.metadata.occurredAt < $1.metadata.occurredAt }
+        for event in sorted {
+            guard case let .nappy(nappy) = event else { continue }
+            let h = calendar.component(.hour, from: nappy.metadata.occurredAt)
+            result[h].append(NappyEventMarker(
+                type: nappy.type,
+                time: markerTimeFormatter.string(from: nappy.metadata.occurredAt)
+            ))
+        }
+        return result
     }
 
     /// Builds a `HourlyCumulativeSeries` from per-hour amounts.

--- a/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/CumulativeLineChartView.swift
+++ b/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/CumulativeLineChartView.swift
@@ -13,6 +13,10 @@ struct CumulativeLineChartView: View {
     let tint: Color
     let isToday: Bool
     let valueFormatter: (Int) -> String
+    /// Pre-formatted event descriptions per hour (24 arrays). Hours with at least
+    /// one string get a small marker dot on the cumulative line; tapping that hour
+    /// shows the event list in the selection callout.
+    let eventMarkers: [[String]]
 
     @State private var selectedHour: Int?
 
@@ -20,12 +24,14 @@ struct CumulativeLineChartView: View {
         series: HourlyCumulativeSeries,
         tint: Color,
         isToday: Bool = true,
-        valueFormatter: @escaping (Int) -> String = { "\($0)" }
+        valueFormatter: @escaping (Int) -> String = { "\($0)" },
+        eventMarkers: [[String]] = Array(repeating: [], count: 24)
     ) {
         self.series = series
         self.tint = tint
         self.isToday = isToday
         self.valueFormatter = valueFormatter
+        self.eventMarkers = eventMarkers
     }
 
     var body: some View {
@@ -54,6 +60,16 @@ struct CumulativeLineChartView: View {
                 .interpolationMethod(.monotone)
                 .foregroundStyle(tint)
                 .lineStyle(StrokeStyle(lineWidth: 2, lineCap: .round, lineJoin: .round))
+            }
+
+            // Event markers — small dots on the cumulative line at hours where events occurred.
+            ForEach(eventMarkerPoints) { point in
+                PointMark(
+                    x: .value("Hour", point.hour),
+                    y: .value("Event", point.value)
+                )
+                .symbolSize(40)
+                .foregroundStyle(tint)
             }
 
             // "Now" indicator — only shown for today; selection callout renders on top due to mark order.
@@ -135,6 +151,13 @@ struct CumulativeLineChartView: View {
         series.averageCumulative.enumerated().map { HourPoint(id: $0, hour: $0, value: $1) }
     }
 
+    private var eventMarkerPoints: [HourPoint] {
+        let hourLimit = isToday ? currentHour + 1 : 24
+        return (0..<min(eventMarkers.count, 24))
+            .filter { $0 < hourLimit && !eventMarkers[$0].isEmpty }
+            .map { HourPoint(id: $0, hour: $0, value: series.todayCumulative[$0]) }
+    }
+
     private var maxValue: Int {
         max(1, (series.todayCumulative + series.averageCumulative).max() ?? 1)
     }
@@ -142,11 +165,19 @@ struct CumulativeLineChartView: View {
     private func selectionCallout(for hour: Int) -> some View {
         let todayVal = series.todayCumulative[hour]
         let avgVal = series.averageCumulative[hour]
+        let events = hour < eventMarkers.count ? eventMarkers[hour] : []
         return VStack(alignment: .leading, spacing: 2) {
             if !isToday || hour <= currentHour {
                 Text("Today: \(valueFormatter(todayVal))").foregroundStyle(tint)
             }
             Text("Avg: \(valueFormatter(avgVal))").foregroundStyle(.secondary)
+            if !events.isEmpty {
+                Divider()
+                    .padding(.vertical, 1)
+                ForEach(events.indices, id: \.self) { i in
+                    Text("· \(events[i])").foregroundStyle(.primary)
+                }
+            }
         }
         .font(.caption2.weight(.medium))
         .padding(.horizontal, 8)
@@ -173,7 +204,14 @@ private struct HourPoint: Identifiable {
     CumulativeLineChartView(
         series: HourlyCumulativeSeries(todayCumulative: rising, averageCumulative: avg),
         tint: .blue,
-        valueFormatter: { "\($0)" }
+        valueFormatter: { "\($0)" },
+        eventMarkers: {
+            var m = Array(repeating: [String](), count: 24)
+            m[7] = ["100ml · 7:00 AM"]
+            m[10] = ["150ml · 10:30 AM"]
+            m[14] = ["100ml · 2:00 PM"]
+            return m
+        }()
     )
     .padding()
 }

--- a/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/SummaryScreenView.swift
+++ b/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/SummaryScreenView.swift
@@ -42,6 +42,17 @@ private enum TodayNappyChartFilter: String, TodayChartFilter {
         case .pooIncludingMixed: data.nappyPooIncludingMixed
         }
     }
+
+    func filterMarkers(_ markers: [[NappyEventMarker]]) -> [[NappyEventMarker]] {
+        switch self {
+        case .all: markers
+        case .pee: markers.map { $0.filter { $0.type == .wee } }
+        case .poo: markers.map { $0.filter { $0.type == .poo } }
+        case .mixed: markers.map { $0.filter { $0.type == .mixed } }
+        case .peeIncludingMixed: markers.map { $0.filter { $0.type == .wee || $0.type == .mixed } }
+        case .pooIncludingMixed: markers.map { $0.filter { $0.type == .poo || $0.type == .mixed } }
+        }
+    }
 }
 
 private enum TodayBottleChartFilter: String, TodayChartFilter {
@@ -73,6 +84,17 @@ private enum TodayBottleChartFilter: String, TodayChartFilter {
         case .mixed: data.bottleMixed
         case .formulaIncludingMixed: data.bottleFormulaIncludingMixed
         case .breastMilkIncludingMixed: data.bottleBreastMilkIncludingMixed
+        }
+    }
+
+    func filterMarkers(_ markers: [[BottleEventMarker]]) -> [[BottleEventMarker]] {
+        switch self {
+        case .all: markers
+        case .formula: markers.map { $0.filter { $0.milkType == .formula } }
+        case .breastMilk: markers.map { $0.filter { $0.milkType == .breastMilk } }
+        case .mixed: markers.map { $0.filter { $0.milkType == .mixed } }
+        case .formulaIncludingMixed: markers.map { $0.filter { $0.milkType == .formula || $0.milkType == .mixed } }
+        case .breastMilkIncludingMixed: markers.map { $0.filter { $0.milkType == .breastMilk || $0.milkType == .mixed } }
         }
     }
 }
@@ -395,7 +417,8 @@ public struct SummaryScreenView: View {
                 isToday: isSelectedDateToday,
                 valueFormatter: { value in
                     FeedVolumePresentation.amountText(for: value, unit: preferredUnit)
-                }
+                },
+                eventMarkers: bottleEventMarkers(from: data.chartData, unit: preferredUnit)
             )
                 .padding(.top, 4)
         }
@@ -451,7 +474,12 @@ public struct SummaryScreenView: View {
                     .foregroundStyle(.secondary)
             }
 
-            CumulativeLineChartView(series: data.chartData.breast, tint: .pink, isToday: isSelectedDateToday)
+            CumulativeLineChartView(
+                series: data.chartData.breast,
+                tint: .pink,
+                isToday: isSelectedDateToday,
+                eventMarkers: breastEventMarkers(from: data.chartData)
+            )
                 .padding(.top, 4)
         }
     }
@@ -480,7 +508,12 @@ public struct SummaryScreenView: View {
                     .foregroundStyle(.secondary)
             }
 
-            CumulativeLineChartView(series: data.chartData.sleep, tint: .indigo, isToday: isSelectedDateToday)
+            CumulativeLineChartView(
+                series: data.chartData.sleep,
+                tint: .indigo,
+                isToday: isSelectedDateToday,
+                eventMarkers: sleepEventMarkers(from: data.chartData)
+            )
                 .padding(.top, 4)
         }
     }
@@ -533,7 +566,12 @@ public struct SummaryScreenView: View {
                     .foregroundStyle(.secondary)
             }
 
-            CumulativeLineChartView(series: selectedNappyFilter.series(from: data.chartData), tint: .green, isToday: isSelectedDateToday)
+            CumulativeLineChartView(
+                series: selectedNappyFilter.series(from: data.chartData),
+                tint: .green,
+                isToday: isSelectedDateToday,
+                eventMarkers: nappyEventMarkers(from: data.chartData)
+            )
                 .padding(.top, 4)
         }
         .frame(maxWidth: .infinity, alignment: .leading)
@@ -552,6 +590,53 @@ public struct SummaryScreenView: View {
         return Text(parts.joined(separator: " • "))
             .font(.caption)
             .foregroundStyle(.secondary)
+    }
+
+    // MARK: - Event marker formatters
+
+    private func bottleEventMarkers(from chartData: TodayChartData, unit: FeedVolumeUnit) -> [[String]] {
+        selectedBottleFilter.filterMarkers(chartData.bottleHourlyMarkers).map { hourMarkers in
+            hourMarkers.map { marker in
+                "\(FeedVolumePresentation.amountText(for: marker.amountMilliliters, unit: unit)) · \(marker.time)"
+            }
+        }
+    }
+
+    private func breastEventMarkers(from chartData: TodayChartData) -> [[String]] {
+        chartData.breastHourlyMarkers.map { hourMarkers in
+            hourMarkers.map { marker in
+                let sideText: String
+                switch marker.side {
+                case .left: sideText = "Left"
+                case .right: sideText = "Right"
+                case .both, nil: sideText = "Both"
+                }
+                return "\(sideText) · \(DurationText.short(minutes: marker.durationMinutes))"
+            }
+        }
+    }
+
+    private func sleepEventMarkers(from chartData: TodayChartData) -> [[String]] {
+        chartData.sleepHourlyMarkers.map { hourMarkers in
+            hourMarkers.map { marker in
+                "Wake \(marker.wakeTime) · \(DurationText.short(minutes: marker.durationMinutes))"
+            }
+        }
+    }
+
+    private func nappyEventMarkers(from chartData: TodayChartData) -> [[String]] {
+        selectedNappyFilter.filterMarkers(chartData.nappyHourlyMarkers).map { hourMarkers in
+            hourMarkers.map { marker in
+                let typeText: String
+                switch marker.type {
+                case .dry: typeText = "Dry"
+                case .wee: typeText = "Wet"
+                case .poo: typeText = "Dirty"
+                case .mixed: typeText = "Mixed"
+                }
+                return "\(typeText) · \(marker.time)"
+            }
+        }
     }
 
     private func loggingStreakRow(data: TodaySummaryData) -> some View {


### PR DESCRIPTION
Closes #236

## Summary

- Each Today-tab chart (bottle, sleep, breast feed, nappy) now shows a small dot marker on the cumulative line at every hour where an event was logged today
- Tapping/selecting a time slot shows the individual events within that hour in the callout, below the cumulative and average values
- Marker dots are consistent with the active filter (e.g. selecting "Formula" on the bottle chart only shows formula feed dots)
- Bottle volumes in callouts respect the user's preferred unit (ml/oz)

## Changes

**New file — `HourlyEventMarkers.swift`**
Four lightweight structs (`BottleEventMarker`, `BreastEventMarker`, `SleepEventMarker`, `NappyEventMarker`) holding per-event display data (amount/side/duration/type + formatted time string).

**`TodayChartData`**
Adds four `hourlyMarkers` arrays (one per chart type), each a 24-element array of event marker arrays indexed by hour.

**`TodaySummaryCalculator`**
Populates the marker arrays from today's filtered events. Breast feed markers use `endedAt` (matching the cumulative series). Sleep markers only include completed sessions and use the wake time. A shared `DateFormatter` with `.short` time style formats the time strings.

**`CumulativeLineChartView`**
- New `eventMarkers: [[String]]` parameter (defaults to 24 empty arrays — no behaviour change for existing callers)
- Adds a `PointMark` (symbol size 40) at each hour that has events, positioned at the corresponding cumulative value on the line
- The selection callout now lists event detail strings below the Today/Avg values when the selected hour has events

**`SummaryScreenView`**
- `TodayBottleChartFilter` and `TodayNappyChartFilter` gain a `filterMarkers(_:)` method so only events matching the active series filter appear as dots
- Four private helper functions (`bottleEventMarkers`, `breastEventMarkers`, `sleepEventMarkers`, `nappyEventMarkers`) format the raw marker structs into display strings and pass them to each `CumulativeLineChartView`

## Callout format per chart type

| Chart | Callout detail |
|---|---|
| Bottle | `150ml · 9:30 AM` |
| Breast | `Left · 20m` |
| Sleep | `Wake 9:30 AM · 1h 30m` |
| Nappy | `Wet · 7:30 AM` |

https://claude.ai/code/session_01GCxvoA447sdLnByUEm5zAg

---
_Generated by [Claude Code](https://claude.ai/code/session_01GCxvoA447sdLnByUEm5zAg)_