### PR TITLE
Add Customize Events preferences screen

### DIFF
--- a/Baby Tracker/App/AppContainer.swift
+++ b/Baby Tracker/App/AppContainer.swift
@@ -24,6 +24,7 @@ struct AppContainer {
         let recordMetadataRepository = SwiftDataCloudKitRecordMetadataRepository(store: store)
         let liveActivityPreferenceStore = UserDefaultsLiveActivityPreferenceStore(userDefaults: userDefaults)
         let reminderNotificationPreferenceStore = UserDefaultsReminderNotificationPreferenceStore(userDefaults: userDefaults)
+        let eventVisibilityPreferenceStore = UserDefaultsEventVisibilityPreferenceStore(userDefaults: userDefaults)
         let appReviewPromptStateStore = UserDefaultsAppReviewPromptStateStore(userDefaults: userDefaults)
 
         if let scenario = launchConfiguration.scenario {
@@ -71,6 +72,7 @@ struct AppContainer {
             liveActivitySnapshotCache: liveActivitySnapshotCache,
             liveActivityPreferenceStore: liveActivityPreferenceStore,
             reminderNotificationPreferenceStore: reminderNotificationPreferenceStore,
+            eventVisibilityPreferenceStore: eventVisibilityPreferenceStore,
             localNotificationManager: localNotificationManager,
             hapticFeedbackProvider: hapticFeedbackProvider,
             appReviewPromptStateStore: appReviewPromptStateStore,
@@ -114,6 +116,7 @@ struct AppContainer {
         let recordMetadataRepository = SwiftDataCloudKitRecordMetadataRepository(store: store)
         let liveActivityPreferenceStore = UserDefaultsLiveActivityPreferenceStore(userDefaults: userDefaults)
         let reminderNotificationPreferenceStore = UserDefaultsReminderNotificationPreferenceStore(userDefaults: userDefaults)
+        let eventVisibilityPreferenceStore = UserDefaultsEventVisibilityPreferenceStore(userDefaults: userDefaults)
 
         try? seed(
             scenario: .mixedEventsPreview,
@@ -143,6 +146,7 @@ struct AppContainer {
             liveActivityManager: NoOpFeedLiveActivityManager(),
             liveActivityPreferenceStore: liveActivityPreferenceStore,
             reminderNotificationPreferenceStore: reminderNotificationPreferenceStore,
+            eventVisibilityPreferenceStore: eventVisibilityPreferenceStore,
             localNotificationManager: NoOpLocalNotificationManager(),
             hapticFeedbackProvider: NoOpHapticFeedbackProvider()
         )

--- a/Baby Tracker/App/UserDefaultsEventVisibilityPreferenceStore.swift
+++ b/Baby Tracker/App/UserDefaultsEventVisibilityPreferenceStore.swift
@@ -1,0 +1,30 @@
+import BabyTrackerDomain
+import BabyTrackerFeature
+import Foundation
+
+@MainActor
+final class UserDefaultsEventVisibilityPreferenceStore: EventVisibilityPreferenceStore {
+    private enum DefaultsKey {
+        static let enabledKinds = "eventVisibility.enabledKinds"
+    }
+
+    private let userDefaults: UserDefaults
+
+    var enabledEventKinds: Set<BabyEventKind> {
+        guard let rawValues = userDefaults.array(forKey: DefaultsKey.enabledKinds) as? [String] else {
+            return Set(BabyEventKind.allCases)
+        }
+
+        let kinds = rawValues.compactMap(BabyEventKind.init(rawValue:))
+        return Set(kinds)
+    }
+
+    init(userDefaults: UserDefaults = .standard) {
+        self.userDefaults = userDefaults
+    }
+
+    func setEnabledEventKinds(_ kinds: Set<BabyEventKind>) {
+        let rawValues = kinds.map { $0.rawValue }
+        userDefaults.set(rawValues, forKey: DefaultsKey.enabledKinds)
+    }
+}

--- a/Baby TrackerTests/AppModelTests.swift
+++ b/Baby TrackerTests/AppModelTests.swift
@@ -1406,6 +1406,63 @@ struct AppModelTests {
     }
 
     @Test
+    func disablingEventKindHidesEventsFromTimelineAndPersistsPreference() throws {
+        let visibilityStore = InMemoryEventVisibilityPreferenceStore()
+        let harness = try Harness(eventVisibilityPreferenceStore: visibilityStore)
+        defer { harness.cleanUp() }
+
+        let seed = try harness.seedOwnerProfile()
+        let breastFeed = try harness.saveBreastFeed(
+            childID: seed.child.id,
+            userID: seed.localUser.id,
+            start: Date(timeIntervalSince1970: 5_000),
+            end: Date(timeIntervalSince1970: 5_900),
+            side: .left
+        )
+        let bottleFeed = try harness.saveBottleFeed(
+            childID: seed.child.id,
+            userID: seed.localUser.id,
+            amountMilliliters: 120,
+            occurredAt: Date(timeIntervalSince1970: 9_000),
+            milkType: .formula
+        )
+
+        harness.model.load(performLaunchSync: false)
+        #expect(harness.model.events.contains(where: { $0.id == breastFeed.id }))
+        #expect(harness.model.events.contains(where: { $0.id == bottleFeed.id }))
+        #expect(harness.model.isEventKindEnabled(.breastFeed))
+
+        harness.model.setEventKindEnabled(.breastFeed, isEnabled: false)
+
+        #expect(!harness.model.isEventKindEnabled(.breastFeed))
+        #expect(visibilityStore.enabledEventKinds == [.bottleFeed, .sleep, .nappy])
+        #expect(!harness.model.events.contains(where: { $0.id == breastFeed.id }))
+        #expect(harness.model.events.contains(where: { $0.id == bottleFeed.id }))
+
+        harness.model.setEventKindEnabled(.breastFeed, isEnabled: true)
+
+        #expect(harness.model.isEventKindEnabled(.breastFeed))
+        #expect(harness.model.events.contains(where: { $0.id == breastFeed.id }))
+    }
+
+    @Test
+    func disablingTheLastEnabledEventKindIsRefused() throws {
+        let visibilityStore = InMemoryEventVisibilityPreferenceStore(enabledEventKinds: [.bottleFeed])
+        let harness = try Harness(eventVisibilityPreferenceStore: visibilityStore)
+        defer { harness.cleanUp() }
+
+        _ = try harness.seedOwnerProfile()
+        harness.model.load(performLaunchSync: false)
+
+        #expect(harness.model.enabledEventKinds == [.bottleFeed])
+
+        harness.model.setEventKindEnabled(.bottleFeed, isEnabled: false)
+
+        #expect(harness.model.enabledEventKinds == [.bottleFeed])
+        #expect(visibilityStore.enabledEventKinds == [.bottleFeed])
+    }
+
+    @Test
     func disabledLiveActivitiesPreventNewSnapshotsDuringRefresh() throws {
         let liveActivityManager = LiveActivityManagerSpy()
         let preferenceStore = InMemoryLiveActivityPreferenceStore(isLiveActivityEnabled: false)
@@ -1760,6 +1817,7 @@ extension AppModelTests {
             liveActivityManager: any FeedLiveActivityManaging = NoOpFeedLiveActivityManager(),
             liveActivityPreferenceStore: any LiveActivityPreferenceStore = InMemoryLiveActivityPreferenceStore(),
             reminderNotificationPreferenceStore: any ReminderNotificationPreferenceStore = InMemoryReminderNotificationPreferenceStore(),
+            eventVisibilityPreferenceStore: any EventVisibilityPreferenceStore = InMemoryEventVisibilityPreferenceStore(),
             localNotificationManager: any LocalNotificationManaging = NoOpLocalNotificationManager(),
             hapticFeedbackProvider: any HapticFeedbackProviding = NoOpHapticFeedbackProvider()
         ) throws {
@@ -1780,6 +1838,7 @@ extension AppModelTests {
                 liveActivityManager: liveActivityManager,
                 liveActivityPreferenceStore: liveActivityPreferenceStore,
                 reminderNotificationPreferenceStore: reminderNotificationPreferenceStore,
+                eventVisibilityPreferenceStore: eventVisibilityPreferenceStore,
                 localNotificationManager: localNotificationManager,
                 hapticFeedbackProvider: hapticFeedbackProvider
             )

--- a/Packages/BabyTrackerDomain/Sources/BabyTrackerDomain/BabyEventKind.swift
+++ b/Packages/BabyTrackerDomain/Sources/BabyTrackerDomain/BabyEventKind.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-public enum BabyEventKind: String, Codable, Equatable, Hashable, Sendable {
+public enum BabyEventKind: String, CaseIterable, Codable, Equatable, Hashable, Sendable {
     case breastFeed
     case bottleFeed
     case sleep

--- a/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/AppModel.swift
+++ b/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/AppModel.swift
@@ -1361,26 +1361,28 @@ public final class AppModel {
     ) -> TimelineDayGridViewState? {
         let eventsByID = Dictionary(uniqueKeysWithValues: events.map { ($0.id, $0) })
 
-        let columns = dataset.columns.map { column in
-            TimelineDayGridColumnViewState(
-                kind: column.kind,
-                title: timelineColumnTitle(for: column.kind),
-                items: column.placements.compactMap { placement in
-                    let groupedEvents = placement.eventIDs.compactMap { eventsByID[$0] }
-                    guard !groupedEvents.isEmpty else {
-                        return nil
-                    }
+        let columns = dataset.columns
+            .filter { enabledEventKinds.contains(eventKind(for: $0.kind)) }
+            .map { column in
+                TimelineDayGridColumnViewState(
+                    kind: column.kind,
+                    title: timelineColumnTitle(for: column.kind),
+                    items: column.placements.compactMap { placement in
+                        let groupedEvents = placement.eventIDs.compactMap { eventsByID[$0] }
+                        guard !groupedEvents.isEmpty else {
+                            return nil
+                        }
 
-                    return makeTimelineDayGridItem(
-                        placement: placement,
-                        events: groupedEvents,
-                        child: child,
-                        day: day,
-                        slotMinutes: dataset.slotMinutes
-                    )
-                }
-            )
-        }
+                        return makeTimelineDayGridItem(
+                            placement: placement,
+                            events: groupedEvents,
+                            child: child,
+                            day: day,
+                            slotMinutes: dataset.slotMinutes
+                        )
+                    }
+                )
+            }
 
         let hasItems = columns.contains { !$0.items.isEmpty }
         guard hasItems else {
@@ -1485,6 +1487,15 @@ public final class AppModel {
             return "Bottle"
         case .breastFeed:
             return "Breast"
+        }
+    }
+
+    private func eventKind(for columnKind: TimelineDayGridColumnKind) -> BabyEventKind {
+        switch columnKind {
+        case .sleep: return .sleep
+        case .nappy: return .nappy
+        case .bottleFeed: return .bottleFeed
+        case .breastFeed: return .breastFeed
         }
     }
 

--- a/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/AppModel.swift
+++ b/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/AppModel.swift
@@ -16,6 +16,7 @@ public final class AppModel {
     public private(set) var undoDeleteMessage: String?
     public private(set) var isLiveActivityEnabled: Bool
     public private(set) var isReminderNotificationsEnabled: Bool
+    public private(set) var enabledEventKinds: Set<BabyEventKind>
     public private(set) var transientMessage: String?
     public private(set) var navigationResetToken: Int = 0
     public private(set) var shareAcceptanceLoadingState: ShareAcceptanceLoadingState?
@@ -73,6 +74,7 @@ public final class AppModel {
     private let liveActivitySnapshotCache: any FeedLiveActivitySnapshotCaching
     private let liveActivityPreferenceStore: any LiveActivityPreferenceStore
     private let reminderNotificationPreferenceStore: any ReminderNotificationPreferenceStore
+    private let eventVisibilityPreferenceStore: any EventVisibilityPreferenceStore
     private let localNotificationManager: any LocalNotificationManaging
     private let hapticFeedbackProvider: any HapticFeedbackProviding
     private let appReviewPromptStateStore: any AppReviewPromptStateStoring
@@ -100,6 +102,7 @@ public final class AppModel {
         liveActivitySnapshotCache: any FeedLiveActivitySnapshotCaching = InMemoryFeedLiveActivitySnapshotCache(),
         liveActivityPreferenceStore: any LiveActivityPreferenceStore = InMemoryLiveActivityPreferenceStore(),
         reminderNotificationPreferenceStore: any ReminderNotificationPreferenceStore = InMemoryReminderNotificationPreferenceStore(),
+        eventVisibilityPreferenceStore: any EventVisibilityPreferenceStore = InMemoryEventVisibilityPreferenceStore(),
         localNotificationManager: any LocalNotificationManaging = NoOpLocalNotificationManager(),
         hapticFeedbackProvider: any HapticFeedbackProviding = NoOpHapticFeedbackProvider(),
         appReviewPromptStateStore: any AppReviewPromptStateStoring = NoOpAppReviewPromptStateStore(),
@@ -115,6 +118,7 @@ public final class AppModel {
         self.liveActivitySnapshotCache = liveActivitySnapshotCache
         self.liveActivityPreferenceStore = liveActivityPreferenceStore
         self.reminderNotificationPreferenceStore = reminderNotificationPreferenceStore
+        self.eventVisibilityPreferenceStore = eventVisibilityPreferenceStore
         self.localNotificationManager = localNotificationManager
         self.hapticFeedbackProvider = hapticFeedbackProvider
         self.appReviewPromptStateStore = appReviewPromptStateStore
@@ -124,6 +128,8 @@ public final class AppModel {
         self.storedReminderNotificationsEnabled = storedReminderNotificationsEnabled
         self.hasReminderNotificationPermission = true
         self.isReminderNotificationsEnabled = storedReminderNotificationsEnabled
+        let storedEnabledEventKinds = eventVisibilityPreferenceStore.enabledEventKinds
+        self.enabledEventKinds = storedEnabledEventKinds.isEmpty ? Set(BabyEventKind.allCases) : storedEnabledEventKinds
     }
 
     public func load(performLaunchSync: Bool = true) {
@@ -190,6 +196,31 @@ public final class AppModel {
         } else {
             stopLiveActivity()
         }
+    }
+
+    public func isEventKindEnabled(_ kind: BabyEventKind) -> Bool {
+        enabledEventKinds.contains(kind)
+    }
+
+    public func setEventKindEnabled(_ kind: BabyEventKind, isEnabled: Bool) {
+        var updated = enabledEventKinds
+        if isEnabled {
+            updated.insert(kind)
+        } else {
+            // Refuse to disable the last enabled kind so the UI never has zero options.
+            guard updated.count > 1, updated.contains(kind) else {
+                return
+            }
+            updated.remove(kind)
+        }
+
+        guard updated != enabledEventKinds else {
+            return
+        }
+
+        enabledEventKinds = updated
+        eventVisibilityPreferenceStore.setEnabledEventKinds(updated)
+        refresh(selecting: childSelectionStore.loadSelectedChildID())
     }
 
     @discardableResult
@@ -1281,7 +1312,8 @@ public final class AppModel {
     }
 
     private func loadVisibleEvents(for childID: UUID) throws -> [BabyEvent] {
-        try eventRepository.loadTimeline(for: childID, includingDeleted: false)
+        let events = try eventRepository.loadTimeline(for: childID, includingDeleted: false)
+        return events.filter { enabledEventKinds.contains($0.kind) }
     }
 
     private func loadTimelinePages(
@@ -1296,7 +1328,7 @@ public final class AppModel {
                 on: day,
                 calendar: calendar,
                 includingDeleted: false
-            )
+            ).filter { enabledEventKinds.contains($0.kind) }
             let gridDataset = buildTimelineDayGridDatasetUseCase.execute(
                 events: events,
                 day: dayStart,

--- a/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/EventVisibilityPreferenceStore.swift
+++ b/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/EventVisibilityPreferenceStore.swift
@@ -1,0 +1,8 @@
+import BabyTrackerDomain
+import Foundation
+
+@MainActor
+public protocol EventVisibilityPreferenceStore: AnyObject {
+    var enabledEventKinds: Set<BabyEventKind> { get }
+    func setEnabledEventKinds(_ kinds: Set<BabyEventKind>)
+}

--- a/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/InMemoryEventVisibilityPreferenceStore.swift
+++ b/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/InMemoryEventVisibilityPreferenceStore.swift
@@ -1,0 +1,15 @@
+import BabyTrackerDomain
+import Foundation
+
+@MainActor
+public final class InMemoryEventVisibilityPreferenceStore: EventVisibilityPreferenceStore {
+    public var enabledEventKinds: Set<BabyEventKind>
+
+    public init(enabledEventKinds: Set<BabyEventKind> = Set(BabyEventKind.allCases)) {
+        self.enabledEventKinds = enabledEventKinds
+    }
+
+    public func setEnabledEventKinds(_ kinds: Set<BabyEventKind>) {
+        enabledEventKinds = kinds
+    }
+}

--- a/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/ViewModels/SummaryViewModel.swift
+++ b/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/ViewModels/SummaryViewModel.swift
@@ -39,6 +39,10 @@ public final class SummaryViewModel {
             ?? .milliliters
     }
 
+    public var enabledEventKinds: Set<BabyEventKind> {
+        appModel?.enabledEventKinds ?? Set(BabyEventKind.allCases)
+    }
+
     public var emptyStateTitle: String { "No summary data yet" }
     public var emptyStateMessage: String { "Add events and your key trends will appear here." }
 }

--- a/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/AppSettingsView.swift
+++ b/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/AppSettingsView.swift
@@ -62,6 +62,15 @@ public struct AppSettingsView: View {
                     )
                 }
 
+                NavigationLink {
+                    EventVisibilitySettingsView(model: model)
+                } label: {
+                    settingsRow(
+                        title: "Customize Events",
+                        value: nil,
+                        accessibilityIdentifier: "app-settings-customize-events-row"
+                    )
+                }
             }
 
             if areDebugOptionsVisible {

--- a/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/ChildHomeView.swift
+++ b/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/ChildHomeView.swift
@@ -56,7 +56,7 @@ public struct ChildHomeView: View {
                 heroCard
                     .transition(.opacity)
 
-                if viewModel.canLogEvents {
+                if viewModel.canLogEvents, !model.enabledEventKinds.isEmpty {
                     quickLogSection
                 }
 
@@ -285,37 +285,32 @@ public struct ChildHomeView: View {
 
             if quickLogSectionExpanded {
                 VStack(spacing: 12) {
-                    HStack(spacing: 12) {
-                        quickLogButton(
-                            title: "Breast Feed",
-                            systemImage: BabyEventStyle.systemImage(for: .breastFeed),
-                            kind: .breastFeed,
-                            accessibilityIdentifier: "quick-log-breast-feed-button",
-                            action: quickLogBreastFeed
-                        )
+                    let firstRow = visibleQuickLogRow(
+                        first: .breastFeed,
+                        second: .bottleFeed
+                    )
+                    let secondRow = visibleQuickLogRow(
+                        first: .sleep,
+                        second: .nappy
+                    )
 
-                        quickLogButton(
-                            title: "Bottle Feed",
-                            systemImage: BabyEventStyle.systemImage(for: .bottleFeed),
-                            kind: .bottleFeed,
-                            accessibilityIdentifier: "quick-log-bottle-feed-button",
-                            action: quickLogBottleFeed
-                        )
+                    if !firstRow.isEmpty {
+                        HStack(spacing: 12) {
+                            ForEach(firstRow, id: \.self) { kind in
+                                quickLogButton(for: kind)
+                            }
+                        }
+                        .geometryGroup()
                     }
-                    .geometryGroup()
 
-                    HStack(spacing: 12) {
-                        sleepQuickLogButton
-
-                        quickLogButton(
-                            title: "Nappy",
-                            systemImage: BabyEventStyle.systemImage(for: .nappy),
-                            kind: .nappy,
-                            accessibilityIdentifier: "quick-log-nappy-button",
-                            action: quickLogNappy
-                        )
+                    if !secondRow.isEmpty {
+                        HStack(spacing: 12) {
+                            ForEach(secondRow, id: \.self) { kind in
+                                quickLogButton(for: kind)
+                            }
+                        }
+                        .geometryGroup()
                     }
-                    .geometryGroup()
                 }
                 .padding(.top, 12)
                 .transition(.opacity.combined(with: .scale(scale: 0.97, anchor: .top)))
@@ -343,6 +338,45 @@ public struct ChildHomeView: View {
         }
         .buttonStyle(.plain)
         .accessibilityIdentifier(accessibilityIdentifier)
+    }
+
+    private func visibleQuickLogRow(
+        first: BabyEventKind,
+        second: BabyEventKind
+    ) -> [BabyEventKind] {
+        [first, second].filter { model.isEventKindEnabled($0) }
+    }
+
+    @ViewBuilder
+    private func quickLogButton(for kind: BabyEventKind) -> some View {
+        switch kind {
+        case .breastFeed:
+            quickLogButton(
+                title: "Breast Feed",
+                systemImage: BabyEventStyle.systemImage(for: .breastFeed),
+                kind: .breastFeed,
+                accessibilityIdentifier: "quick-log-breast-feed-button",
+                action: quickLogBreastFeed
+            )
+        case .bottleFeed:
+            quickLogButton(
+                title: "Bottle Feed",
+                systemImage: BabyEventStyle.systemImage(for: .bottleFeed),
+                kind: .bottleFeed,
+                accessibilityIdentifier: "quick-log-bottle-feed-button",
+                action: quickLogBottleFeed
+            )
+        case .sleep:
+            sleepQuickLogButton
+        case .nappy:
+            quickLogButton(
+                title: "Nappy",
+                systemImage: BabyEventStyle.systemImage(for: .nappy),
+                kind: .nappy,
+                accessibilityIdentifier: "quick-log-nappy-button",
+                action: quickLogNappy
+            )
+        }
     }
 
     @ViewBuilder

--- a/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/ChildHomeView.swift
+++ b/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/ChildHomeView.swift
@@ -224,9 +224,12 @@ public struct ChildHomeView: View {
             .buttonStyle(.plain)
 
             if statusSectionExpanded {
-                CurrentStatusCardView(status: viewModel.currentStatus)
-                    .padding(.top, 10)
-                    .transition(.opacity.combined(with: .scale(scale: 0.97, anchor: .top)))
+                CurrentStatusCardView(
+                    status: viewModel.currentStatus,
+                    enabledEventKinds: model.enabledEventKinds
+                )
+                .padding(.top, 10)
+                .transition(.opacity.combined(with: .scale(scale: 0.97, anchor: .top)))
             }
         }
     }

--- a/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/ChildHomeView.swift
+++ b/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/ChildHomeView.swift
@@ -288,27 +288,9 @@ public struct ChildHomeView: View {
 
             if quickLogSectionExpanded {
                 VStack(spacing: 12) {
-                    let firstRow = visibleQuickLogRow(
-                        first: .breastFeed,
-                        second: .bottleFeed
-                    )
-                    let secondRow = visibleQuickLogRow(
-                        first: .sleep,
-                        second: .nappy
-                    )
-
-                    if !firstRow.isEmpty {
+                    ForEach(Array(quickLogRows.enumerated()), id: \.offset) { _, row in
                         HStack(spacing: 12) {
-                            ForEach(firstRow, id: \.self) { kind in
-                                quickLogButton(for: kind)
-                            }
-                        }
-                        .geometryGroup()
-                    }
-
-                    if !secondRow.isEmpty {
-                        HStack(spacing: 12) {
-                            ForEach(secondRow, id: \.self) { kind in
+                            ForEach(row, id: \.self) { kind in
                                 quickLogButton(for: kind)
                             }
                         }
@@ -343,11 +325,11 @@ public struct ChildHomeView: View {
         .accessibilityIdentifier(accessibilityIdentifier)
     }
 
-    private func visibleQuickLogRow(
-        first: BabyEventKind,
-        second: BabyEventKind
-    ) -> [BabyEventKind] {
-        [first, second].filter { model.isEventKindEnabled($0) }
+    private var quickLogRows: [[BabyEventKind]] {
+        let kinds = BabyEventKind.allCases.filter { model.isEventKindEnabled($0) }
+        return stride(from: 0, to: kinds.count, by: 2).map { i in
+            Array(kinds[i..<min(i + 2, kinds.count)])
+        }
     }
 
     @ViewBuilder

--- a/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/ChildWorkspaceTabView.swift
+++ b/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/ChildWorkspaceTabView.swift
@@ -152,7 +152,10 @@ public struct ChildWorkspaceTabView: View {
             )
         }
         .sheet(isPresented: $showingEventFilter) {
-            EventFilterView(currentFilter: eventHistoryViewModel.activeFilter) { newFilter in
+            EventFilterView(
+                currentFilter: eventHistoryViewModel.activeFilter,
+                enabledEventKinds: model.enabledEventKinds
+            ) { newFilter in
                 eventHistoryViewModel.updateFilter(newFilter)
             }
         }

--- a/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/CurrentStatusCardView.swift
+++ b/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/CurrentStatusCardView.swift
@@ -3,13 +3,22 @@ import SwiftUI
 
 public struct CurrentStatusCardView: View {
     let status: CurrentStatusCardViewState
+    let enabledEventKinds: Set<BabyEventKind>
 
-    public init(status: CurrentStatusCardViewState) {
+    public init(
+        status: CurrentStatusCardViewState,
+        enabledEventKinds: Set<BabyEventKind> = Set(BabyEventKind.allCases)
+    ) {
         self.status = status
+        self.enabledEventKinds = enabledEventKinds
     }
 
     private var showSleepRow: Bool {
-        status.lastSleep?.isActive != true
+        enabledEventKinds.contains(.sleep) && status.lastSleep?.isActive != true
+    }
+
+    private var showFeedsToday: Bool {
+        enabledEventKinds.contains(.breastFeed) || enabledEventKinds.contains(.bottleFeed)
     }
 
     public var body: some View {
@@ -30,61 +39,71 @@ public struct CurrentStatusCardView: View {
                     .transition(.opacity.combined(with: .move(edge: .bottom)))
             }
 
-            statusRow(
-                title: "Last breast feed",
-                subtitle: status.lastBreastFeed?.detailText,
-                systemImage: BabyEventStyle.systemImage(for: .breastFeed),
-                iconTint: BabyEventStyle.accentColor(for: .breastFeed),
-                identifier: "current-status-last-breast-feed"
-            ) {
-                if let lastBreastFeed = status.lastBreastFeed {
-                    relativeTimeText(for: lastBreastFeed.occurredAt)
-                } else {
-                    Text("No feeds yet")
+            if enabledEventKinds.contains(.breastFeed) {
+                statusRow(
+                    title: "Last breast feed",
+                    subtitle: status.lastBreastFeed?.detailText,
+                    systemImage: BabyEventStyle.systemImage(for: .breastFeed),
+                    iconTint: BabyEventStyle.accentColor(for: .breastFeed),
+                    identifier: "current-status-last-breast-feed"
+                ) {
+                    if let lastBreastFeed = status.lastBreastFeed {
+                        relativeTimeText(for: lastBreastFeed.occurredAt)
+                    } else {
+                        Text("No feeds yet")
+                    }
+                }
+
+                Divider()
+            }
+
+            if enabledEventKinds.contains(.bottleFeed) {
+                statusRow(
+                    title: "Last bottle feed",
+                    subtitle: status.lastBottleFeed?.detailText,
+                    systemImage: BabyEventStyle.systemImage(for: .bottleFeed),
+                    iconTint: BabyEventStyle.accentColor(for: .bottleFeed),
+                    identifier: "current-status-last-bottle-feed"
+                ) {
+                    if let lastBottleFeed = status.lastBottleFeed {
+                        relativeTimeText(for: lastBottleFeed.occurredAt)
+                    } else {
+                        Text("No feeds yet")
+                    }
+                }
+
+                Divider()
+            }
+
+            if enabledEventKinds.contains(.nappy) {
+                statusRow(
+                    title: "Last nappy",
+                    subtitle: status.lastNappy?.detailText,
+                    systemImage: BabyEventStyle.systemImage(for: .nappy),
+                    iconTint: BabyEventStyle.accentColor(for: .nappy),
+                    identifier: "current-status-last-nappy"
+                ) {
+                    if let lastNappy = status.lastNappy {
+                        relativeTimeText(for: lastNappy.occurredAt)
+                    } else {
+                        Text("No nappies yet")
+                    }
+                }
+
+                if showFeedsToday {
+                    Divider()
                 }
             }
 
-            Divider()
-
-            statusRow(
-                title: "Last bottle feed",
-                subtitle: status.lastBottleFeed?.detailText,
-                systemImage: BabyEventStyle.systemImage(for: .bottleFeed),
-                iconTint: BabyEventStyle.accentColor(for: .bottleFeed),
-                identifier: "current-status-last-bottle-feed"
-            ) {
-                if let lastBottleFeed = status.lastBottleFeed {
-                    relativeTimeText(for: lastBottleFeed.occurredAt)
-                } else {
-                    Text("No feeds yet")
+            if showFeedsToday {
+                statusRow(
+                    title: "Feeds today",
+                    systemImage: "list.number",
+                    iconTint: BabyEventStyle.accentColor(for: .breastFeed),
+                    identifier: "current-status-feeds-today"
+                ) {
+                    Text("\(status.feedsTodayCount)")
                 }
-            }
-
-            Divider()
-
-            statusRow(
-                title: "Last nappy",
-                subtitle: status.lastNappy?.detailText,
-                systemImage: BabyEventStyle.systemImage(for: .nappy),
-                iconTint: BabyEventStyle.accentColor(for: .nappy),
-                identifier: "current-status-last-nappy"
-            ) {
-                if let lastNappy = status.lastNappy {
-                    relativeTimeText(for: lastNappy.occurredAt)
-                } else {
-                    Text("No nappies yet")
-                }
-            }
-
-            Divider()
-
-            statusRow(
-                title: "Feeds today",
-                systemImage: "list.number",
-                iconTint: BabyEventStyle.accentColor(for: .breastFeed),
-                identifier: "current-status-feeds-today"
-            ) {
-                Text("\(status.feedsTodayCount)")
             }
         }
         .padding(20)
@@ -98,6 +117,7 @@ public struct CurrentStatusCardView: View {
                 .stroke(Color(.separator).opacity(0.35), lineWidth: 1)
         )
         .animation(.easeInOut(duration: 0.35), value: showSleepRow)
+        .animation(.easeInOut(duration: 0.35), value: enabledEventKinds)
         .accessibilityElement(children: .contain)
         .accessibilityIdentifier("current-status-card")
     }
@@ -194,5 +214,19 @@ public struct CurrentStatusCardView: View {
         feedsTodayCount: 0,
         lastNappy: nil
     ))
+    .padding()
+}
+
+#Preview("Bottle only (breast feed hidden)") {
+    CurrentStatusCardView(
+        status: CurrentStatusCardViewState(
+            lastSleep: LastSleepSummaryViewState(isActive: false, startedAt: Date().addingTimeInterval(-18_000), endedAt: Date().addingTimeInterval(-10_800)),
+            lastBreastFeed: nil,
+            lastBottleFeed: LastEventSummaryViewState(kind: .bottleFeed, title: "Bottle Feed", detailText: "120 mL • Formula", occurredAt: Date().addingTimeInterval(-3_600)),
+            feedsTodayCount: 3,
+            lastNappy: LastNappySummaryViewState(title: "Nappy", detailText: "Pee • Light", occurredAt: Date().addingTimeInterval(-5_400))
+        ),
+        enabledEventKinds: [.sleep, .bottleFeed, .nappy]
+    )
     .padding()
 }

--- a/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/EventFilterView.swift
+++ b/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/EventFilterView.swift
@@ -3,6 +3,7 @@ import SwiftUI
 
 public struct EventFilterView: View {
     let currentFilter: EventFilter
+    let enabledEventKinds: Set<BabyEventKind>
     let onApply: (EventFilter) -> Void
 
     @Environment(\.dismiss) private var dismiss
@@ -10,9 +11,11 @@ public struct EventFilterView: View {
 
     public init(
         currentFilter: EventFilter,
+        enabledEventKinds: Set<BabyEventKind> = Set(BabyEventKind.allCases),
         onApply: @escaping (EventFilter) -> Void
     ) {
         self.currentFilter = currentFilter
+        self.enabledEventKinds = enabledEventKinds
         self.onApply = onApply
         self._draft = State(initialValue: currentFilter)
     }
@@ -57,7 +60,7 @@ public struct EventFilterView: View {
 
     private var eventTypeSection: some View {
         filterCard("Event Type") {
-            let kinds: [BabyEventKind] = [.breastFeed, .bottleFeed, .sleep, .nappy]
+            let kinds = BabyEventKind.allCases.filter { enabledEventKinds.contains($0) }
             LazyVGrid(columns: [GridItem(.flexible(), spacing: 10), GridItem(.flexible(), spacing: 10)], spacing: 10) {
                 ForEach(kinds, id: \.self) { kind in
                     eventKindChip(kind)
@@ -324,19 +327,23 @@ public struct EventFilterView: View {
     // MARK: - Visibility
 
     private var shouldShowNappySection: Bool {
-        draft.eventTypes.isEmpty || draft.eventTypes.contains(.nappy)
+        enabledEventKinds.contains(.nappy) &&
+            (draft.eventTypes.isEmpty || draft.eventTypes.contains(.nappy))
     }
 
     private var shouldShowMilkSection: Bool {
-        draft.eventTypes.isEmpty || draft.eventTypes.contains(.bottleFeed)
+        enabledEventKinds.contains(.bottleFeed) &&
+            (draft.eventTypes.isEmpty || draft.eventTypes.contains(.bottleFeed))
     }
 
     private var shouldShowBreastSection: Bool {
-        draft.eventTypes.isEmpty || draft.eventTypes.contains(.breastFeed)
+        enabledEventKinds.contains(.breastFeed) &&
+            (draft.eventTypes.isEmpty || draft.eventTypes.contains(.breastFeed))
     }
 
     private var shouldShowSleepSection: Bool {
-        draft.eventTypes.isEmpty || draft.eventTypes.contains(.sleep)
+        enabledEventKinds.contains(.sleep) &&
+            (draft.eventTypes.isEmpty || draft.eventTypes.contains(.sleep))
     }
 
     // MARK: - Mutation

--- a/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/EventVisibilitySettingsView.swift
+++ b/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/EventVisibilitySettingsView.swift
@@ -1,0 +1,50 @@
+import BabyTrackerDomain
+import SwiftUI
+
+public struct EventVisibilitySettingsView: View {
+    let model: AppModel
+
+    public init(model: AppModel) {
+        self.model = model
+    }
+
+    public var body: some View {
+        List {
+            Section {
+                ForEach(BabyEventKind.allCases, id: \.self) { kind in
+                    eventToggleRow(for: kind)
+                }
+            } footer: {
+                Text("Disabled events stay hidden across the app, but your existing data is never deleted. Re-enable an event at any time to see it again.")
+            }
+        }
+        .listStyle(.insetGrouped)
+        .navigationTitle("Customize Events")
+        .navigationBarTitleDisplayMode(.inline)
+    }
+
+    private func eventToggleRow(for kind: BabyEventKind) -> some View {
+        let isEnabled = model.isEventKindEnabled(kind)
+        let isOnlyEnabled = isEnabled && model.enabledEventKinds.count == 1
+
+        return Toggle(isOn: Binding(
+            get: { model.isEventKindEnabled(kind) },
+            set: { model.setEventKindEnabled(kind, isEnabled: $0) }
+        )) {
+            HStack(spacing: 12) {
+                Image(systemName: BabyEventStyle.systemImage(for: kind))
+                    .foregroundStyle(BabyEventStyle.accentColor(for: kind))
+                    .frame(width: 24)
+                Text(BabyEventPresentation.title(for: kind))
+            }
+        }
+        .disabled(isOnlyEnabled)
+        .accessibilityIdentifier("event-visibility-toggle-\(kind.rawValue)")
+    }
+}
+
+#Preview {
+    NavigationStack {
+        EventVisibilitySettingsView(model: ChildProfilePreviewFactory.makeModel())
+    }
+}

--- a/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/InteractiveOnboardingView.swift
+++ b/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/InteractiveOnboardingView.swift
@@ -51,6 +51,7 @@ public struct InteractiveOnboardingView: View {
         case notificationsDemo
         case caregiverName
         case babySetup
+        case customizeEvents
         case firstEvent
         case appPreview
 
@@ -263,6 +264,9 @@ public struct InteractiveOnboardingView: View {
                 addAction: submitBabySetup
             )
 
+        case .customizeEvents:
+            OnboardingCustomizeEventsStepView(model: model)
+
         case .firstEvent:
             OnboardingFirstEventStepView(
                 model: model,
@@ -304,6 +308,9 @@ public struct InteractiveOnboardingView: View {
                 action: submitBabySetup,
                 isDisabled: trimmedChildName.isEmpty
             )
+
+        case .customizeEvents:
+            OnboardingPrimaryButton(title: "Continue", action: advance)
 
         case .firstEvent:
             Button(action: advance) {
@@ -470,17 +477,24 @@ public struct InteractiveOnboardingView: View {
     )
 }
 
-#Preview("First Event") {
+#Preview("Customize Events") {
     InteractiveOnboardingView(
         model: ChildProfilePreviewFactory.makeModel(),
         previewStepIndex: 8
     )
 }
 
-#Preview("App Preview") {
+#Preview("First Event") {
     InteractiveOnboardingView(
         model: ChildProfilePreviewFactory.makeModel(),
         previewStepIndex: 9
+    )
+}
+
+#Preview("App Preview") {
+    InteractiveOnboardingView(
+        model: ChildProfilePreviewFactory.makeModel(),
+        previewStepIndex: 10
     )
 }
 

--- a/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/OnboardingCustomizeEventsStepView.swift
+++ b/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/OnboardingCustomizeEventsStepView.swift
@@ -1,0 +1,191 @@
+import BabyTrackerDomain
+import SwiftUI
+
+struct OnboardingCustomizeEventsStepView: View {
+    let model: AppModel
+
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+    @State private var appearedMask: [Bool] = Array(repeating: false, count: 2 + BabyEventKind.allCases.count + 1)
+
+    var body: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: 28) {
+                header
+                kindCard
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .padding(.horizontal, 24)
+            .padding(.top, 32)
+            .padding(.bottom, 8)
+        }
+        .scrollBounceBehavior(.basedOnSize)
+        .onAppear { staggerIn() }
+    }
+
+    // MARK: - Header
+
+    private var header: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            Text("What would you like to track?")
+                .font(.largeTitle.weight(.bold))
+                .opacity(appearedMask[0] ? 1 : 0)
+                .offset(y: appearedMask[0] ? 0 : 18)
+
+            Text("Select the events that matter to you. You can change this at any time in Settings.")
+                .font(.title3)
+                .foregroundStyle(.secondary)
+                .fixedSize(horizontal: false, vertical: true)
+                .opacity(appearedMask[1] ? 1 : 0)
+                .offset(y: appearedMask[1] ? 0 : 14)
+        }
+    }
+
+    // MARK: - Kind card
+
+    private var kindCard: some View {
+        VStack(spacing: 0) {
+            ForEach(Array(BabyEventKind.allCases.enumerated()), id: \.element) { index, kind in
+                kindRow(kind, appearedIndex: index + 2)
+
+                if kind != BabyEventKind.allCases.last {
+                    Divider()
+                        .padding(.leading, 60)
+                }
+            }
+
+            Divider()
+
+            resetRow
+        }
+        .background(
+            RoundedRectangle(cornerRadius: 18, style: .continuous)
+                .fill(Color(.secondarySystemGroupedBackground))
+        )
+        .clipShape(RoundedRectangle(cornerRadius: 18, style: .continuous))
+        .overlay(
+            RoundedRectangle(cornerRadius: 18, style: .continuous)
+                .stroke(Color(.separator).opacity(0.35), lineWidth: 1)
+        )
+    }
+
+    // MARK: - Kind row
+
+    private func kindRow(_ kind: BabyEventKind, appearedIndex: Int) -> some View {
+        let isEnabled = model.enabledEventKinds.contains(kind)
+        let isOnlyEnabled = isEnabled && model.enabledEventKinds.count == 1
+
+        return Button {
+            guard !isOnlyEnabled else { return }
+            model.setEventKindEnabled(kind, isEnabled: !isEnabled)
+        } label: {
+            HStack(spacing: 14) {
+                Image(systemName: BabyEventStyle.systemImage(for: kind))
+                    .font(.body.weight(.semibold))
+                    .foregroundStyle(BabyEventStyle.accentColor(for: kind))
+                    .frame(width: 32, height: 32)
+                    .background(BabyEventStyle.backgroundColor(for: kind), in: RoundedRectangle(cornerRadius: 9, style: .continuous))
+
+                VStack(alignment: .leading, spacing: 2) {
+                    Text(kindTitle(kind))
+                        .font(.body)
+                        .foregroundStyle(.primary)
+
+                    Text(kindDescription(kind))
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+
+                Spacer()
+
+                Image(systemName: isEnabled ? "checkmark.circle.fill" : "circle")
+                    .font(.title3)
+                    .foregroundStyle(isEnabled ? BabyEventStyle.accentColor(for: kind) : Color(.tertiaryLabel))
+                    .animation(.spring(response: 0.3, dampingFraction: 0.7), value: isEnabled)
+            }
+            .padding(.horizontal, 16)
+            .padding(.vertical, 14)
+            .contentShape(Rectangle())
+            .opacity(isOnlyEnabled ? 0.4 : 1.0)
+        }
+        .buttonStyle(.plain)
+        .opacity(appearedMask[appearedIndex] ? 1 : 0)
+        .offset(y: appearedMask[appearedIndex] ? 0 : 14)
+    }
+
+    // MARK: - Reset row
+
+    private var resetRow: some View {
+        let allEnabled = model.enabledEventKinds.count == BabyEventKind.allCases.count
+        let resetIndex = 2 + BabyEventKind.allCases.count
+
+        return Button {
+            for kind in BabyEventKind.allCases {
+                model.setEventKindEnabled(kind, isEnabled: true)
+            }
+        } label: {
+            Text("Reset to all")
+                .font(.subheadline)
+                .foregroundStyle(allEnabled ? Color(.tertiaryLabel) : .secondary)
+                .frame(maxWidth: .infinity)
+                .padding(.vertical, 14)
+                .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .disabled(allEnabled)
+        .opacity(appearedMask[resetIndex] ? 1 : 0)
+        .offset(y: appearedMask[resetIndex] ? 0 : 10)
+    }
+
+    // MARK: - Copy
+
+    private func kindTitle(_ kind: BabyEventKind) -> String {
+        switch kind {
+        case .breastFeed: "Breast feed"
+        case .bottleFeed: "Bottle feed"
+        case .sleep: "Sleep"
+        case .nappy: "Nappy"
+        }
+    }
+
+    private func kindDescription(_ kind: BabyEventKind) -> String {
+        switch kind {
+        case .breastFeed: "Nursing sessions and duration"
+        case .bottleFeed: "Formula and expressed milk"
+        case .sleep: "Naps and overnight sleeps"
+        case .nappy: "Wet and dirty nappy changes"
+        }
+    }
+
+    // MARK: - Entrance animation
+
+    private func staggerIn() {
+        if reduceMotion {
+            appearedMask = Array(repeating: true, count: appearedMask.count)
+            return
+        }
+        Task { @MainActor in
+            try? await Task.sleep(for: .milliseconds(420))
+            withAnimation(.spring(response: 0.5, dampingFraction: 0.82)) {
+                appearedMask[0] = true
+            }
+            withAnimation(.spring(response: 0.5, dampingFraction: 0.82).delay(0.08)) {
+                appearedMask[1] = true
+            }
+            for index in 2..<appearedMask.count {
+                let delay = Double(index - 2) * 0.08
+                withAnimation(.spring(response: 0.42, dampingFraction: 0.78).delay(delay)) {
+                    appearedMask[index] = true
+                }
+            }
+        }
+    }
+}
+
+// MARK: - Preview
+
+#Preview {
+    OnboardingCustomizeEventsStepView(
+        model: ChildProfilePreviewFactory.makeModel()
+    )
+    .background(Color(.systemGroupedBackground))
+}

--- a/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/OnboardingFirstEventStepView.swift
+++ b/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/OnboardingFirstEventStepView.swift
@@ -15,10 +15,14 @@ struct OnboardingFirstEventStepView: View {
 
     @State private var activeEventSheet: ChildEventSheet?
     @State private var firstEventSaved = false
-    @State private var appearedMask: [Bool] = [false, false, false, false, false, false]
+    @State private var appearedMask: [Bool] = Array(repeating: false, count: 6)
     @State private var highlightedIndex = 0
-    @State private var wiggleScales: [Double] = [1.0, 1.0, 1.0, 1.0]
-    @State private var rotations: [Double] = [0, 0, 0, 0]
+    @State private var wiggleScales: [Double] = Array(repeating: 1.0, count: 4)
+    @State private var rotations: [Double] = Array(repeating: 0, count: 4)
+
+    private var visibleKinds: [BabyEventKind] {
+        BabyEventKind.allCases.filter { model.isEventKindEnabled($0) }
+    }
 
     private var childName: String {
         model.currentChild?.name ?? "your baby"
@@ -42,25 +46,20 @@ struct OnboardingFirstEventStepView: View {
                 }
 
                 VStack(spacing: 12) {
-                    HStack(spacing: 12) {
-                        quickLogButton(0, title: "Breast Feed", kind: .breastFeed) {
-                            activeEventSheet = .quickLogBreastFeed
-                        }
-                        quickLogButton(1, title: "Bottle Feed", kind: .bottleFeed) {
-                            activeEventSheet = .quickLogBottleFeed(smartSuggestions: [])
-                        }
+                    let rows = stride(from: 0, to: visibleKinds.count, by: 2).map { i in
+                        Array(visibleKinds[i..<min(i + 2, visibleKinds.count)])
                     }
-                    .geometryGroup()
-
-                    HStack(spacing: 12) {
-                        quickLogButton(2, title: "Start Sleep", kind: .sleep) {
-                            activeEventSheet = .startSleep(suggestions: [])
+                    ForEach(Array(rows.enumerated()), id: \.offset) { rowIndex, row in
+                        HStack(spacing: 12) {
+                            ForEach(Array(row.enumerated()), id: \.element) { colIndex, kind in
+                                let buttonIndex = rowIndex * 2 + colIndex
+                                quickLogButton(buttonIndex, title: buttonTitle(for: kind), kind: kind) {
+                                    activeEventSheet = eventSheet(for: kind)
+                                }
+                            }
                         }
-                        quickLogButton(3, title: "Nappy", kind: .nappy) {
-                            activeEventSheet = .quickLogNappy(.mixed)
-                        }
+                        .geometryGroup()
                     }
-                    .geometryGroup()
                 }
             }
             .frame(maxWidth: .infinity, alignment: .leading)
@@ -74,13 +73,15 @@ struct OnboardingFirstEventStepView: View {
         }
         .task(id: reduceMotion) {
             guard !reduceMotion else { return }
+            let count = visibleKinds.count
+            guard count > 0 else { return }
             // Wait for page slide-in + full stagger to settle before first wiggle
             try? await Task.sleep(for: .milliseconds(1200))
             animateWiggle(0)
             while !Task.isCancelled {
                 try? await Task.sleep(for: .seconds(2.4))
                 guard !Task.isCancelled else { break }
-                let next = (highlightedIndex + 1) % 4
+                let next = (highlightedIndex + 1) % count
                 withAnimation(.spring(response: 0.38, dampingFraction: 0.62)) {
                     highlightedIndex = next
                 }
@@ -92,6 +93,26 @@ struct OnboardingFirstEventStepView: View {
         }
         .onChange(of: firstEventSaved) { _, saved in
             if saved { onEventSaved() }
+        }
+    }
+
+    // MARK: - Kind helpers
+
+    private func buttonTitle(for kind: BabyEventKind) -> String {
+        switch kind {
+        case .breastFeed: "Breast Feed"
+        case .bottleFeed: "Bottle Feed"
+        case .sleep: "Start Sleep"
+        case .nappy: "Nappy"
+        }
+    }
+
+    private func eventSheet(for kind: BabyEventKind) -> ChildEventSheet {
+        switch kind {
+        case .breastFeed: .quickLogBreastFeed
+        case .bottleFeed: .quickLogBottleFeed(smartSuggestions: [])
+        case .sleep: .startSleep(suggestions: [])
+        case .nappy: .quickLogNappy(.mixed)
         }
     }
 
@@ -144,7 +165,7 @@ struct OnboardingFirstEventStepView: View {
             withAnimation(.spring(response: 0.5, dampingFraction: 0.82).delay(0.08)) {
                 appearedMask[1] = true
             }
-            for index in 2..<appearedMask.count {
+            for index in 2..<(2 + visibleKinds.count) {
                 let delay = Double(index - 2) * 0.1
                 withAnimation(.spring(response: 0.38, dampingFraction: 0.52).delay(delay)) {
                     appearedMask[index] = true

--- a/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/SummaryScreenView.swift
+++ b/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/SummaryScreenView.swift
@@ -303,12 +303,13 @@ public struct SummaryScreenView: View {
                     message: viewModel.emptyStateMessage
                 )
             } else {
+                let enabled = viewModel.enabledEventKinds
                 VStack(alignment: .leading, spacing: 12) {
                     dateNavigationRow
-                    sleepSectionCard(data: data)
-                    bottleSectionCard(data: data)
-                    breastSectionCard(data: data)
-                    nappySectionCard(data: data)
+                    if enabled.contains(.sleep) { sleepSectionCard(data: data) }
+                    if enabled.contains(.bottleFeed) { bottleSectionCard(data: data) }
+                    if enabled.contains(.breastFeed) { breastSectionCard(data: data) }
+                    if enabled.contains(.nappy) { nappySectionCard(data: data) }
                     advancedSummaryLink
                     loggingStreakRow(data: data)
                 }
@@ -689,6 +690,7 @@ public struct SummaryScreenView: View {
             || data.dailySleep.contains { $0.totalMinutes > 0 }
             || data.dailyNappy.contains { $0.totalCount > 0 }
 
+        let enabled = viewModel.enabledEventKinds
         return VStack(alignment: .leading, spacing: 12) {
             trendsRangePicker
 
@@ -698,10 +700,10 @@ public struct SummaryScreenView: View {
                     message: "Try a broader range to see feeding, sleep, and nappy trends."
                 )
             } else {
-                sleepChartCard(data: data)
-                bottleChartCard(data: data)
-                breastChartCard(data: data)
-                nappyChartCard(data: data)
+                if enabled.contains(.sleep) { sleepChartCard(data: data) }
+                if enabled.contains(.bottleFeed) { bottleChartCard(data: data) }
+                if enabled.contains(.breastFeed) { breastChartCard(data: data) }
+                if enabled.contains(.nappy) { nappyChartCard(data: data) }
             }
         }
     }


### PR DESCRIPTION
Lets users toggle which event kinds (Breast Feed, Bottle Feed, Sleep,
Nappy) appear across the app. Disabled kinds are hidden from the Home
tab's Quick Log buttons, the event history list and filter, the
timeline grid, and the today/summary aggregations. Existing data is
never deleted — re-enabling a kind restores it.

Mirrors the LiveActivityPreferenceStore pattern: protocol +
InMemory + UserDefaults stores, exposed through AppModel as
enabledEventKinds with a setter that persists, refreshes derived
state, and refuses to disable the last enabled kind.