### PR TITLE
Add bath event type

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -236,6 +236,43 @@ Check:
 
 For requested features, tweaks, and bug fixes, default to planning first. Create or update the plan before implementing the work. If the change is large enough to be worth documenting, create the GitHub issue before writing code.
 
+### Adding a new event type
+When adding a new first-class event type, do not stop at the obvious enum and UI updates. Treat event types as a cross-cutting feature and check all of the existing event system touch points.
+
+At minimum, review and update the relevant places in:
+
+- Domain models and enums
+  - event entities such as `BabyEvent`, `BabyEventKind`, event-specific structs, import/export DTOs, filters, timeline dataset builders, notification/suggestion use cases, restore/delete flows, and any event-specific validation or create/update use cases
+- Persistence
+  - SwiftData models, model container schema, repositories, soft-delete handling, timeline/day queries, and sync-state record references
+- CloudKit sync
+  - record type names, field mappings, mutable field lists, save/load decoding, sync engine event-type switches, and any code that enumerates syncable record types
+- Presentation and interaction
+  - event presentation helpers, titles, detail text, icons, colors, cards, timeline items, edit payloads, quick log buttons, sheets, filters, visibility settings, summaries, onboarding/demo content, previews, sample data, and accessibility identifiers/labels
+- Summary and charts
+  - trend aggregations, chart cards, summary calculators, and explicit decisions about whether the new event belongs in Today, Trends, both, or neither
+- Import and export
+  - Huckleberry/Nest import mapping, JSON/CSV parsing, import preview rows, import summaries, export payload mapping, export screen copy, and full child restore/import flows
+- Tests
+  - domain behavior, repository round-trips, CloudKit mapping, filters, timeline ordering, summary/trend calculations, import/export coverage, and any existing app-model or presentation tests affected by the new event
+
+If the event syncs with CloudKit, also assume the schema may need to change:
+
+- add the new record type and fields in code
+- run the app against the development CloudKit environment so the schema appears in the dashboard
+- verify the new record type and fields in CloudKit Dashboard
+- deploy the schema to production before shipping builds that create or sync the new event type
+
+For event-type work, explicitly search the codebase for places where event types are:
+
+- declared
+- switched over
+- serialized or deserialized
+- filtered
+- color-coded or icon-coded
+- displayed in lists, cards, timelines, summaries, or charts
+- imported, exported, restored, or synced
+
 ### While making changes
 Keep edits narrow and intentional.
 

--- a/Baby Tracker Live Activities/BabyEventKindAccentColor.swift
+++ b/Baby Tracker Live Activities/BabyEventKindAccentColor.swift
@@ -4,6 +4,8 @@ import SwiftUI
 extension BabyEventKind {
     var accentColor: Color {
         switch self {
+        case .bath:
+            Color(red: 0.09, green: 0.63, blue: 0.67)
         case .breastFeed:
             Color(red: 0.84, green: 0.29, blue: 0.42)
         case .bottleFeed:

--- a/Baby Tracker Live Activities/FeedLiveActivityContentView.swift
+++ b/Baby Tracker Live Activities/FeedLiveActivityContentView.swift
@@ -110,6 +110,8 @@ struct FeedLiveActivityContentView: View {
 
     private func symbolName(for kind: BabyEventKind) -> String {
         switch kind {
+        case .bath:
+            "drop.fill"
         case .breastFeed:
             "heart.text.square"
         case .bottleFeed:

--- a/Baby Tracker Live Activities/FeedLiveActivityWidget.swift
+++ b/Baby Tracker Live Activities/FeedLiveActivityWidget.swift
@@ -54,6 +54,8 @@ struct FeedLiveActivityWidget: Widget {
 
     private func symbolName(for metric: CompactDynamicIslandMetric) -> String {
         switch metric.kind {
+        case .bath:
+            "drop.fill"
         case .breastFeed:
             "heart.text.square"
         case .bottleFeed:

--- a/Baby TrackerTests/AppModelTests.swift
+++ b/Baby TrackerTests/AppModelTests.swift
@@ -1456,7 +1456,7 @@ struct AppModelTests {
         harness.model.setEventKindEnabled(.breastFeed, isEnabled: false)
 
         #expect(!harness.model.isEventKindEnabled(.breastFeed))
-        #expect(visibilityStore.enabledEventKinds == [.bottleFeed, .sleep, .nappy])
+        #expect(visibilityStore.enabledEventKinds == [.bath, .bottleFeed, .sleep, .nappy])
         #expect(!harness.model.events.contains(where: { $0.id == breastFeed.id }))
         #expect(harness.model.events.contains(where: { $0.id == bottleFeed.id }))
 

--- a/Baby TrackerTests/BabyEventDomainTests.swift
+++ b/Baby TrackerTests/BabyEventDomainTests.swift
@@ -200,6 +200,38 @@ struct BabyEventDomainTests {
     }
 
     @Test
+    func bathEventsSupportCreateAndUpdate() throws {
+        let childID = UUID()
+        let userID = UUID()
+        let occurredAt = Date(timeIntervalSince1970: 4_250)
+
+        let original = BathEvent(
+            metadata: EventMetadata(
+                childID: childID,
+                occurredAt: occurredAt,
+                createdAt: occurredAt,
+                createdBy: userID
+            ),
+            usedShampoo: false,
+            usedSoap: true
+        )
+
+        let updated = original.updating(
+            occurredAt: occurredAt.addingTimeInterval(600),
+            usedShampoo: true,
+            usedSoap: false,
+            updatedBy: userID
+        )
+
+        #expect(original.usedShampoo == false)
+        #expect(original.usedSoap == true)
+        #expect(updated.usedShampoo == true)
+        #expect(updated.usedSoap == false)
+        #expect(updated.metadata.occurredAt == occurredAt.addingTimeInterval(600))
+        #expect(updated.metadata.updatedBy == userID)
+    }
+
+    @Test
     func updatingNappySupportsValidEditsAndRejectsInvalidPooColor() throws {
         let childID = UUID()
         let userID = UUID()

--- a/Baby TrackerTests/BabyEventStyleTests.swift
+++ b/Baby TrackerTests/BabyEventStyleTests.swift
@@ -8,7 +8,7 @@ import UIKit
 struct BabyEventStyleTests {
     @Test
     func prominentEventSurfacesMaintainReadableContrastAcrossAppearances() {
-        for kind in [BabyEventKind.breastFeed, .bottleFeed, .sleep, .nappy] {
+        for kind in [BabyEventKind.bath, .breastFeed, .bottleFeed, .sleep, .nappy] {
             let fill = UIColor(BabyEventStyle.buttonFillColor(for: kind))
             let foreground = UIColor(BabyEventStyle.buttonForegroundColor(for: kind))
 
@@ -19,7 +19,7 @@ struct BabyEventStyleTests {
 
     @Test
     func eventCardsMaintainReadableContrastAcrossAppearances() {
-        for kind in [BabyEventKind.breastFeed, .bottleFeed, .sleep, .nappy] {
+        for kind in [BabyEventKind.bath, .breastFeed, .bottleFeed, .sleep, .nappy] {
             let fill = UIColor(BabyEventStyle.cardFillColor(for: kind))
             let foreground = UIColor(BabyEventStyle.cardForegroundColor(for: kind))
             let secondaryForeground = UIColor(BabyEventStyle.cardSecondaryForegroundColor(for: kind))

--- a/Baby TrackerTests/CloudKitRecordMapperTests.swift
+++ b/Baby TrackerTests/CloudKitRecordMapperTests.swift
@@ -133,6 +133,46 @@ struct CloudKitRecordMapperTests {
     }
 
     @Test
+    func bathMapperRoundTripsShampooAndSoapFields() throws {
+        let childID = UUID()
+        let userID = UUID()
+        let occurredAt = Date(timeIntervalSince1970: 3_500)
+        let zoneID = CloudKitRecordNames.zoneID(
+            for: childID,
+            ownerName: "probe-owner"
+        )
+        let bath = BathEvent(
+            metadata: EventMetadata(
+                childID: childID,
+                occurredAt: occurredAt,
+                createdAt: occurredAt,
+                createdBy: userID
+            ),
+            usedShampoo: true,
+            usedSoap: false
+        )
+
+        let record = CloudKitRecordMapper.eventRecord(
+            from: .bath(bath),
+            zoneID: zoneID
+        )
+
+        #expect(record.recordType == CloudKitConfiguration.bathRecordType)
+        #expect(record["shampooUsed"] as? Int64 == 1)
+        #expect(record["soapUsed"] as? Int64 == 0)
+
+        let mappedEvent = try CloudKitRecordMapper.event(from: record)
+
+        switch mappedEvent {
+        case let .bath(event):
+            #expect(event.usedShampoo == true)
+            #expect(event.usedSoap == false)
+        default:
+            Issue.record("Expected a bath event")
+        }
+    }
+
+    @Test
     func sleepMapperRoundTripsOpenEndedAndCompletedSessions() throws {
         let childID = UUID()
         let userID = UUID()

--- a/Baby TrackerTests/EventRepositoryTests.swift
+++ b/Baby TrackerTests/EventRepositoryTests.swift
@@ -234,6 +234,54 @@ struct EventRepositoryTests {
     }
 
     @Test
+    func bathEventsRoundTripAndSortByOccurredAt() throws {
+        let harness = try RepositoryHarness()
+        defer { harness.cleanUp() }
+
+        let childID = UUID()
+        let userID = UUID()
+        let earlierTime = Date(timeIntervalSince1970: 8_000)
+        let laterTime = Date(timeIntervalSince1970: 9_000)
+
+        let earlierBath = BathEvent(
+            metadata: EventMetadata(
+                childID: childID,
+                occurredAt: earlierTime,
+                createdAt: earlierTime,
+                createdBy: userID
+            ),
+            usedShampoo: true,
+            usedSoap: false
+        )
+        let laterBath = BathEvent(
+            metadata: EventMetadata(
+                childID: childID,
+                occurredAt: laterTime,
+                createdAt: laterTime,
+                createdBy: userID
+            ),
+            usedShampoo: true,
+            usedSoap: true
+        )
+
+        try harness.repository.saveEvent(.bath(earlierBath))
+        try harness.repository.saveEvent(.bath(laterBath))
+
+        let timeline = try harness.repository.loadTimeline(for: childID, includingDeleted: false)
+        let reloadedBath = try #require(try harness.repository.loadEvent(id: laterBath.id))
+
+        #expect(timeline.map(\.kind) == [.bath, .bath])
+
+        switch reloadedBath {
+        case let .bath(event):
+            #expect(event.usedShampoo == true)
+            #expect(event.usedSoap == true)
+        default:
+            Issue.record("Expected a bath event")
+        }
+    }
+
+    @Test
     func savingEditedEventUpdatesExistingRecordInPlace() throws {
         let harness = try RepositoryHarness()
         defer { harness.cleanUp() }

--- a/Baby TrackerTests/TestDoubles/InMemoryEventRepository.swift
+++ b/Baby TrackerTests/TestDoubles/InMemoryEventRepository.swift
@@ -64,6 +64,9 @@ final class InMemoryEventRepository: EventRepository {
     func softDeleteEvent(id: UUID, deletedAt: Date, deletedBy: UUID) throws {
         guard let event = store.events[id] else { return }
         switch event {
+        case var .bath(e):
+            e.metadata.markDeleted(at: deletedAt, by: deletedBy)
+            store.events[id] = .bath(e)
         case var .breastFeed(e):
             e.metadata.markDeleted(at: deletedAt, by: deletedBy)
             store.events[id] = .breastFeed(e)
@@ -82,6 +85,7 @@ final class InMemoryEventRepository: EventRepository {
 
     private func syncRecordType(for event: BabyEvent) -> SyncRecordType {
         switch event {
+        case .bath: return .bathEvent
         case .breastFeed: return .breastFeedEvent
         case .bottleFeed: return .bottleFeedEvent
         case .sleep: return .sleepEvent

--- a/Baby TrackerTests/TrendsSummaryCalculatorTests.swift
+++ b/Baby TrackerTests/TrendsSummaryCalculatorTests.swift
@@ -1,0 +1,48 @@
+import BabyTrackerDomain
+import BabyTrackerFeature
+import Foundation
+import Testing
+
+struct TrendsSummaryCalculatorTests {
+    @Test
+    func bathTrendCountsAreGroupedPerDayAndAverageOverNonZeroDays() throws {
+        var calendar = Calendar(identifier: .gregorian)
+        calendar.timeZone = TimeZone(secondsFromGMT: 0)!
+
+        let childID = UUID()
+        let userID = UUID()
+        let now = try #require(calendar.date(from: DateComponents(year: 2026, month: 3, day: 26, hour: 12)))
+        let todayBath = try #require(calendar.date(from: DateComponents(year: 2026, month: 3, day: 26, hour: 9)))
+        let yesterdayBathOne = try #require(calendar.date(from: DateComponents(year: 2026, month: 3, day: 25, hour: 8)))
+        let yesterdayBathTwo = try #require(calendar.date(from: DateComponents(year: 2026, month: 3, day: 25, hour: 18)))
+
+        let events: [BabyEvent] = [
+            .bath(BathEvent(
+                metadata: EventMetadata(childID: childID, occurredAt: todayBath, createdAt: todayBath, createdBy: userID),
+                usedShampoo: true,
+                usedSoap: false
+            )),
+            .bath(BathEvent(
+                metadata: EventMetadata(childID: childID, occurredAt: yesterdayBathOne, createdAt: yesterdayBathOne, createdBy: userID),
+                usedShampoo: false,
+                usedSoap: true
+            )),
+            .bath(BathEvent(
+                metadata: EventMetadata(childID: childID, occurredAt: yesterdayBathTwo, createdAt: yesterdayBathTwo, createdBy: userID),
+                usedShampoo: true,
+                usedSoap: true
+            )),
+        ]
+
+        let data = TrendsSummaryCalculator.makeData(
+            from: events,
+            range: .sevenDays,
+            now: now,
+            calendar: calendar
+        )
+
+        #expect(data.dailyBath.first(where: { calendar.isDate($0.date, inSameDayAs: yesterdayBathOne) })?.count == 2)
+        #expect(data.dailyBath.first(where: { calendar.isDate($0.date, inSameDayAs: todayBath) })?.count == 1)
+        #expect(data.avgDailyBaths == 2)
+    }
+}

--- a/Claude.md
+++ b/Claude.md
@@ -236,6 +236,43 @@ Check:
 
 For requested features, tweaks, and bug fixes, default to planning first. Create or update the plan before implementing the work. If the change is large enough to be worth documenting, create the GitHub issue before writing code.
 
+### Adding a new event type
+When adding a new first-class event type, do not stop at the obvious enum and UI updates. Treat event types as a cross-cutting feature and check all of the existing event system touch points.
+
+At minimum, review and update the relevant places in:
+
+- Domain models and enums
+  - event entities such as `BabyEvent`, `BabyEventKind`, event-specific structs, import/export DTOs, filters, timeline dataset builders, notification/suggestion use cases, restore/delete flows, and any event-specific validation or create/update use cases
+- Persistence
+  - SwiftData models, model container schema, repositories, soft-delete handling, timeline/day queries, and sync-state record references
+- CloudKit sync
+  - record type names, field mappings, mutable field lists, save/load decoding, sync engine event-type switches, and any code that enumerates syncable record types
+- Presentation and interaction
+  - event presentation helpers, titles, detail text, icons, colors, cards, timeline items, edit payloads, quick log buttons, sheets, filters, visibility settings, summaries, onboarding/demo content, previews, sample data, and accessibility identifiers/labels
+- Summary and charts
+  - trend aggregations, chart cards, summary calculators, and explicit decisions about whether the new event belongs in Today, Trends, both, or neither
+- Import and export
+  - Huckleberry/Nest import mapping, JSON/CSV parsing, import preview rows, import summaries, export payload mapping, export screen copy, and full child restore/import flows
+- Tests
+  - domain behavior, repository round-trips, CloudKit mapping, filters, timeline ordering, summary/trend calculations, import/export coverage, and any existing app-model or presentation tests affected by the new event
+
+If the event syncs with CloudKit, also assume the schema may need to change:
+
+- add the new record type and fields in code
+- run the app against the development CloudKit environment so the schema appears in the dashboard
+- verify the new record type and fields in CloudKit Dashboard
+- deploy the schema to production before shipping builds that create or sync the new event type
+
+For event-type work, explicitly search the codebase for places where event types are:
+
+- declared
+- switched over
+- serialized or deserialized
+- filtered
+- color-coded or icon-coded
+- displayed in lists, cards, timelines, summaries, or charts
+- imported, exported, restored, or synced
+
 ### While making changes
 Keep edits narrow and intentional.
 

--- a/Packages/BabyTrackerDomain/Sources/BabyTrackerDomain/BabyEvent.swift
+++ b/Packages/BabyTrackerDomain/Sources/BabyTrackerDomain/BabyEvent.swift
@@ -1,6 +1,7 @@
 import Foundation
 
 public enum BabyEvent: Equatable, Identifiable, Sendable {
+    case bath(BathEvent)
     case breastFeed(BreastFeedEvent)
     case bottleFeed(BottleFeedEvent)
     case sleep(SleepEvent)
@@ -12,6 +13,8 @@ public enum BabyEvent: Equatable, Identifiable, Sendable {
 
     public var metadata: EventMetadata {
         switch self {
+        case let .bath(event):
+            event.metadata
         case let .breastFeed(event):
             event.metadata
         case let .bottleFeed(event):
@@ -25,6 +28,8 @@ public enum BabyEvent: Equatable, Identifiable, Sendable {
 
     public var kind: BabyEventKind {
         switch self {
+        case .bath:
+            .bath
         case .breastFeed:
             .breastFeed
         case .bottleFeed:

--- a/Packages/BabyTrackerDomain/Sources/BabyTrackerDomain/BabyEventKind.swift
+++ b/Packages/BabyTrackerDomain/Sources/BabyTrackerDomain/BabyEventKind.swift
@@ -1,6 +1,7 @@
 import Foundation
 
 public enum BabyEventKind: String, CaseIterable, Codable, Equatable, Hashable, Sendable {
+    case bath
     case breastFeed
     case bottleFeed
     case sleep

--- a/Packages/BabyTrackerDomain/Sources/BabyTrackerDomain/BathEvent.swift
+++ b/Packages/BabyTrackerDomain/Sources/BabyTrackerDomain/BathEvent.swift
@@ -1,0 +1,39 @@
+import Foundation
+
+public struct BathEvent: Equatable, Identifiable, Sendable {
+    public var metadata: EventMetadata
+    public var usedShampoo: Bool
+    public var usedSoap: Bool
+
+    public var id: UUID {
+        metadata.id
+    }
+
+    public init(
+        metadata: EventMetadata,
+        usedShampoo: Bool,
+        usedSoap: Bool
+    ) {
+        self.metadata = metadata
+        self.usedShampoo = usedShampoo
+        self.usedSoap = usedSoap
+    }
+
+    public func updating(
+        occurredAt: Date,
+        usedShampoo: Bool,
+        usedSoap: Bool,
+        updatedAt: Date = Date(),
+        updatedBy: UUID
+    ) -> BathEvent {
+        var metadata = metadata
+        metadata.occurredAt = occurredAt
+        metadata.markUpdated(at: updatedAt, by: updatedBy)
+
+        return BathEvent(
+            metadata: metadata,
+            usedShampoo: usedShampoo,
+            usedSoap: usedSoap
+        )
+    }
+}

--- a/Packages/BabyTrackerDomain/Sources/BabyTrackerDomain/EventFilter.swift
+++ b/Packages/BabyTrackerDomain/Sources/BabyTrackerDomain/EventFilter.swift
@@ -71,6 +71,9 @@ public struct EventFilter: Equatable, Sendable {
                 return false
             }
 
+        case .bath:
+            break
+
         case let .bottleFeed(bottle):
             if !milkTypes.isEmpty {
                 guard let milkType = bottle.milkType, milkTypes.contains(milkType) else {

--- a/Packages/BabyTrackerDomain/Sources/BabyTrackerDomain/ImportableEvent.swift
+++ b/Packages/BabyTrackerDomain/Sources/BabyTrackerDomain/ImportableEvent.swift
@@ -2,6 +2,7 @@ import Foundation
 
 /// Represents a fully-parsed CSV row, typed and ready to be saved as a domain event.
 public enum ImportableEvent: Equatable, Sendable, Identifiable {
+    case bath(BathImport)
     case bottleFeed(BottleFeedImport)
     case breastFeed(BreastFeedImport)
     case sleep(SleepImport)
@@ -11,6 +12,7 @@ public enum ImportableEvent: Equatable, Sendable, Identifiable {
 
     public var metadata: ImportEventMetadata {
         switch self {
+        case .bath(let e): return e.metadata
         case .bottleFeed(let e): return e.metadata
         case .breastFeed(let e): return e.metadata
         case .sleep(let e): return e.metadata
@@ -22,6 +24,7 @@ public enum ImportableEvent: Equatable, Sendable, Identifiable {
 
     public var kind: BabyEventKind {
         switch self {
+        case .bath: return .bath
         case .bottleFeed: return .bottleFeed
         case .breastFeed: return .breastFeed
         case .sleep: return .sleep
@@ -31,6 +34,17 @@ public enum ImportableEvent: Equatable, Sendable, Identifiable {
 
     public var displayTitle: String {
         switch self {
+        case .bath(let e):
+            if e.usedShampoo && e.usedSoap {
+                return "Shampoo · Soap"
+            }
+            if e.usedShampoo {
+                return "Shampoo"
+            }
+            if e.usedSoap {
+                return "Soap"
+            }
+            return "Bath only"
         case .bottleFeed(let e):
             var parts = ["\(e.amountMilliliters)ml"]
             if let milkType = e.milkType {
@@ -53,6 +67,7 @@ public enum ImportableEvent: Equatable, Sendable, Identifiable {
 
     public var eventKindLabel: String {
         switch self {
+        case .bath: return "Bath"
         case .bottleFeed: return "Bottle Feed"
         case .breastFeed: return "Breast Feed"
         case .sleep: return "Sleep"
@@ -84,6 +99,22 @@ public struct BottleFeedImport: Equatable, Sendable {
         self.metadata = metadata
         self.amountMilliliters = amountMilliliters
         self.milkType = milkType
+    }
+}
+
+public struct BathImport: Equatable, Sendable {
+    public let metadata: ImportEventMetadata
+    public let usedShampoo: Bool
+    public let usedSoap: Bool
+
+    public init(
+        metadata: ImportEventMetadata,
+        usedShampoo: Bool,
+        usedSoap: Bool
+    ) {
+        self.metadata = metadata
+        self.usedShampoo = usedShampoo
+        self.usedSoap = usedSoap
     }
 }
 

--- a/Packages/BabyTrackerDomain/Sources/BabyTrackerDomain/NestExportData.swift
+++ b/Packages/BabyTrackerDomain/Sources/BabyTrackerDomain/NestExportData.swift
@@ -38,6 +38,7 @@ public struct NestChildExport: Codable, Sendable {
 /// A single exported event. Encoded as a flat JSON object with a `"type"` discriminator key.
 /// All serialisation is handled manually here so associated-value structs remain plain `Sendable` types.
 public enum NestEventExport: Codable, Sendable {
+    case bath(NestBathExport)
     case breastFeed(NestBreastFeedExport)
     case bottleFeed(NestBottleFeedExport)
     case sleep(NestSleepExport)
@@ -46,6 +47,8 @@ public enum NestEventExport: Codable, Sendable {
     private enum CodingKeys: String, CodingKey {
         case type
         case id, occurredAt, notes
+        // bath
+        case usedShampoo, usedSoap
         // breastFeed
         case side, startedAt, endedAt, leftDurationSeconds, rightDurationSeconds
         // bottleFeed
@@ -62,6 +65,14 @@ public enum NestEventExport: Codable, Sendable {
         let notes = try c.decodeIfPresent(String.self, forKey: .notes) ?? ""
 
         switch type {
+        case "bath":
+            self = .bath(NestBathExport(
+                id: id,
+                occurredAt: occurredAt,
+                notes: notes,
+                usedShampoo: try c.decodeIfPresent(Bool.self, forKey: .usedShampoo) ?? false,
+                usedSoap: try c.decodeIfPresent(Bool.self, forKey: .usedSoap) ?? false
+            ))
         case "breastFeed":
             self = .breastFeed(NestBreastFeedExport(
                 id: id,
@@ -114,6 +125,14 @@ public enum NestEventExport: Codable, Sendable {
         var c = encoder.container(keyedBy: CodingKeys.self)
 
         switch self {
+        case .bath(let e):
+            try c.encode("bath", forKey: .type)
+            try c.encode(e.id, forKey: .id)
+            try c.encode(e.occurredAt, forKey: .occurredAt)
+            try c.encode(e.notes, forKey: .notes)
+            try c.encode(e.usedShampoo, forKey: .usedShampoo)
+            try c.encode(e.usedSoap, forKey: .usedSoap)
+
         case .breastFeed(let e):
             try c.encode("breastFeed", forKey: .type)
             try c.encode(e.id, forKey: .id)
@@ -155,6 +174,28 @@ public enum NestEventExport: Codable, Sendable {
 }
 
 // MARK: - Per-event structs (plain data carriers — not Codable)
+
+public struct NestBathExport: Sendable {
+    public let id: UUID
+    public let occurredAt: Date
+    public let notes: String
+    public let usedShampoo: Bool
+    public let usedSoap: Bool
+
+    public init(
+        id: UUID,
+        occurredAt: Date,
+        notes: String,
+        usedShampoo: Bool,
+        usedSoap: Bool
+    ) {
+        self.id = id
+        self.occurredAt = occurredAt
+        self.notes = notes
+        self.usedShampoo = usedShampoo
+        self.usedSoap = usedSoap
+    }
+}
 
 public struct NestBreastFeedExport: Sendable {
     public let id: UUID

--- a/Packages/BabyTrackerDomain/Sources/BabyTrackerDomain/NestJSONParser.swift
+++ b/Packages/BabyTrackerDomain/Sources/BabyTrackerDomain/NestJSONParser.swift
@@ -33,6 +33,13 @@ public struct NestJSONParser {
 
     private func importableEvent(from nestEvent: NestEventExport, skippedReasons: inout [String]) -> ImportableEvent? {
         switch nestEvent {
+        case .bath(let e):
+            let metadata = ImportEventMetadata(occurredAt: e.occurredAt, notes: e.notes.isEmpty ? nil : e.notes)
+            return .bath(BathImport(
+                metadata: metadata,
+                usedShampoo: e.usedShampoo,
+                usedSoap: e.usedSoap
+            ))
         case .breastFeed(let e):
             let durationMinutes = Int(e.endedAt.timeIntervalSince(e.startedAt) / 60)
             let metadata = ImportEventMetadata(occurredAt: e.occurredAt, notes: e.notes.isEmpty ? nil : e.notes)

--- a/Packages/BabyTrackerDomain/Sources/BabyTrackerDomain/TimelineDayGridColumnKind.swift
+++ b/Packages/BabyTrackerDomain/Sources/BabyTrackerDomain/TimelineDayGridColumnKind.swift
@@ -3,6 +3,7 @@ import Foundation
 public enum TimelineDayGridColumnKind: String, CaseIterable, Equatable, Sendable {
     case sleep
     case nappy
+    case bath
     case bottleFeed
     case breastFeed
 }

--- a/Packages/BabyTrackerDomain/Sources/BabyTrackerDomain/UseCases/BuildRemoteCaregiverNotificationUseCase.swift
+++ b/Packages/BabyTrackerDomain/Sources/BabyTrackerDomain/UseCases/BuildRemoteCaregiverNotificationUseCase.swift
@@ -62,6 +62,8 @@ public struct BuildRemoteCaregiverNotificationUseCase: Sendable {
 
     private func addedMessage(for change: RemoteCaregiverEventChange) -> String {
         switch change.event {
+        case let .bath(event):
+            return "\(change.actorDisplayName) logged a bath at \(formatTime(event.metadata.occurredAt))."
         case let .sleep(event):
             if event.endedAt == nil {
                 return "\(change.actorDisplayName) started a sleep timer."
@@ -79,6 +81,8 @@ public struct BuildRemoteCaregiverNotificationUseCase: Sendable {
 
     private func deletedMessage(for change: RemoteCaregiverEventChange) -> String {
         switch change.event {
+        case .bath:
+            return "\(change.actorDisplayName) deleted a bath log."
         case .sleep:
             return "\(change.actorDisplayName) deleted a sleep log."
         case let .nappy(event):

--- a/Packages/BabyTrackerDomain/Sources/BabyTrackerDomain/UseCases/BuildTimelineDayGridDatasetUseCase.swift
+++ b/Packages/BabyTrackerDomain/Sources/BabyTrackerDomain/UseCases/BuildTimelineDayGridDatasetUseCase.swift
@@ -171,6 +171,8 @@ public struct BuildTimelineDayGridDatasetUseCase {
             return .sleep
         case .nappy:
             return .nappy
+        case .bath:
+            return .bath
         case .bottleFeed:
             return .bottleFeed
         case .breastFeed:
@@ -180,7 +182,7 @@ public struct BuildTimelineDayGridDatasetUseCase {
 
     private func occupiesSingleSlot(_ event: BabyEvent) -> Bool {
         switch event {
-        case .bottleFeed, .nappy:
+        case .bath, .bottleFeed, .nappy:
             true
         case .breastFeed, .sleep:
             false
@@ -189,6 +191,8 @@ public struct BuildTimelineDayGridDatasetUseCase {
 
     private func eventStart(for event: BabyEvent) -> Date {
         switch event {
+        case let .bath(bath):
+            bath.metadata.occurredAt
         case let .breastFeed(feed):
             feed.startedAt
         case let .bottleFeed(feed):
@@ -205,6 +209,8 @@ public struct BuildTimelineDayGridDatasetUseCase {
         now: Date
     ) -> Date {
         switch event {
+        case let .bath(bath):
+            bath.metadata.occurredAt.addingTimeInterval(TimeInterval(slotMinutes * 60))
         case let .breastFeed(feed):
             feed.endedAt
         case let .bottleFeed(feed):

--- a/Packages/BabyTrackerDomain/Sources/BabyTrackerDomain/UseCases/BuildTimelineStripDatasetUseCase.swift
+++ b/Packages/BabyTrackerDomain/Sources/BabyTrackerDomain/UseCases/BuildTimelineStripDatasetUseCase.swift
@@ -127,6 +127,8 @@ public struct BuildTimelineStripDatasetUseCase {
             return 4
         case .breastFeed:
             return 3
+        case .bath:
+            return 3
         case .bottleFeed:
             return 2
         case .nappy:
@@ -146,6 +148,8 @@ public struct BuildTimelineStripDatasetUseCase {
 
     private func timelineStartDate(for event: BabyEvent) -> Date {
         switch event {
+        case let .bath(bath):
+            return bath.metadata.occurredAt
         case let .breastFeed(feed):
             return feed.startedAt
         case let .bottleFeed(feed):
@@ -162,6 +166,8 @@ public struct BuildTimelineStripDatasetUseCase {
         now: Date
     ) -> Date {
         switch event {
+        case let .bath(bath):
+            return bath.metadata.occurredAt.addingTimeInterval(TimeInterval(slotMinutes * 60))
         case let .breastFeed(feed):
             return feed.endedAt
         case let .bottleFeed(feed):

--- a/Packages/BabyTrackerDomain/Sources/BabyTrackerDomain/UseCases/ExportEventsUseCase.swift
+++ b/Packages/BabyTrackerDomain/Sources/BabyTrackerDomain/UseCases/ExportEventsUseCase.swift
@@ -53,6 +53,14 @@ public struct ExportEventsUseCase: UseCase {
 
     private func nestEvent(from event: BabyEvent) -> NestEventExport? {
         switch event {
+        case .bath(let e):
+            return .bath(NestBathExport(
+                id: e.metadata.id,
+                occurredAt: e.metadata.occurredAt,
+                notes: e.metadata.notes,
+                usedShampoo: e.usedShampoo,
+                usedSoap: e.usedSoap
+            ))
         case .breastFeed(let e):
             return .breastFeed(NestBreastFeedExport(
                 id: e.metadata.id,

--- a/Packages/BabyTrackerDomain/Sources/BabyTrackerDomain/UseCases/ImportChildWithEventsUseCase.swift
+++ b/Packages/BabyTrackerDomain/Sources/BabyTrackerDomain/UseCases/ImportChildWithEventsUseCase.swift
@@ -96,6 +96,12 @@ public struct ImportChildWithEventsUseCase {
 
     private func importableEvent(from nestEvent: NestEventExport) -> ImportableEvent? {
         switch nestEvent {
+        case .bath(let e):
+            return .bath(BathImport(
+                metadata: ImportEventMetadata(occurredAt: e.occurredAt, notes: e.notes.isEmpty ? nil : e.notes),
+                usedShampoo: e.usedShampoo,
+                usedSoap: e.usedSoap
+            ))
         case .breastFeed(let e):
             let durationMinutes = Int(e.endedAt.timeIntervalSince(e.startedAt) / 60)
             return .breastFeed(BreastFeedImport(

--- a/Packages/BabyTrackerDomain/Sources/BabyTrackerDomain/UseCases/ImportEventsUseCase.swift
+++ b/Packages/BabyTrackerDomain/Sources/BabyTrackerDomain/UseCases/ImportEventsUseCase.swift
@@ -82,6 +82,8 @@ public struct ImportEventsUseCase {
 
     private func save(_ event: ImportableEvent, childID: UUID, localUserID: UUID, membership: Membership) throws {
         switch event {
+        case .bath(let e):
+            try saveBath(e, childID: childID, localUserID: localUserID, membership: membership)
         case .bottleFeed(let e):
             try saveBottleFeed(e, childID: childID, localUserID: localUserID, membership: membership)
         case .breastFeed(let e):
@@ -111,6 +113,26 @@ public struct ImportEventsUseCase {
                 milkType: e.milkType,
                 membership: membership
             ))
+    }
+
+    private func saveBath(
+        _ e: BathImport,
+        childID: UUID,
+        localUserID: UUID,
+        membership: Membership
+    ) throws {
+        _ = try LogBathUseCase(
+            eventRepository: eventRepository,
+            hapticFeedbackProvider: NoOpHapticFeedbackProvider()
+        )
+        .execute(.init(
+            childID: childID,
+            localUserID: localUserID,
+            occurredAt: e.metadata.occurredAt,
+            usedShampoo: e.usedShampoo,
+            usedSoap: e.usedSoap,
+            membership: membership
+        ))
     }
 
     private func saveBreastFeed(

--- a/Packages/BabyTrackerDomain/Sources/BabyTrackerDomain/UseCases/LogBathUseCase.swift
+++ b/Packages/BabyTrackerDomain/Sources/BabyTrackerDomain/UseCases/LogBathUseCase.swift
@@ -1,0 +1,61 @@
+import Foundation
+
+@MainActor
+public struct LogBathUseCase: UseCase {
+    public struct Input {
+        public let childID: UUID
+        public let localUserID: UUID
+        public let occurredAt: Date
+        public let usedShampoo: Bool
+        public let usedSoap: Bool
+        public let membership: Membership
+
+        public init(
+            childID: UUID,
+            localUserID: UUID,
+            occurredAt: Date,
+            usedShampoo: Bool,
+            usedSoap: Bool,
+            membership: Membership
+        ) {
+            self.childID = childID
+            self.localUserID = localUserID
+            self.occurredAt = occurredAt
+            self.usedShampoo = usedShampoo
+            self.usedSoap = usedSoap
+            self.membership = membership
+        }
+    }
+
+    private let eventRepository: any EventRepository
+    private let hapticFeedbackProvider: any HapticFeedbackProviding
+
+    public init(
+        eventRepository: any EventRepository,
+        hapticFeedbackProvider: any HapticFeedbackProviding = NoOpHapticFeedbackProvider()
+    ) {
+        self.eventRepository = eventRepository
+        self.hapticFeedbackProvider = hapticFeedbackProvider
+    }
+
+    public func execute(_ input: Input) throws -> BabyEvent {
+        guard ChildAccessPolicy.canPerform(.logEvent, membership: input.membership) else {
+            throw ChildProfileValidationError.insufficientPermissions
+        }
+
+        let event = BathEvent(
+            metadata: EventMetadata(
+                childID: input.childID,
+                occurredAt: input.occurredAt,
+                createdAt: .now,
+                createdBy: input.localUserID
+            ),
+            usedShampoo: input.usedShampoo,
+            usedSoap: input.usedSoap
+        )
+
+        try eventRepository.saveEvent(.bath(event))
+        hapticFeedbackProvider.play(.actionSucceeded)
+        return .bath(event)
+    }
+}

--- a/Packages/BabyTrackerDomain/Sources/BabyTrackerDomain/UseCases/RestoreDeletedEventUseCase.swift
+++ b/Packages/BabyTrackerDomain/Sources/BabyTrackerDomain/UseCases/RestoreDeletedEventUseCase.swift
@@ -32,6 +32,9 @@ public struct RestoreDeletedEventUseCase: UseCase {
 
     private func restoreDeleted(_ event: BabyEvent, by userID: UUID) -> BabyEvent {
         switch event {
+        case var .bath(feed):
+            feed.metadata.restoreDeleted(by: userID)
+            return .bath(feed)
         case var .breastFeed(feed):
             feed.metadata.restoreDeleted(by: userID)
             return .breastFeed(feed)

--- a/Packages/BabyTrackerDomain/Sources/BabyTrackerDomain/UseCases/UpdateBathUseCase.swift
+++ b/Packages/BabyTrackerDomain/Sources/BabyTrackerDomain/UseCases/UpdateBathUseCase.swift
@@ -1,0 +1,59 @@
+import Foundation
+
+@MainActor
+public struct UpdateBathUseCase: UseCase {
+    public struct Input {
+        public let eventID: UUID
+        public let localUserID: UUID
+        public let occurredAt: Date
+        public let usedShampoo: Bool
+        public let usedSoap: Bool
+        public let membership: Membership
+
+        public init(
+            eventID: UUID,
+            localUserID: UUID,
+            occurredAt: Date,
+            usedShampoo: Bool,
+            usedSoap: Bool,
+            membership: Membership
+        ) {
+            self.eventID = eventID
+            self.localUserID = localUserID
+            self.occurredAt = occurredAt
+            self.usedShampoo = usedShampoo
+            self.usedSoap = usedSoap
+            self.membership = membership
+        }
+    }
+
+    private let eventRepository: any EventRepository
+    private let hapticFeedbackProvider: any HapticFeedbackProviding
+
+    public init(
+        eventRepository: any EventRepository,
+        hapticFeedbackProvider: any HapticFeedbackProviding = NoOpHapticFeedbackProvider()
+    ) {
+        self.eventRepository = eventRepository
+        self.hapticFeedbackProvider = hapticFeedbackProvider
+    }
+
+    public func execute(_ input: Input) throws {
+        guard ChildAccessPolicy.canPerform(.editEvent, membership: input.membership) else {
+            throw ChildProfileValidationError.insufficientPermissions
+        }
+        guard let event = try eventRepository.loadEvent(id: input.eventID),
+              case let .bath(bath) = event else {
+            return
+        }
+
+        let updatedEvent = bath.updating(
+            occurredAt: input.occurredAt,
+            usedShampoo: input.usedShampoo,
+            usedSoap: input.usedSoap,
+            updatedBy: input.localUserID
+        )
+        try eventRepository.saveEvent(.bath(updatedEvent))
+        hapticFeedbackProvider.play(.actionSucceeded)
+    }
+}

--- a/Packages/BabyTrackerDomain/Tests/BabyTrackerDomainTests/BathImportExportTests.swift
+++ b/Packages/BabyTrackerDomain/Tests/BabyTrackerDomainTests/BathImportExportTests.swift
@@ -1,0 +1,167 @@
+import XCTest
+@testable import BabyTrackerDomain
+
+final class BathImportExportTests: XCTestCase {
+    func testNestJSONParserParsesBathEventsFromExportData() throws {
+        let occurredAt = Date(timeIntervalSince1970: 12_345)
+        let exportData = NestExportData(
+            exportedAt: Date(timeIntervalSince1970: 20_000),
+            child: NestChildExport(
+                id: UUID(uuidString: "11111111-2222-3333-4444-555555555555")!,
+                name: "Robin",
+                birthDate: nil
+            ),
+            events: [
+                .bath(NestBathExport(
+                    id: UUID(uuidString: "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee")!,
+                    occurredAt: occurredAt,
+                    notes: "Warm bath",
+                    usedShampoo: true,
+                    usedSoap: false
+                ))
+            ]
+        )
+
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .iso8601
+        let data = try encoder.encode(exportData)
+
+        let result = NestJSONParser().parse(data: data)
+
+        XCTAssertEqual(result.skippedCount, 0)
+        XCTAssertEqual(result.events.count, 1)
+
+        guard case let .bath(bath)? = result.events.first else {
+            return XCTFail("Expected parsed event to be a bath")
+        }
+
+        XCTAssertEqual(bath.metadata.occurredAt, occurredAt)
+        XCTAssertEqual(bath.metadata.notes, "Warm bath")
+        XCTAssertTrue(bath.usedShampoo)
+        XCTAssertFalse(bath.usedSoap)
+    }
+
+    @MainActor
+    func testImportChildWithEventsRestoresBathEvents() async throws {
+        let localUser = try UserIdentity(displayName: "Alex")
+        let occurredAt = Date(timeIntervalSince1970: 54_321)
+        let exportData = NestExportData(
+            exportedAt: Date(timeIntervalSince1970: 60_000),
+            child: NestChildExport(
+                id: UUID(uuidString: "11111111-2222-3333-4444-555555555555")!,
+                name: "Robin",
+                birthDate: Date(timeIntervalSince1970: 1_000)
+            ),
+            events: [
+                .bath(NestBathExport(
+                    id: UUID(uuidString: "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee")!,
+                    occurredAt: occurredAt,
+                    notes: "Night bath",
+                    usedShampoo: true,
+                    usedSoap: true
+                ))
+            ]
+        )
+
+        let childRepository = BathImportChildRepository()
+        let membershipRepository = BathImportMembershipRepository()
+        let childSelectionStore = BathImportChildSelectionStore()
+        let eventRepository = BathImportEventRepository()
+        let useCase = ImportChildWithEventsUseCase(
+            childRepository: childRepository,
+            membershipRepository: membershipRepository,
+            childSelectionStore: childSelectionStore,
+            eventRepository: eventRepository,
+            hapticFeedbackProvider: NoOpHapticFeedbackProvider()
+        )
+
+        let output = try await useCase.execute(.init(exportData: exportData, localUser: localUser))
+
+        XCTAssertEqual(output.child.name, "Robin")
+        XCTAssertEqual(output.child.birthDate, exportData.child.birthDate)
+        XCTAssertEqual(output.importResult.importedCount, 1)
+        XCTAssertEqual(output.importResult.skippedSaveCount, 0)
+        XCTAssertEqual(childSelectionStore.selectedChildID, output.child.id)
+        XCTAssertEqual(childRepository.savedChildren.count, 1)
+        XCTAssertEqual(membershipRepository.savedMemberships.count, 1)
+        XCTAssertEqual(eventRepository.savedEvents.count, 1)
+
+        guard case let .bath(bath)? = eventRepository.savedEvents.first else {
+            return XCTFail("Expected restored event to be a bath")
+        }
+
+        XCTAssertEqual(bath.metadata.childID, output.child.id)
+        XCTAssertEqual(bath.metadata.occurredAt, occurredAt)
+        XCTAssertTrue(bath.usedShampoo)
+        XCTAssertTrue(bath.usedSoap)
+    }
+}
+
+@MainActor
+private final class BathImportChildRepository: ChildRepository {
+    private(set) var savedChildren: [Child] = []
+
+    func loadAllChildren() throws -> [Child] { [] }
+    func loadActiveChildren(for userID: UUID) throws -> [Child] { [] }
+    func loadArchivedChildren(for userID: UUID) throws -> [Child] { [] }
+    func loadChild(id: UUID) throws -> Child? { savedChildren.first(where: { $0.id == id }) }
+
+    func saveChild(_ child: Child) throws {
+        savedChildren.append(child)
+    }
+
+    func purgeChildData(id: UUID) throws {}
+}
+
+@MainActor
+private final class BathImportMembershipRepository: MembershipRepository {
+    private(set) var savedMemberships: [Membership] = []
+
+    func loadMemberships(for childID: UUID) throws -> [Membership] {
+        savedMemberships.filter { $0.childID == childID }
+    }
+
+    func saveMembership(_ membership: Membership) throws {
+        savedMemberships.append(membership)
+    }
+}
+
+@MainActor
+private final class BathImportChildSelectionStore: ChildSelectionStore {
+    private(set) var selectedChildID: UUID?
+
+    func loadSelectedChildID() -> UUID? {
+        selectedChildID
+    }
+
+    func saveSelectedChildID(_ childID: UUID?) {
+        selectedChildID = childID
+    }
+}
+
+@MainActor
+private final class BathImportEventRepository: EventRepository {
+    private(set) var savedEvents: [BabyEvent] = []
+
+    func saveEvent(_ event: BabyEvent) throws {
+        savedEvents.append(event)
+    }
+
+    func loadEvent(id: UUID) throws -> BabyEvent? {
+        savedEvents.first(where: { $0.id == id })
+    }
+
+    func loadTimeline(for childID: UUID, includingDeleted: Bool) throws -> [BabyEvent] {
+        savedEvents.filter { $0.metadata.childID == childID }
+    }
+
+    func loadEvents(for childID: UUID, on day: Date, calendar: Calendar, includingDeleted: Bool) throws -> [BabyEvent] {
+        savedEvents.filter {
+            $0.metadata.childID == childID &&
+            calendar.isDate($0.metadata.occurredAt, inSameDayAs: day)
+        }
+    }
+
+    func loadActiveSleepEvent(for childID: UUID) throws -> SleepEvent? { nil }
+    func softDeleteEvent(id: UUID, deletedAt: Date, deletedBy: UUID) throws {}
+}

--- a/Packages/BabyTrackerDomain/Tests/BabyTrackerDomainTests/BuildRemoteCaregiverNotificationUseCaseTests.swift
+++ b/Packages/BabyTrackerDomain/Tests/BabyTrackerDomainTests/BuildRemoteCaregiverNotificationUseCaseTests.swift
@@ -135,6 +135,30 @@ final class BuildRemoteCaregiverNotificationUseCaseTests: XCTestCase {
         XCTAssertEqual(content?.body, "Jordan deleted a bottle feed log.")
     }
 
+    func testSingleBathBuildsSpecificMessage() throws {
+        let caregiver = try UserIdentity(displayName: "Jordan")
+        let child = try Child(name: "Robin", birthDate: nil, createdBy: caregiver.id)
+        let bath = BathEvent(
+            metadata: EventMetadata(
+                childID: child.id,
+                occurredAt: Date(timeIntervalSince1970: 100),
+                createdAt: Date(timeIntervalSince1970: 100),
+                createdBy: caregiver.id,
+                updatedAt: Date(timeIntervalSince1970: 100),
+                updatedBy: caregiver.id
+            ),
+            usedShampoo: true,
+            usedSoap: true
+        )
+
+        let useCase = BuildRemoteCaregiverNotificationUseCase(formatTime: { _ in "7:15 PM" })
+        let content = useCase.execute(.init(changes: [
+            .init(actorDisplayName: caregiver.displayName, event: .bath(bath), isDeleted: false),
+        ]))
+
+        XCTAssertEqual(content?.body, "Jordan logged a bath at 7:15 PM.")
+    }
+
     func testSingleDeletedBreastFeedBuildsDeletedMessage() throws {
         let caregiver = try UserIdentity(displayName: "Morgan")
         let child = try Child(name: "Robin", birthDate: nil, createdBy: caregiver.id)

--- a/Packages/BabyTrackerDomain/Tests/BabyTrackerDomainTests/EventFilterTests.swift
+++ b/Packages/BabyTrackerDomain/Tests/BabyTrackerDomainTests/EventFilterTests.swift
@@ -62,6 +62,22 @@ struct EventFilterTests {
         #expect(!filter.matches(.bottleFeed(bottle)))
     }
 
+    @Test
+    func eventTypeFilterIncludesBathAndBathIgnoresOtherTypedFilters() throws {
+        let bath = BathEvent(metadata: metadata(), usedShampoo: true, usedSoap: false)
+        let filter = EventFilter(
+            eventTypes: [.bath],
+            nappyTypes: [.poo],
+            milkTypes: [.formula],
+            breastSides: [.left],
+            sleepMinDurationMinutes: 30,
+            sleepMaxDurationMinutes: 60,
+            occurredOnOrAfter: nil,
+            occurredOnOrBefore: nil
+        )
+        #expect(filter.matches(.bath(bath)))
+    }
+
     // MARK: - Nappy type filter
 
     @Test

--- a/Packages/BabyTrackerDomain/Tests/BabyTrackerDomainTests/ExportEventsUseCaseTests.swift
+++ b/Packages/BabyTrackerDomain/Tests/BabyTrackerDomainTests/ExportEventsUseCaseTests.swift
@@ -30,13 +30,61 @@ final class ExportEventsUseCaseTests: XCTestCase {
         XCTAssertEqual(exportData.child.birthDate, child.birthDate)
         XCTAssertTrue(exportData.events.isEmpty)
     }
+
+    @MainActor
+    func testExportIncludesBathEvents() throws {
+        let owner = try UserIdentity(displayName: "Alex")
+        let child = try Child(
+            id: UUID(uuidString: "11111111-2222-3333-4444-555555555555")!,
+            name: "Robin",
+            birthDate: nil,
+            createdBy: owner.id
+        )
+        let bathTime = Date(timeIntervalSince1970: 2_345)
+        let bath = BathEvent(
+            metadata: EventMetadata(
+                childID: child.id,
+                occurredAt: bathTime,
+                createdAt: bathTime,
+                createdBy: owner.id
+            ),
+            usedShampoo: true,
+            usedSoap: false
+        )
+        let eventRepository = StubEventRepository(events: [.bath(bath)])
+        let useCase = ExportEventsUseCase(
+            eventRepository: eventRepository,
+            hapticFeedbackProvider: NoOpHapticFeedbackProvider()
+        )
+        let membership = Membership.owner(childID: child.id, userID: owner.id, createdAt: child.createdAt)
+
+        let data = try useCase.execute(.init(child: child, membership: membership))
+
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        let exportData = try decoder.decode(NestExportData.self, from: data)
+
+        guard case let .bath(exportedBath)? = exportData.events.first else {
+            return XCTFail("Expected first exported event to be a bath")
+        }
+
+        XCTAssertEqual(exportedBath.occurredAt, bathTime)
+        XCTAssertTrue(exportedBath.usedShampoo)
+        XCTAssertFalse(exportedBath.usedSoap)
+    }
 }
 
 @MainActor
 private final class StubEventRepository: EventRepository {
+    private let events: [BabyEvent]
+
+    init(events: [BabyEvent] = []) {
+        self.events = events
+    }
+
     func saveEvent(_ event: BabyEvent) throws {}
     func loadEvent(id: UUID) throws -> BabyEvent? { nil }
-    func loadTimeline(for childID: UUID, includingDeleted: Bool) throws -> [BabyEvent] { [] }
+    func loadTimeline(for childID: UUID, includingDeleted: Bool) throws -> [BabyEvent] { events }
     func loadEvents(for childID: UUID, on day: Date, calendar: Calendar, includingDeleted: Bool) throws -> [BabyEvent] { [] }
     func loadActiveSleepEvent(for childID: UUID) throws -> SleepEvent? { nil }
     func softDeleteEvent(id: UUID, deletedAt: Date, deletedBy: UUID) throws {}

--- a/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/AppModel.swift
+++ b/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/AppModel.swift
@@ -690,6 +690,30 @@ public final class AppModel {
     }
 
     @discardableResult
+    public func logBath(
+        occurredAt: Date,
+        usedShampoo: Bool,
+        usedSoap: Bool
+    ) -> Bool {
+        perform(onSuccess: handleSuccessfulEventLog) {
+            guard let currentChild, let currentMembership else { throw ChildProfileValidationError.insufficientPermissions }
+            guard let localUser else { throw ChildProfileValidationError.insufficientPermissions }
+            _ = try LogBathUseCase(
+                eventRepository: eventRepository,
+                hapticFeedbackProvider: hapticFeedbackProvider
+            )
+                .execute(.init(
+                    childID: currentChild.id,
+                    localUserID: localUser.id,
+                    occurredAt: occurredAt,
+                    usedShampoo: usedShampoo,
+                    usedSoap: usedSoap,
+                    membership: currentMembership
+                ))
+        }
+    }
+
+    @discardableResult
     public func logBottleFeed(
         amountMilliliters: Int,
         occurredAt: Date,
@@ -834,6 +858,31 @@ public final class AppModel {
                     side: side,
                     leftDurationSeconds: leftDurationSeconds,
                     rightDurationSeconds: rightDurationSeconds,
+                    membership: currentMembership
+                ))
+        }
+    }
+
+    @discardableResult
+    public func updateBath(
+        id: UUID,
+        occurredAt: Date,
+        usedShampoo: Bool,
+        usedSoap: Bool
+    ) -> Bool {
+        perform {
+            guard let currentMembership else { throw ChildProfileValidationError.insufficientPermissions }
+            guard let localUser else { throw ChildProfileValidationError.insufficientPermissions }
+            try UpdateBathUseCase(
+                eventRepository: eventRepository,
+                hapticFeedbackProvider: hapticFeedbackProvider
+            )
+                .execute(.init(
+                    eventID: id,
+                    localUserID: localUser.id,
+                    occurredAt: occurredAt,
+                    usedShampoo: usedShampoo,
+                    usedSoap: usedSoap,
                     membership: currentMembership
                 ))
         }
@@ -1211,6 +1260,7 @@ public final class AppModel {
             let status = CloudKitStatusViewState(summary: syncEngine.statusSummary)
             let pendingCounts = (try? syncEngine.loadPendingChangeCounts()) ?? [:]
             let builtPendingChanges: [PendingChangeSummaryItem] = [
+                (.bathEvent,        "drop.fill",                   "Baths"),
                 (.breastFeedEvent, "figure.seated.side.air.upper", "Breast feeds"),
                 (.bottleFeedEvent, "waterbottle.fill",             "Bottle feeds"),
                 (.sleepEvent,      "moon.zzz.fill",                "Sleep sessions"),
@@ -1500,6 +1550,8 @@ public final class AppModel {
             return "Sleep"
         case .nappy:
             return "Nappy"
+        case .bath:
+            return "Bath"
         case .bottleFeed:
             return "Bottle"
         case .breastFeed:
@@ -1511,6 +1563,7 @@ public final class AppModel {
         switch columnKind {
         case .sleep: return .sleep
         case .nappy: return .nappy
+        case .bath: return .bath
         case .bottleFeed: return .bottleFeed
         case .breastFeed: return .breastFeed
         }
@@ -1518,6 +1571,8 @@ public final class AppModel {
 
     private func timelineTimeText(for event: BabyEvent) -> String {
         switch event {
+        case let .bath(bath):
+            return shortTimeText(for: bath.metadata.occurredAt)
         case let .breastFeed(feed):
             return "\(shortTimeText(for: feed.startedAt))-\(shortTimeText(for: feed.endedAt))"
         case let .bottleFeed(feed):
@@ -1551,6 +1606,12 @@ public final class AppModel {
             return (
                 title: timelineNappyTypeText(for: nappy.type),
                 detailText: "",
+                timeText: ""
+            )
+        case let .bath(bath):
+            return (
+                title: "Bath",
+                detailText: BabyEventPresentation.detailText(for: .bath(bath)) ?? "",
                 timeText: ""
             )
         case let .bottleFeed(feed):
@@ -1593,6 +1654,12 @@ public final class AppModel {
 
     private func eventActionPayload(for event: BabyEvent) -> EventActionPayload {
         switch event {
+        case let .bath(bath):
+            return .editBath(
+                occurredAt: bath.metadata.occurredAt,
+                usedShampoo: bath.usedShampoo,
+                usedSoap: bath.usedSoap
+            )
         case let .breastFeed(feed):
             let durationMinutes = max(1, Int(feed.endedAt.timeIntervalSince(feed.startedAt) / 60))
             return .editBreastFeed(

--- a/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/BabyEventPresentation.swift
+++ b/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/BabyEventPresentation.swift
@@ -8,6 +8,8 @@ public enum BabyEventPresentation {
 
     static func title(for kind: BabyEventKind) -> String {
         switch kind {
+        case .bath:
+            "Bath"
         case .breastFeed:
             "Breast Feed"
         case .bottleFeed:
@@ -24,6 +26,8 @@ public enum BabyEventPresentation {
         preferredFeedVolumeUnit: FeedVolumeUnit = .milliliters
     ) -> String? {
         switch event {
+        case let .bath(event):
+            bathDetailText(for: event)
         case let .breastFeed(feed):
             breastFeedDetailText(for: feed)
         case let .bottleFeed(feed):
@@ -50,6 +54,8 @@ public enum BabyEventPresentation {
 
     public static func systemImage(for kind: BabyEventKind) -> String {
         switch kind {
+        case .bath:
+            "drop.fill"
         case .breastFeed:
             "figure.seated.side.air.upper"
         case .bottleFeed:
@@ -59,6 +65,22 @@ public enum BabyEventPresentation {
         case .nappy:
             "checklist.checked"
         }
+    }
+
+    private static func bathDetailText(
+        for event: BathEvent
+    ) -> String {
+        var parts: [String] = []
+
+        if event.usedShampoo {
+            parts.append("Shampoo")
+        }
+
+        if event.usedSoap {
+            parts.append("Soap")
+        }
+
+        return parts.isEmpty ? "Bath only" : parts.joined(separator: " • ")
     }
 
     private static func breastFeedDetailText(

--- a/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/EventActionPayload.swift
+++ b/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/EventActionPayload.swift
@@ -2,6 +2,11 @@ import BabyTrackerDomain
 import Foundation
 
 public enum EventActionPayload: Equatable, Sendable {
+    case editBath(
+        occurredAt: Date,
+        usedShampoo: Bool,
+        usedSoap: Bool
+    )
     case editBreastFeed(
         durationMinutes: Int,
         endTime: Date,

--- a/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/EventCardViewState.swift
+++ b/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/EventCardViewState.swift
@@ -31,6 +31,23 @@ public struct EventCardViewState: Equatable, Identifiable, Sendable {
         timestampText: String? = nil
     ) {
         switch event {
+        case let .bath(bath):
+            id = bath.id
+            kind = .bath
+            title = BabyEventPresentation.title(for: event)
+            detailText = BabyEventPresentation.detailText(
+                for: event,
+                preferredFeedVolumeUnit: preferredFeedVolumeUnit
+            ) ?? ""
+            self.timestampText = timestampText ?? bath.metadata.occurredAt.formatted(
+                date: .abbreviated,
+                time: .shortened
+            )
+            actionPayload = .editBath(
+                occurredAt: bath.metadata.occurredAt,
+                usedShampoo: bath.usedShampoo,
+                usedSoap: bath.usedSoap
+            )
         case let .breastFeed(feed):
             let durationMinutes = max(
                 1,

--- a/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/HelpFAQContent.swift
+++ b/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/HelpFAQContent.swift
@@ -23,7 +23,7 @@ public enum HelpFAQContent {
             ]
         ),
         HelpFAQSection(
-            title: "Feed, Sleep, and Nappy Trends",
+            title: "Feed, Sleep, Nappy, and Bath Trends",
             items: [
                 HelpFAQItem(
                     id: "feeds",
@@ -39,6 +39,11 @@ public enum HelpFAQContent {
                     id: "nappies",
                     title: "How are nappy trends grouped?",
                     answer: "Nappy trends are grouped by the type you log: wet, dirty, mixed, or dry. The Summary view is meant to help you review what was recorded, not to interpret whether a pattern is normal."
+                ),
+                HelpFAQItem(
+                    id: "baths",
+                    title: "What does the bath trend chart show?",
+                    answer: "Bath trends show how many bath events were logged in each grouped period. Shampoo and soap details stay attached to the event itself, while the trend chart focuses on the number of baths over time."
                 ),
             ]
         ),

--- a/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/RecentFeedEventViewState.swift
+++ b/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/RecentFeedEventViewState.swift
@@ -45,7 +45,7 @@ public struct RecentFeedEventViewState: Equatable, Identifiable, Sendable {
                 occurredAt: feed.metadata.occurredAt,
                 milkType: feed.milkType
             )
-        case .sleep, .nappy:
+        case .bath, .sleep, .nappy:
             return nil
         }
     }

--- a/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/SummaryMetricsCalculator.swift
+++ b/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/SummaryMetricsCalculator.swift
@@ -147,7 +147,7 @@ public enum SummaryMetricsCalculator {
             switch event {
             case .breastFeed, .bottleFeed:
                 event
-            case .sleep, .nappy:
+            case .bath, .sleep, .nappy:
                 nil
             }
         }
@@ -252,7 +252,7 @@ public enum SummaryMetricsCalculator {
             return max(1, Int(feed.endedAt.timeIntervalSince(feed.startedAt) / 60))
         case .bottleFeed:
             return nil
-        case .sleep, .nappy:
+        case .bath, .sleep, .nappy:
             return nil
         }
     }

--- a/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/SummaryScreenPreviewFactory.swift
+++ b/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/SummaryScreenPreviewFactory.swift
@@ -106,6 +106,20 @@ enum SummaryScreenPreviewFactory {
             ))
         }
 
+        let bathTimes: [(Int, Int, Bool, Bool)] = [
+            (16, 0, true, true),
+        ]
+        for (hour, minute, usedShampoo, usedSoap) in bathTimes {
+            let time = dateToday(hour: hour, minute: minute)
+            events.append(.bath(
+                BathEvent(
+                    metadata: EventMetadata(childID: childID, occurredAt: time, createdAt: time, createdBy: userID),
+                    usedShampoo: usedShampoo,
+                    usedSoap: usedSoap
+                )
+            ))
+        }
+
         // MARK: Historical events (past 7 days) for average line
 
         for dayOffset in 1...7 {
@@ -152,6 +166,17 @@ enum SummaryScreenPreviewFactory {
                         metadata: EventMetadata(childID: childID, occurredAt: t, createdAt: t, createdBy: userID),
                         type: .wee,
                         peeVolume: .medium
+                    )
+                ))
+            }
+
+            if dayOffset.isMultiple(of: 2) {
+                let bathTime = dateOffset(days: neg, hour: 16)
+                events.append(.bath(
+                    BathEvent(
+                        metadata: EventMetadata(childID: childID, occurredAt: bathTime, createdAt: bathTime, createdBy: userID),
+                        usedShampoo: dayOffset.isMultiple(of: 4),
+                        usedSoap: true
                     )
                 ))
             }

--- a/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/TimelineDayGridItemViewState.swift
+++ b/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/TimelineDayGridItemViewState.swift
@@ -66,6 +66,8 @@ public struct TimelineDayGridItemViewState: Equatable, Identifiable, Sendable {
             .sleep
         case .nappy:
             .nappy
+        case .bath:
+            .bath
         case .bottleFeed:
             .bottleFeed
         case .breastFeed:

--- a/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/TodaySummaryCalculator.swift
+++ b/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/TodaySummaryCalculator.swift
@@ -64,7 +64,7 @@ public enum TodaySummaryCalculator {
         let allFeedEvents = todayEvents.filter {
             switch $0 {
             case .breastFeed, .bottleFeed: true
-            case .sleep, .nappy: false
+            case .bath, .sleep, .nappy: false
             }
         }
         let averageFeedInterval = averageFeedIntervalMinutes(for: allFeedEvents)

--- a/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/TrendsSummaryCalculator.swift
+++ b/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/TrendsSummaryCalculator.swift
@@ -88,15 +88,30 @@ public enum TrendsSummaryCalculator {
             )
         }
 
+        let dailyBath = dates.map { date -> DailyBathData in
+            let dayEvents = eventsByDay[date] ?? []
+            let baths = dayEvents.compactMap { event -> BathEvent? in
+                guard case let .bath(bath) = event else { return nil }
+                return bath
+            }
+            return DailyBathData(
+                date: date,
+                label: formatter(date),
+                count: baths.count
+            )
+        }
+
         return TrendsSummaryData(
             dailyBottle: dailyBottle,
             dailyBreastFeed: dailyBreastFeed,
             dailySleep: dailySleep,
             dailyNappy: dailyNappy,
+            dailyBath: dailyBath,
             avgDailyBottleMilliliters: average(of: dailyBottle.filter { $0.count > 0 }.map(\.totalMilliliters)),
             avgDailyBreastFeedSessions: average(of: dailyBreastFeed.filter { $0.sessionCount > 0 }.map(\.sessionCount)),
             avgDailySleepMinutes: average(of: dailySleep.filter { $0.totalMinutes > 0 }.map(\.totalMinutes)),
-            avgDailyNappies: average(of: dailyNappy.filter { $0.totalCount > 0 }.map(\.totalCount))
+            avgDailyNappies: average(of: dailyNappy.filter { $0.totalCount > 0 }.map(\.totalCount)),
+            avgDailyBaths: average(of: dailyBath.filter { $0.count > 0 }.map(\.count))
         )
     }
 

--- a/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/TrendsSummaryData.swift
+++ b/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/TrendsSummaryData.swift
@@ -81,33 +81,51 @@ public struct DailyNappyData: Equatable, Sendable {
     }
 }
 
+public struct DailyBathData: Equatable, Sendable {
+    public let date: Date
+    public let label: String
+    public let count: Int
+
+    public init(date: Date, label: String, count: Int) {
+        self.date = date
+        self.label = label
+        self.count = count
+    }
+}
+
 public struct TrendsSummaryData: Equatable, Sendable {
     public let dailyBottle: [DailyBottleData]
     public let dailyBreastFeed: [DailyBreastFeedData]
     public let dailySleep: [DailySleepData]
     public let dailyNappy: [DailyNappyData]
+    public let dailyBath: [DailyBathData]
     public let avgDailyBottleMilliliters: Int?
     public let avgDailyBreastFeedSessions: Int?
     public let avgDailySleepMinutes: Int?
     public let avgDailyNappies: Int?
+    public let avgDailyBaths: Int?
 
     public init(
         dailyBottle: [DailyBottleData],
         dailyBreastFeed: [DailyBreastFeedData],
         dailySleep: [DailySleepData],
         dailyNappy: [DailyNappyData],
+        dailyBath: [DailyBathData],
         avgDailyBottleMilliliters: Int?,
         avgDailyBreastFeedSessions: Int?,
         avgDailySleepMinutes: Int?,
-        avgDailyNappies: Int?
+        avgDailyNappies: Int?,
+        avgDailyBaths: Int?
     ) {
         self.dailyBottle = dailyBottle
         self.dailyBreastFeed = dailyBreastFeed
         self.dailySleep = dailySleep
         self.dailyNappy = dailyNappy
+        self.dailyBath = dailyBath
         self.avgDailyBottleMilliliters = avgDailyBottleMilliliters
         self.avgDailyBreastFeedSessions = avgDailyBreastFeedSessions
         self.avgDailySleepMinutes = avgDailySleepMinutes
         self.avgDailyNappies = avgDailyNappies
+        self.avgDailyBaths = avgDailyBaths
     }
 }

--- a/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/ViewModels/HomeViewModel.swift
+++ b/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/ViewModels/HomeViewModel.swift
@@ -76,6 +76,10 @@ public final class HomeViewModel {
             let occurredAt: Date
 
             switch event {
+            case let .bath(bath):
+                id = bath.id
+                kind = .bath
+                occurredAt = bath.metadata.occurredAt
             case let .breastFeed(feed):
                 id = feed.id
                 kind = .breastFeed

--- a/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/BabyEventStyle.swift
+++ b/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/BabyEventStyle.swift
@@ -49,6 +49,17 @@ public enum BabyEventStyle {
 
     private static func palette(for kind: BabyEventKind) -> EventPalette {
         switch kind {
+        case .bath:
+            EventPalette(
+                accent: adaptiveColor(light: rgb(0.09, 0.63, 0.67), dark: rgb(0.45, 0.89, 0.91)),
+                badgeFill: adaptiveColor(light: rgba(0.09, 0.63, 0.67, 0.14), dark: rgba(0.09, 0.63, 0.67, 0.28)),
+                cardFill: adaptiveColor(light: rgb(0.91, 0.98, 0.98), dark: rgb(0.07, 0.24, 0.25)),
+                cardForeground: adaptiveColor(light: rgb(0.03, 0.34, 0.36), dark: rgb(0.93, 0.99, 0.99)),
+                cardSecondaryForeground: adaptiveColor(light: rgb(0.12, 0.45, 0.47), dark: rgb(0.77, 0.93, 0.94)),
+                prominentFill: adaptiveColor(light: rgb(0.04, 0.50, 0.53), dark: rgb(0.08, 0.43, 0.45)),
+                prominentForeground: adaptiveColor(light: rgb(1.00, 1.00, 1.00), dark: rgb(0.94, 0.99, 1.00)),
+                prominentBorder: adaptiveColor(light: rgba(0.09, 0.63, 0.67, 0.82), dark: rgba(0.45, 0.89, 0.91, 0.72))
+            )
         case .breastFeed:
             EventPalette(
                 accent: adaptiveColor(light: rgb(0.84, 0.29, 0.42), dark: rgb(1.00, 0.61, 0.72)),

--- a/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/BathEditorSheetView.swift
+++ b/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/BathEditorSheetView.swift
@@ -1,0 +1,154 @@
+import BabyTrackerDomain
+import SwiftUI
+
+public struct BathEditorSheetView: View {
+    private static let eventColor = BabyEventStyle.accentColor(for: .bath)
+
+    let navigationTitle: String
+    let primaryActionTitle: String
+    let childName: String
+    let saveAction: (_ occurredAt: Date, _ usedShampoo: Bool, _ usedSoap: Bool) -> Bool
+    let deleteAction: (() -> Void)?
+
+    @Environment(\.dismiss) private var dismiss
+    @State private var occurredAt: Date
+    @State private var usedShampoo: Bool
+    @State private var usedSoap: Bool
+    @State private var showDeleteConfirmation = false
+    private let initialTimePreset: QuickTimeSelectorView.TimePreset
+
+    public init(
+        navigationTitle: String,
+        primaryActionTitle: String,
+        childName: String,
+        initialOccurredAt: Date,
+        initialUsedShampoo: Bool,
+        initialUsedSoap: Bool,
+        initialTimePreset: QuickTimeSelectorView.TimePreset = .now,
+        deleteAction: (() -> Void)? = nil,
+        saveAction: @escaping (_ occurredAt: Date, _ usedShampoo: Bool, _ usedSoap: Bool) -> Bool
+    ) {
+        self.navigationTitle = navigationTitle
+        self.primaryActionTitle = primaryActionTitle
+        self.childName = childName
+        self.deleteAction = deleteAction
+        self.saveAction = saveAction
+        _occurredAt = State(initialValue: initialOccurredAt)
+        _usedShampoo = State(initialValue: initialUsedShampoo)
+        _usedSoap = State(initialValue: initialUsedSoap)
+        self.initialTimePreset = initialTimePreset
+    }
+
+    public var body: some View {
+        NavigationStack {
+            Form {
+                LoggingSummaryView(sentence: summarySentence)
+
+                Section("When was the Bath?") {
+                    QuickTimeSelectorView(selection: $occurredAt, initialPreset: initialTimePreset, buttonColor: Self.eventColor)
+                        .accessibilityIdentifier("bath-time-selector")
+                }
+
+                Section("Used") {
+                    Toggle("Shampoo", isOn: $usedShampoo)
+                        .accessibilityIdentifier("bath-shampoo-toggle")
+                    Toggle("Soap", isOn: $usedSoap)
+                        .accessibilityIdentifier("bath-soap-toggle")
+                }
+
+                if deleteAction != nil {
+                    Section {
+                        Button("Delete Bath", role: .destructive) {
+                            showDeleteConfirmation = true
+                        }
+                        .accessibilityIdentifier("delete-bath-button")
+                    }
+                }
+            }
+            .alert("Delete Bath?", isPresented: $showDeleteConfirmation) {
+                Button("Delete", role: .destructive) {
+                    deleteAction?()
+                    dismiss()
+                }
+                Button("Cancel", role: .cancel) {}
+            } message: {
+                Text("This event will be permanently removed.")
+            }
+            .scrollContentBackground(.hidden)
+            .background(Self.eventColor.opacity(0.08))
+            .navigationTitle(navigationTitle)
+            .navigationBarTitleDisplayMode(.inline)
+            .presentationDetents([.large])
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button("Cancel") {
+                        dismiss()
+                    }
+                }
+
+                ToolbarItem(placement: .confirmationAction) {
+                    Button(primaryActionTitle) {
+                        let didSave = saveAction(occurredAt, usedShampoo, usedSoap)
+                        if didSave {
+                            dismiss()
+                        }
+                    }
+                    .accessibilityIdentifier("save-bath-button")
+                }
+            }
+        }
+        .tint(Self.eventColor)
+    }
+
+    private var summarySentence: AttributedString {
+        let timeText = occurredAt.formatted(date: .omitted, time: .shortened)
+        var sentence = summaryVariable(childName, color: Self.eventColor)
+        sentence += AttributedString(" had a bath at ")
+        sentence += summaryVariable(timeText, color: Self.eventColor)
+
+        let bathDetails = selectedDetailTitles
+        if !bathDetails.isEmpty {
+            sentence += AttributedString(" using ")
+            sentence += summaryVariable(bathDetails.joined(separator: " and ").lowercased(), color: Self.eventColor)
+        }
+
+        return sentence
+    }
+
+    private var selectedDetailTitles: [String] {
+        var details: [String] = []
+        if usedShampoo {
+            details.append("Shampoo")
+        }
+        if usedSoap {
+            details.append("Soap")
+        }
+        return details
+    }
+}
+
+#Preview("Quick Log Bath") {
+    BathEditorSheetView(
+        navigationTitle: "Bath",
+        primaryActionTitle: "Save",
+        childName: "Poppy",
+        initialOccurredAt: .now,
+        initialUsedShampoo: true,
+        initialUsedSoap: false,
+        saveAction: { _, _, _ in true }
+    )
+}
+
+#Preview("Edit Bath") {
+    BathEditorSheetView(
+        navigationTitle: "Edit Bath",
+        primaryActionTitle: "Update",
+        childName: "Poppy",
+        initialOccurredAt: .now.addingTimeInterval(-3_600),
+        initialUsedShampoo: true,
+        initialUsedSoap: true,
+        initialTimePreset: .custom,
+        deleteAction: {},
+        saveAction: { _, _, _ in true }
+    )
+}

--- a/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/ChildEventSheet.swift
+++ b/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/ChildEventSheet.swift
@@ -2,6 +2,7 @@ import BabyTrackerDomain
 import Foundation
 
 public enum ChildEventSheet: Identifiable {
+    case quickLogBath
     case quickLogBreastFeed
     case quickLogBottleFeed(smartSuggestions: [Int])
     case startSleep(suggestions: [(label: String, date: Date)])
@@ -35,9 +36,22 @@ public enum ChildEventSheet: Identifiable {
         pooVolume: NappyVolume?,
         pooColor: PooColor?
     )
+    case editBath(
+        id: UUID,
+        occurredAt: Date,
+        usedShampoo: Bool,
+        usedSoap: Bool
+    )
 
     public init(id: UUID, actionPayload: EventActionPayload) {
         switch actionPayload {
+        case let .editBath(occurredAt, usedShampoo, usedSoap):
+            self = .editBath(
+                id: id,
+                occurredAt: occurredAt,
+                usedShampoo: usedShampoo,
+                usedSoap: usedSoap
+            )
         case let .editBreastFeed(durationMinutes, endTime, side, leftDurationSeconds, rightDurationSeconds):
             self = .editBreastFeed(
                 id: id,
@@ -76,6 +90,8 @@ public enum ChildEventSheet: Identifiable {
 
     public var id: String {
         switch self {
+        case .quickLogBath:
+            "quick-log-bath"
         case .quickLogBreastFeed:
             "quick-log-breast-feed"
         case .quickLogBottleFeed:
@@ -96,6 +112,8 @@ public enum ChildEventSheet: Identifiable {
             "edit-sleep-\(id.uuidString)"
         case let .editNappy(id, _, _, _, _, _):
             "edit-nappy-\(id.uuidString)"
+        case let .editBath(id, _, _, _):
+            "edit-bath-\(id.uuidString)"
         }
     }
 }

--- a/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/ChildHomeView.swift
+++ b/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/ChildHomeView.swift
@@ -11,6 +11,7 @@ public struct ChildHomeView: View {
     let quickLogBottleFeed: () -> Void
     let quickLogSleep: () -> Void
     let quickLogNappy: () -> Void
+    let quickLogBath: () -> Void
     let openProfile: () -> Void
 
     @State private var statusSectionExpanded: Bool
@@ -28,6 +29,7 @@ public struct ChildHomeView: View {
         quickLogBottleFeed: @escaping () -> Void,
         quickLogSleep: @escaping () -> Void,
         quickLogNappy: @escaping () -> Void,
+        quickLogBath: @escaping () -> Void,
         openProfile: @escaping () -> Void
     ) {
         self.model = model
@@ -39,6 +41,7 @@ public struct ChildHomeView: View {
         self.quickLogBottleFeed = quickLogBottleFeed
         self.quickLogSleep = quickLogSleep
         self.quickLogNappy = quickLogNappy
+        self.quickLogBath = quickLogBath
         self.openProfile = openProfile
 
         let defaults = UserDefaults.standard
@@ -361,6 +364,14 @@ public struct ChildHomeView: View {
                 accessibilityIdentifier: "quick-log-nappy-button",
                 action: quickLogNappy
             )
+        case .bath:
+            quickLogButton(
+                title: "Bath",
+                systemImage: BabyEventStyle.systemImage(for: .bath),
+                kind: .bath,
+                accessibilityIdentifier: "quick-log-bath-button",
+                action: quickLogBath
+            )
         }
     }
 
@@ -451,6 +462,7 @@ private func makeHomeView(from model: AppModel) -> some View {
             quickLogBottleFeed: {},
             quickLogSleep: {},
             quickLogNappy: {},
+            quickLogBath: {},
             openProfile: {}
         )
     }

--- a/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/ChildProfileExportView.swift
+++ b/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/ChildProfileExportView.swift
@@ -44,6 +44,7 @@ public struct ChildProfileExportView: View {
 
             Section("What gets exported") {
                 exportableRow(icon: "person.crop.circle", title: "Child name & birth date", color: .purple)
+                exportableRow(icon: "drop.fill", title: "Baths (shampoo & soap details)", color: .teal)
                 exportableRow(icon: "moon.zzz.fill", title: "Sleep sessions", color: .indigo)
                 exportableRow(icon: "waterbottle.fill", title: "Bottle feeds (amount & milk type)", color: .blue)
                 exportableRow(icon: "figure.seated.side.air.upper", title: "Breast feeds (side & duration)", color: .pink)

--- a/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/ChildProfileImportView.swift
+++ b/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/ChildProfileImportView.swift
@@ -408,6 +408,7 @@ private struct ImportEventRow: View {
 
     private var iconName: String {
         switch tagged.event {
+        case .bath: return "drop.fill"
         case .sleep: return "moon.zzz.fill"
         case .bottleFeed: return "waterbottle.fill"
         case .breastFeed: return "figure.seated.side.air.upper"
@@ -417,6 +418,7 @@ private struct ImportEventRow: View {
 
     private var iconColor: Color {
         switch tagged.event {
+        case .bath: return .teal
         case .sleep: return .indigo
         case .bottleFeed: return .blue
         case .breastFeed: return .pink
@@ -430,4 +432,3 @@ private struct ImportEventRow: View {
         ChildProfileImportView(appModel: ChildProfilePreviewFactory.makeModel())
     }
 }
-

--- a/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/ChildProfileNestImportView.swift
+++ b/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/ChildProfileNestImportView.swift
@@ -55,6 +55,7 @@ public struct ChildProfileNestImportView: View {
             }
 
             Section("What gets imported") {
+                importableRow(icon: "drop.fill", title: "Baths (shampoo & soap details)", color: .teal)
                 importableRow(icon: "moon.zzz.fill", title: "Sleep sessions", color: .indigo)
                 importableRow(icon: "waterbottle.fill", title: "Bottle feeds (amount & milk type)", color: .blue)
                 importableRow(icon: "figure.seated.side.air.upper", title: "Breast feeds (side & duration)", color: .pink)
@@ -126,11 +127,15 @@ public struct ChildProfileNestImportView: View {
             }
 
             Section("Summary") {
+                let bathCount = state.taggedEvents.filter { if case .bath = $0.event { true } else { false } }.count
                 let sleepCount = state.taggedEvents.filter { if case .sleep = $0.event { true } else { false } }.count
                 let bottleCount = state.taggedEvents.filter { if case .bottleFeed = $0.event { true } else { false } }.count
                 let breastCount = state.taggedEvents.filter { if case .breastFeed = $0.event { true } else { false } }.count
                 let nappyCount = state.taggedEvents.filter { if case .nappy = $0.event { true } else { false } }.count
 
+                if bathCount > 0 {
+                    eventCountRow(icon: "drop.fill", label: "Baths", count: bathCount, color: .teal)
+                }
                 if sleepCount > 0 {
                     eventCountRow(icon: "moon.zzz.fill", label: "Sleep sessions", count: sleepCount, color: .indigo)
                 }
@@ -409,6 +414,7 @@ private struct NestImportEventRow: View {
 
     private var iconName: String {
         switch tagged.event {
+        case .bath: return "drop.fill"
         case .sleep: return "moon.zzz.fill"
         case .bottleFeed: return "waterbottle.fill"
         case .breastFeed: return "figure.seated.side.air.upper"
@@ -418,6 +424,7 @@ private struct NestImportEventRow: View {
 
     private var iconColor: Color {
         switch tagged.event {
+        case .bath: return .teal
         case .sleep: return .indigo
         case .bottleFeed: return .blue
         case .breastFeed: return .pink

--- a/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/ChildWorkspaceTabView.swift
+++ b/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/ChildWorkspaceTabView.swift
@@ -41,6 +41,7 @@ public struct ChildWorkspaceTabView: View {
                 quickLogNappy: {
                     activeEventSheet = .quickLogNappy(.mixed)
                 },
+                quickLogBath: { activeEventSheet = .quickLogBath },
                 openProfile: { showingEditChildSheet = true }
             )
             .tag(ChildWorkspaceTab.home)
@@ -265,6 +266,25 @@ public struct ChildWorkspaceTabView: View {
     @ViewBuilder
     private func eventSheet(for sheet: ChildEventSheet) -> some View {
         switch sheet {
+        case .quickLogBath:
+            BathEditorSheetView(
+                navigationTitle: "Bath",
+                primaryActionTitle: "Save",
+                childName: childProfileViewModel.childName,
+                initialOccurredAt: Date(),
+                initialUsedShampoo: false,
+                initialUsedSoap: false
+            ) { occurredAt, usedShampoo, usedSoap in
+                let didSave = model.logBath(
+                    occurredAt: occurredAt,
+                    usedShampoo: usedShampoo,
+                    usedSoap: usedSoap
+                )
+                if didSave {
+                    activeEventSheet = nil
+                }
+                return didSave
+            }
         case .quickLogBreastFeed:
             BreastFeedEditorSheetView(
                 navigationTitle: "Breast Feed",
@@ -511,6 +531,32 @@ public struct ChildWorkspaceTabView: View {
                     peeVolume: updatedPeeVolume,
                     pooVolume: updatedPooVolume,
                     pooColor: updatedPooColor
+                )
+                if didSave {
+                    activeEventSheet = nil
+                }
+                return didSave
+            }
+        case let .editBath(id, occurredAt, usedShampoo, usedSoap):
+            BathEditorSheetView(
+                navigationTitle: "Edit Bath",
+                primaryActionTitle: "Update",
+                childName: childProfileViewModel.childName,
+                initialOccurredAt: occurredAt,
+                initialUsedShampoo: usedShampoo,
+                initialUsedSoap: usedSoap,
+                initialTimePreset: .custom,
+                deleteAction: childProfileViewModel.canManageEvents ? {
+                    if model.deleteEvent(id: id) {
+                        activeEventSheet = nil
+                    }
+                } : nil
+            ) { updatedOccurredAt, updatedUsedShampoo, updatedUsedSoap in
+                let didSave = model.updateBath(
+                    id: id,
+                    occurredAt: updatedOccurredAt,
+                    usedShampoo: updatedUsedShampoo,
+                    usedSoap: updatedUsedSoap
                 )
                 if didSave {
                     activeEventSheet = nil

--- a/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/EventDeleteCandidate.swift
+++ b/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/EventDeleteCandidate.swift
@@ -23,6 +23,8 @@ public struct EventDeleteCandidate: Identifiable {
 
     public var dialogTitle: String {
         switch kind {
+        case .bath:
+            return "Delete Bath?"
         case .breastFeed, .bottleFeed:
             return "Delete Feed?"
         case .sleep:
@@ -34,6 +36,8 @@ public struct EventDeleteCandidate: Identifiable {
 
     public var confirmButtonTitle: String {
         switch kind {
+        case .bath:
+            return "Delete Bath"
         case .breastFeed, .bottleFeed:
             return "Delete Feed"
         case .sleep:

--- a/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/EventHistoryView.swift
+++ b/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/EventHistoryView.swift
@@ -175,7 +175,7 @@ public struct EventHistoryView: View {
         switch event.actionPayload {
         case .endSleep:
             "End"
-        case .editBreastFeed, .editBottleFeed, .editNappy, .editSleep:
+        case .editBath, .editBreastFeed, .editBottleFeed, .editNappy, .editSleep:
             "Edit"
         }
     }
@@ -265,7 +265,7 @@ struct ActiveFilterPill: Identifiable {
     static func pills(for filter: EventFilter) -> [ActiveFilterPill] {
         var pills: [ActiveFilterPill] = []
 
-        for kind in [BabyEventKind.breastFeed, .bottleFeed, .sleep, .nappy]
+        for kind in [BabyEventKind.bath, .breastFeed, .bottleFeed, .sleep, .nappy]
             where filter.eventTypes.contains(kind) {
             pills.append(ActiveFilterPill(
                 id: "eventType_\(kind.rawValue)",

--- a/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/HomeTodayTimelineView.swift
+++ b/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/HomeTodayTimelineView.swift
@@ -154,6 +154,11 @@ private let previewEventsFull: [HomeTimelineEventViewState] = [
         timeText: "5:34 PM", isOngoing: false
     ),
     HomeTimelineEventViewState(
+        id: UUID(), kind: .bath,
+        title: "Bath", detailText: "Shampoo • Soap",
+        timeText: "4:55 PM", isOngoing: false
+    ),
+    HomeTimelineEventViewState(
         id: UUID(), kind: .nappy,
         title: "Nappy", detailText: "Poo · medium · yellow",
         timeText: "4:15 PM", isOngoing: false
@@ -185,6 +190,11 @@ private let previewEventsAwake: [HomeTimelineEventViewState] = [
         id: UUID(), kind: .sleep,
         title: "Nap ended", detailText: "1h 30m",
         timeText: "1:40 PM", isOngoing: false
+    ),
+    HomeTimelineEventViewState(
+        id: UUID(), kind: .bath,
+        title: "Bath", detailText: "Soap",
+        timeText: "12:20 PM", isOngoing: false
     ),
     HomeTimelineEventViewState(
         id: UUID(), kind: .nappy,

--- a/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/OnboardingAppPreviewStepView.swift
+++ b/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/OnboardingAppPreviewStepView.swift
@@ -103,6 +103,8 @@ struct OnboardingAppPreviewStepView: View {
     @ViewBuilder
     private func eventDetailView(for event: BabyEvent) -> some View {
         switch event {
+        case let .bath(e):
+            Text(bathDetail(e))
         case let .breastFeed(e):
             Text(breastFeedDetail(e))
 
@@ -249,6 +251,19 @@ struct OnboardingAppPreviewStepView: View {
         return ["\(e.amountMilliliters) mL", milkLabel].filter { !$0.isEmpty }.joined(separator: " · ")
     }
 
+    private func bathDetail(_ e: BathEvent) -> String {
+        if e.usedShampoo && e.usedSoap {
+            return "Shampoo · Soap"
+        }
+        if e.usedShampoo {
+            return "Shampoo"
+        }
+        if e.usedSoap {
+            return "Soap"
+        }
+        return "Bath only"
+    }
+
     private func completedSleepDetail(_ e: SleepEvent) -> String {
         guard let endedAt = e.endedAt else { return "" }
         let duration = Int(endedAt.timeIntervalSince(e.startedAt) / 60)
@@ -266,6 +281,7 @@ struct OnboardingAppPreviewStepView: View {
 
     private func eventTypeName(for event: BabyEvent) -> String {
         switch event.kind {
+        case .bath: return "Bath"
         case .breastFeed: return "Breast feed"
         case .bottleFeed: return "Bottle feed"
         case .sleep:      return "Sleep"

--- a/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/OnboardingCustomizeEventsStepView.swift
+++ b/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/OnboardingCustomizeEventsStepView.swift
@@ -140,6 +140,7 @@ struct OnboardingCustomizeEventsStepView: View {
 
     private func kindTitle(_ kind: BabyEventKind) -> String {
         switch kind {
+        case .bath: "Bath"
         case .breastFeed: "Breast feed"
         case .bottleFeed: "Bottle feed"
         case .sleep: "Sleep"
@@ -149,6 +150,7 @@ struct OnboardingCustomizeEventsStepView: View {
 
     private func kindDescription(_ kind: BabyEventKind) -> String {
         switch kind {
+        case .bath: "Baths with shampoo and soap details"
         case .breastFeed: "Nursing sessions and duration"
         case .bottleFeed: "Formula and expressed milk"
         case .sleep: "Naps and overnight sleeps"

--- a/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/OnboardingFirstEventStepView.swift
+++ b/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/OnboardingFirstEventStepView.swift
@@ -15,10 +15,10 @@ struct OnboardingFirstEventStepView: View {
 
     @State private var activeEventSheet: ChildEventSheet?
     @State private var firstEventSaved = false
-    @State private var appearedMask: [Bool] = Array(repeating: false, count: 6)
+    @State private var appearedMask: [Bool] = Array(repeating: false, count: 2 + BabyEventKind.allCases.count)
     @State private var highlightedIndex = 0
-    @State private var wiggleScales: [Double] = Array(repeating: 1.0, count: 4)
-    @State private var rotations: [Double] = Array(repeating: 0, count: 4)
+    @State private var wiggleScales: [Double] = Array(repeating: 1.0, count: BabyEventKind.allCases.count)
+    @State private var rotations: [Double] = Array(repeating: 0, count: BabyEventKind.allCases.count)
 
     private var visibleKinds: [BabyEventKind] {
         BabyEventKind.allCases.filter { model.isEventKindEnabled($0) }
@@ -100,6 +100,7 @@ struct OnboardingFirstEventStepView: View {
 
     private func buttonTitle(for kind: BabyEventKind) -> String {
         switch kind {
+        case .bath: "Bath"
         case .breastFeed: "Breast Feed"
         case .bottleFeed: "Bottle Feed"
         case .sleep: "Start Sleep"
@@ -109,6 +110,7 @@ struct OnboardingFirstEventStepView: View {
 
     private func eventSheet(for kind: BabyEventKind) -> ChildEventSheet {
         switch kind {
+        case .bath: .quickLogBath
         case .breastFeed: .quickLogBreastFeed
         case .bottleFeed: .quickLogBottleFeed(smartSuggestions: [])
         case .sleep: .startSleep(suggestions: [])
@@ -216,6 +218,27 @@ struct OnboardingFirstEventStepView: View {
                     side: side,
                     leftDurationSeconds: leftDurationSeconds,
                     rightDurationSeconds: rightDurationSeconds
+                )
+                if didSave {
+                    activeEventSheet = nil
+                    firstEventSaved = true
+                }
+                return didSave
+            }
+
+        case .quickLogBath:
+            BathEditorSheetView(
+                navigationTitle: "Bath",
+                primaryActionTitle: "Save",
+                childName: childName,
+                initialOccurredAt: Date(),
+                initialUsedShampoo: false,
+                initialUsedSoap: false
+            ) { occurredAt, usedShampoo, usedSoap in
+                let didSave = model.logBath(
+                    occurredAt: occurredAt,
+                    usedShampoo: usedShampoo,
+                    usedSoap: usedSoap
                 )
                 if didSave {
                     activeEventSheet = nil

--- a/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/OnboardingLiveActivityDemoView.swift
+++ b/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/OnboardingLiveActivityDemoView.swift
@@ -307,6 +307,8 @@ struct OnboardingLiveActivityDemoView: View {
 
     private func symbolName(for kind: BabyEventKind) -> String {
         switch kind {
+        case .bath:
+            "drop.fill"
         case .breastFeed:
             "heart.text.square"
         case .bottleFeed:
@@ -320,6 +322,8 @@ struct OnboardingLiveActivityDemoView: View {
 
     private func accentColor(for kind: BabyEventKind) -> Color {
         switch kind {
+        case .bath:
+            Color(red: 0.08, green: 0.68, blue: 0.72)
         case .breastFeed:
             Color(red: 0.84, green: 0.29, blue: 0.42)
         case .bottleFeed:

--- a/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/OnboardingQuickLogDemoView.swift
+++ b/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/OnboardingQuickLogDemoView.swift
@@ -8,9 +8,10 @@ struct OnboardingQuickLogDemoView: View {
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
 
     @State private var cardVisible = false
-    @State private var appearedMask: [Bool] = [false, false, false, false]
+    @State private var appearedMask: [Bool] = [false, false, false, false, false]
 
     private let buttons: [(title: String, kind: BabyEventKind)] = [
+        ("Bath", .bath),
         ("Breast Feed", .breastFeed),
         ("Bottle Feed", .bottleFeed),
         ("Start Sleep", .sleep),
@@ -33,6 +34,12 @@ struct OnboardingQuickLogDemoView: View {
                     demoButton(index: 2)
                     demoButton(index: 3)
                 }
+
+                HStack(spacing: 12) {
+                    demoButton(index: 4)
+                    Color.clear
+                        .frame(maxWidth: .infinity, minHeight: 56)
+                }
             }
             .padding(.horizontal, 16)
         }
@@ -47,7 +54,7 @@ struct OnboardingQuickLogDemoView: View {
         .onAppear {
             if reduceMotion {
                 cardVisible = true
-                appearedMask = [true, true, true, true]
+                appearedMask = [true, true, true, true, true]
                 return
             }
             Task { @MainActor in

--- a/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/OnboardingTimelineDemoView.swift
+++ b/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/OnboardingTimelineDemoView.swift
@@ -12,12 +12,13 @@ struct OnboardingTimelineDemoView: View {
     @State private var columnsVisible = false
     @State private var visibleBlockIDs: Set<Int> = []
     @State private var blockOffsets: [Int: CGFloat] = [:]
-    @State private var legendMask: [Bool] = [false, false, false, false]
+    @State private var legendMask: [Bool] = [false, false, false, false, false]
 
     private let columnHeight: CGFloat = 200
 
     private let legendItems: [(kind: BabyEventKind, label: String)] = [
         (.sleep, "Sleep"),
+        (.bath, "Bath"),
         (.breastFeed, "Breast Feed"),
         (.bottleFeed, "Bottle Feed"),
         (.nappy, "Nappy"),
@@ -119,7 +120,7 @@ struct OnboardingTimelineDemoView: View {
             columnsVisible = true
             visibleBlockIDs = Set(Self.sampleData.indices)
             blockOffsets = Dictionary(uniqueKeysWithValues: Self.sampleData.indices.map { ($0, 0) })
-            legendMask = [true, true, true, true]
+            legendMask = [true, true, true, true, true]
             return
         }
         Task { @MainActor in
@@ -205,6 +206,8 @@ struct OnboardingTimelineDemoView: View {
         switch entry.kind {
         case .sleep:
             baseDelay = 0
+        case .bath:
+            baseDelay = 210
         case .breastFeed, .bottleFeed:
             baseDelay = 130
         case .nappy:
@@ -254,6 +257,9 @@ struct OnboardingTimelineDemoView: View {
             s(0, 0.62, 0.66, .bottleFeed),  s(1, 0.63, 0.67, .breastFeed),
             s(2, 0.61, 0.65, .bottleFeed),  s(3, 0.62, 0.66, .breastFeed),
             s(4, 0.64, 0.68, .bottleFeed),
+
+            // ── Baths (~4pm) ───────────────────────────────────────────
+            s(0, 0.67, 0.71, .bath), s(2, 0.68, 0.72, .bath), s(4, 0.69, 0.73, .bath),
 
             // ── Evening feeds (~5:30pm) ───────────────────────────────
             s(0, 0.72, 0.76, .breastFeed),  s(1, 0.71, 0.75, .bottleFeed),

--- a/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/SummaryScreenView.swift
+++ b/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/SummaryScreenView.swift
@@ -689,6 +689,7 @@ public struct SummaryScreenView: View {
             || data.dailyBreastFeed.contains { $0.sessionCount > 0 }
             || data.dailySleep.contains { $0.totalMinutes > 0 }
             || data.dailyNappy.contains { $0.totalCount > 0 }
+            || data.dailyBath.contains { $0.count > 0 }
 
         let enabled = viewModel.enabledEventKinds
         return VStack(alignment: .leading, spacing: 12) {
@@ -701,6 +702,7 @@ public struct SummaryScreenView: View {
                 )
             } else {
                 if enabled.contains(.sleep) { sleepChartCard(data: data) }
+                if enabled.contains(.bath) { bathChartCard(data: data) }
                 if enabled.contains(.bottleFeed) { bottleChartCard(data: data) }
                 if enabled.contains(.breastFeed) { breastChartCard(data: data) }
                 if enabled.contains(.nappy) { nappyChartCard(data: data) }
@@ -779,6 +781,24 @@ public struct SummaryScreenView: View {
                 tint: .indigo,
                 valueFormatter: { DurationText.short(minutes: $0) },
                 averageValue: data.avgDailySleepMinutes
+            )
+        }
+    }
+
+    private func bathChartCard(data: TrendsSummaryData) -> some View {
+        let points = data.dailyBath.map { ($0.label, $0.count) }
+        let avgText = data.avgDailyBaths.map { "Avg \($0) bath\($0 == 1 ? "" : "s")/day" }
+
+        return chartCard(
+            title: "Baths",
+            symbol: BabyEventStyle.systemImage(for: .bath),
+            tint: BabyEventStyle.accentColor(for: .bath),
+            subtitle: avgText ?? "No baths in this period"
+        ) {
+            TrendsBarChartView(
+                points: points,
+                tint: BabyEventStyle.accentColor(for: .bath),
+                averageValue: data.avgDailyBaths
             )
         }
     }

--- a/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/TimelineDayGridItemView.swift
+++ b/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/TimelineDayGridItemView.swift
@@ -230,4 +230,23 @@ private enum TimelineDayGridItemPreviewFactory {
             milkType: .formula
         )
     )
+
+    static let bathItem = TimelineDayGridItemViewState(
+        id: "bath-preview",
+        columnKind: .bath,
+        startSlotIndex: 32,
+        endSlotIndex: 33,
+        eventIDs: [UUID()],
+        count: 1,
+        title: "Bath",
+        detailText: "Shampoo",
+        timeText: "",
+        actionPayloads: [
+            EventActionPayload.editBath(
+                occurredAt: .now,
+                usedShampoo: true,
+                usedSoap: false
+            )
+        ]
+    )
 }

--- a/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/TimelineDayGridView.swift
+++ b/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/TimelineDayGridView.swift
@@ -223,6 +223,8 @@ public struct TimelineDayGridView: View {
             .sleep
         case .nappy:
             .nappy
+        case .bath:
+            .bath
         case .bottleFeed:
             .bottleFeed
         case .breastFeed:
@@ -296,6 +298,7 @@ private enum TimelineDayGridPreviewFactory {
         columns: [
             TimelineDayGridColumnViewState(kind: .sleep, title: "Sleep", items: []),
             TimelineDayGridColumnViewState(kind: .nappy, title: "Nappy", items: []),
+            TimelineDayGridColumnViewState(kind: .bath, title: "Bath", items: []),
             TimelineDayGridColumnViewState(kind: .bottleFeed, title: "Bottle", items: []),
             TimelineDayGridColumnViewState(kind: .breastFeed, title: "Breast", items: [])
         ]
@@ -339,6 +342,28 @@ private enum TimelineDayGridPreviewFactory {
                                 peeVolume: nil,
                                 pooVolume: nil,
                                 pooColor: nil
+                            )
+                        ]
+                    )
+                ]
+            ),
+            TimelineDayGridColumnViewState(
+                kind: .bath,
+                title: "Bath",
+                items: [
+                    item(
+                        id: "bath-1",
+                        kind: TimelineDayGridColumnKind.bath,
+                        startSlotIndex: 32,
+                        endSlotIndex: 33,
+                        title: "Bath",
+                        detailText: "Shampoo",
+                        timeText: "",
+                        payloads: [
+                            EventActionPayload.editBath(
+                                occurredAt: day,
+                                usedShampoo: true,
+                                usedSoap: false
                             )
                         ]
                     )
@@ -418,6 +443,7 @@ private enum TimelineDayGridPreviewFactory {
                 ]
             ),
             TimelineDayGridColumnViewState(kind: .nappy, title: "Nappy", items: []),
+            TimelineDayGridColumnViewState(kind: .bath, title: "Bath", items: []),
             TimelineDayGridColumnViewState(kind: .bottleFeed, title: "Bottle", items: []),
             TimelineDayGridColumnViewState(
                 kind: .breastFeed,

--- a/Packages/BabyTrackerPersistence/Sources/BabyTrackerPersistence/BabyTrackerModelStore.swift
+++ b/Packages/BabyTrackerPersistence/Sources/BabyTrackerPersistence/BabyTrackerModelStore.swift
@@ -13,6 +13,7 @@ public final class BabyTrackerModelStore {
             StoredBottleFeedEvent.self,
             StoredSleepEvent.self,
             StoredNappyEvent.self,
+            StoredBathEvent.self,
             StoredCloudKitRecordMetadata.self,
             StoredSyncAnchor.self,
         ])

--- a/Packages/BabyTrackerPersistence/Sources/BabyTrackerPersistence/Models/StoredBathEvent.swift
+++ b/Packages/BabyTrackerPersistence/Sources/BabyTrackerPersistence/Models/StoredBathEvent.swift
@@ -1,0 +1,55 @@
+import Foundation
+import SwiftData
+
+@Model
+final class StoredBathEvent {
+    var id: UUID = UUID()
+    var childID: UUID = UUID()
+    var occurredAt: Date = Date()
+    var createdAt: Date = Date()
+    var createdBy: UUID = UUID()
+    var updatedAt: Date = Date()
+    var updatedBy: UUID = UUID()
+    var notes: String = ""
+    var isDeleted: Bool = false
+    var deletedAt: Date?
+    var usedShampoo: Bool = false
+    var usedSoap: Bool = false
+    var syncStateRawValue: String = ""
+    var lastSyncedAt: Date?
+    var lastSyncErrorCode: String?
+
+    init(
+        id: UUID,
+        childID: UUID,
+        occurredAt: Date,
+        createdAt: Date,
+        createdBy: UUID,
+        updatedAt: Date,
+        updatedBy: UUID,
+        notes: String,
+        isDeleted: Bool,
+        deletedAt: Date?,
+        usedShampoo: Bool,
+        usedSoap: Bool,
+        syncStateRawValue: String,
+        lastSyncedAt: Date?,
+        lastSyncErrorCode: String?
+    ) {
+        self.id = id
+        self.childID = childID
+        self.occurredAt = occurredAt
+        self.createdAt = createdAt
+        self.createdBy = createdBy
+        self.updatedAt = updatedAt
+        self.updatedBy = updatedBy
+        self.notes = notes
+        self.isDeleted = isDeleted
+        self.deletedAt = deletedAt
+        self.usedShampoo = usedShampoo
+        self.usedSoap = usedSoap
+        self.syncStateRawValue = syncStateRawValue
+        self.lastSyncedAt = lastSyncedAt
+        self.lastSyncErrorCode = lastSyncErrorCode
+    }
+}

--- a/Packages/BabyTrackerPersistence/Sources/BabyTrackerPersistence/SwiftDataChildRepository.swift
+++ b/Packages/BabyTrackerPersistence/Sources/BabyTrackerPersistence/SwiftDataChildRepository.swift
@@ -114,6 +114,10 @@ public final class SwiftDataChildRepository: CloudKitChildRepository {
             modelContext.delete(event)
         }
 
+        for event in try modelContext.fetch(FetchDescriptor<StoredBathEvent>()) where event.childID == id {
+            modelContext.delete(event)
+        }
+
         if let child = try fetchStoredChild(id: id) {
             modelContext.delete(child)
         }

--- a/Packages/BabyTrackerPersistence/Sources/BabyTrackerPersistence/SwiftDataEventRepository.swift
+++ b/Packages/BabyTrackerPersistence/Sources/BabyTrackerPersistence/SwiftDataEventRepository.swift
@@ -19,6 +19,8 @@ public final class SwiftDataEventRepository: EventRepository {
 
     public func saveEvent(_ event: BabyEvent) throws {
         switch event {
+        case let .bath(value):
+            try saveBath(value)
         case let .breastFeed(value):
             try saveBreastFeed(value)
         case let .bottleFeed(value):
@@ -33,6 +35,10 @@ public final class SwiftDataEventRepository: EventRepository {
     }
 
     public func loadEvent(id: UUID) throws -> BabyEvent? {
+        if let storedEvent = try fetchStoredBathEvent(id: id) {
+            return .bath(mapBath(storedEvent))
+        }
+
         if let storedEvent = try fetchStoredBreastFeedEvent(id: id) {
             return .breastFeed(try mapBreastFeed(storedEvent))
         }
@@ -58,6 +64,18 @@ public final class SwiftDataEventRepository: EventRepository {
     ) throws -> [BabyEvent] {
         var timeline: [BabyEvent] = []
 
+        timeline.append(contentsOf: try modelContext.fetch(FetchDescriptor<StoredBathEvent>())
+            .filter { storedEvent in
+                storedEvent.childID == childID &&
+                (
+                    includingDeleted ||
+                    !isSoftDeleted(
+                        isDeleted: storedEvent.isDeleted,
+                        deletedAt: storedEvent.deletedAt
+                    )
+                )
+            }
+            .map { .bath(mapBath($0)) })
         timeline.append(contentsOf: try modelContext.fetch(FetchDescriptor<StoredBreastFeedEvent>())
             .filter { storedEvent in
                 storedEvent.childID == childID &&
@@ -141,6 +159,8 @@ public final class SwiftDataEventRepository: EventRepository {
             return sleep.startedAt < endOfDay && end > startOfDay
         case let .breastFeed(feed):
             return feed.startedAt < endOfDay && feed.endedAt > startOfDay
+        case let .bath(bath):
+            return bath.metadata.occurredAt >= startOfDay && bath.metadata.occurredAt < endOfDay
         case let .bottleFeed(feed):
             return feed.metadata.occurredAt >= startOfDay && feed.metadata.occurredAt < endOfDay
         case let .nappy(nappy):
@@ -168,7 +188,9 @@ public final class SwiftDataEventRepository: EventRepository {
         deletedAt: Date,
         deletedBy: UUID
     ) throws {
-        if let storedEvent = try fetchStoredBreastFeedEvent(id: id) {
+        if let storedEvent = try fetchStoredBathEvent(id: id) {
+            markDeleted(storedEvent, deletedAt: deletedAt, deletedBy: deletedBy)
+        } else if let storedEvent = try fetchStoredBreastFeedEvent(id: id) {
             markDeleted(storedEvent, deletedAt: deletedAt, deletedBy: deletedBy)
         } else if let storedEvent = try fetchStoredBottleFeedEvent(id: id) {
             markDeleted(storedEvent, deletedAt: deletedAt, deletedBy: deletedBy)
@@ -183,6 +205,36 @@ public final class SwiftDataEventRepository: EventRepository {
 
     private var modelContext: ModelContext {
         store.modelContainer.mainContext
+    }
+
+    private func saveBath(_ event: BathEvent) throws {
+        let existingEvent = try fetchStoredBathEvent(id: event.id)
+        let storedEvent = existingEvent ?? StoredBathEvent(
+            id: event.id,
+            childID: event.metadata.childID,
+            occurredAt: event.metadata.occurredAt,
+            createdAt: event.metadata.createdAt,
+            createdBy: event.metadata.createdBy,
+            updatedAt: event.metadata.updatedAt,
+            updatedBy: event.metadata.updatedBy,
+            notes: event.metadata.notes,
+            isDeleted: event.metadata.isDeleted,
+            deletedAt: event.metadata.deletedAt,
+            usedShampoo: event.usedShampoo,
+            usedSoap: event.usedSoap,
+            syncStateRawValue: SyncState.pendingSync.rawValue,
+            lastSyncedAt: nil,
+            lastSyncErrorCode: nil
+        )
+
+        applyMetadata(event.metadata, to: storedEvent)
+        storedEvent.usedShampoo = event.usedShampoo
+        storedEvent.usedSoap = event.usedSoap
+        markPending(storedEvent)
+
+        if existingEvent == nil {
+            modelContext.insert(storedEvent)
+        }
     }
 
     private func saveBreastFeed(_ event: BreastFeedEvent) throws {
@@ -316,6 +368,11 @@ public final class SwiftDataEventRepository: EventRepository {
         }
     }
 
+    private func fetchStoredBathEvent(id: UUID) throws -> StoredBathEvent? {
+        try modelContext.fetch(FetchDescriptor<StoredBathEvent>())
+            .first { $0.id == id }
+    }
+
     private func fetchStoredBreastFeedEvent(id: UUID) throws -> StoredBreastFeedEvent? {
         try modelContext.fetch(FetchDescriptor<StoredBreastFeedEvent>())
             .first { $0.id == id }
@@ -334,6 +391,25 @@ public final class SwiftDataEventRepository: EventRepository {
     private func fetchStoredNappyEvent(id: UUID) throws -> StoredNappyEvent? {
         try modelContext.fetch(FetchDescriptor<StoredNappyEvent>())
             .first { $0.id == id }
+    }
+
+    private func mapBath(_ storedEvent: StoredBathEvent) -> BathEvent {
+        BathEvent(
+            metadata: makeMetadata(
+                id: storedEvent.id,
+                childID: storedEvent.childID,
+                occurredAt: storedEvent.occurredAt,
+                createdAt: storedEvent.createdAt,
+                createdBy: storedEvent.createdBy,
+                updatedAt: storedEvent.updatedAt,
+                updatedBy: storedEvent.updatedBy,
+                notes: storedEvent.notes,
+                isDeleted: storedEvent.isDeleted,
+                deletedAt: storedEvent.deletedAt
+            ),
+            usedShampoo: storedEvent.usedShampoo,
+            usedSoap: storedEvent.usedSoap
+        )
     }
 
     private func mapBreastFeed(_ storedEvent: StoredBreastFeedEvent) throws -> BreastFeedEvent {
@@ -466,6 +542,18 @@ public final class SwiftDataEventRepository: EventRepository {
         isDeleted || deletedAt != nil
     }
 
+    private func applyMetadata(_ metadata: EventMetadata, to storedEvent: StoredBathEvent) {
+        storedEvent.childID = metadata.childID
+        storedEvent.occurredAt = metadata.occurredAt
+        storedEvent.createdAt = metadata.createdAt
+        storedEvent.createdBy = metadata.createdBy
+        storedEvent.updatedAt = metadata.updatedAt
+        storedEvent.updatedBy = metadata.updatedBy
+        storedEvent.notes = metadata.notes
+        storedEvent.isDeleted = metadata.isDeleted
+        storedEvent.deletedAt = metadata.deletedAt
+    }
+
     private func applyMetadata(_ metadata: EventMetadata, to storedEvent: StoredBreastFeedEvent) {
         storedEvent.childID = metadata.childID
         storedEvent.occurredAt = metadata.occurredAt
@@ -515,6 +603,18 @@ public final class SwiftDataEventRepository: EventRepository {
     }
 
     private func markDeleted(
+        _ storedEvent: StoredBathEvent,
+        deletedAt: Date,
+        deletedBy: UUID
+    ) {
+        storedEvent.isDeleted = true
+        storedEvent.deletedAt = deletedAt
+        storedEvent.updatedAt = deletedAt
+        storedEvent.updatedBy = deletedBy
+        markPending(storedEvent)
+    }
+
+    private func markDeleted(
         _ storedEvent: StoredBreastFeedEvent,
         deletedAt: Date,
         deletedBy: UUID
@@ -560,6 +660,11 @@ public final class SwiftDataEventRepository: EventRepository {
         storedEvent.updatedAt = deletedAt
         storedEvent.updatedBy = deletedBy
         markPending(storedEvent)
+    }
+
+    private func markPending(_ storedEvent: StoredBathEvent) {
+        storedEvent.syncStateRawValue = SyncState.pendingSync.rawValue
+        storedEvent.lastSyncErrorCode = nil
     }
 
     private func markPending(_ storedEvent: StoredBreastFeedEvent) {

--- a/Packages/BabyTrackerPersistence/Sources/BabyTrackerPersistence/SwiftDataSyncStateRepository.swift
+++ b/Packages/BabyTrackerPersistence/Sources/BabyTrackerPersistence/SwiftDataSyncStateRepository.swift
@@ -28,6 +28,7 @@ public final class SwiftDataSyncStateRepository: SyncStateRepository {
         records.append(contentsOf: try pendingBottleFeeds())
         records.append(contentsOf: try pendingSleepEvents())
         records.append(contentsOf: try pendingNappyEvents())
+        records.append(contentsOf: try pendingBathEvents())
 
         return records
     }
@@ -65,6 +66,10 @@ public final class SwiftDataSyncStateRepository: SyncStateRepository {
             }
         case .nappyEvent:
             if let model = try fetchNappy(id: record.recordID) {
+                apply(state: state, lastSyncedAt: lastSyncedAt, lastSyncErrorCode: lastSyncErrorCode, to: model)
+            }
+        case .bathEvent:
+            if let model = try fetchBath(id: record.recordID) {
                 apply(state: state, lastSyncedAt: lastSyncedAt, lastSyncErrorCode: lastSyncErrorCode, to: model)
             }
         }
@@ -201,6 +206,12 @@ public final class SwiftDataSyncStateRepository: SyncStateRepository {
             .map { SyncRecordReference(recordType: .nappyEvent, recordID: $0.id, childID: $0.childID) }
     }
 
+    private func pendingBathEvents() throws -> [SyncRecordReference] {
+        try modelContext.fetch(FetchDescriptor<StoredBathEvent>())
+            .filter { $0.syncStateRawValue == SyncState.pendingSync.rawValue }
+            .map { SyncRecordReference(recordType: .bathEvent, recordID: $0.id, childID: $0.childID) }
+    }
+
     private func fetchChild(id: UUID) throws -> StoredChild? {
         try modelContext.fetch(FetchDescriptor<StoredChild>()).first { $0.id == id }
     }
@@ -229,6 +240,10 @@ public final class SwiftDataSyncStateRepository: SyncStateRepository {
         try modelContext.fetch(FetchDescriptor<StoredNappyEvent>()).first { $0.id == id }
     }
 
+    private func fetchBath(id: UUID) throws -> StoredBathEvent? {
+        try modelContext.fetch(FetchDescriptor<StoredBathEvent>()).first { $0.id == id }
+    }
+
     private func fetchAnchor(
         databaseScope: String,
         zoneName: String?,
@@ -252,6 +267,7 @@ public final class SwiftDataSyncStateRepository: SyncStateRepository {
         rawValues.append(contentsOf: try modelContext.fetch(FetchDescriptor<StoredBottleFeedEvent>()).map(\.syncStateRawValue))
         rawValues.append(contentsOf: try modelContext.fetch(FetchDescriptor<StoredSleepEvent>()).map(\.syncStateRawValue))
         rawValues.append(contentsOf: try modelContext.fetch(FetchDescriptor<StoredNappyEvent>()).map(\.syncStateRawValue))
+        rawValues.append(contentsOf: try modelContext.fetch(FetchDescriptor<StoredBathEvent>()).map(\.syncStateRawValue))
 
         return rawValues.compactMap(SyncState.init(rawValue:))
     }
@@ -263,7 +279,8 @@ public final class SwiftDataSyncStateRepository: SyncStateRepository {
             modelContext.fetch(FetchDescriptor<StoredBreastFeedEvent>()).map(\.lastSyncedAt) +
             modelContext.fetch(FetchDescriptor<StoredBottleFeedEvent>()).map(\.lastSyncedAt) +
             modelContext.fetch(FetchDescriptor<StoredSleepEvent>()).map(\.lastSyncedAt) +
-            modelContext.fetch(FetchDescriptor<StoredNappyEvent>()).map(\.lastSyncedAt)
+            modelContext.fetch(FetchDescriptor<StoredNappyEvent>()).map(\.lastSyncedAt) +
+            modelContext.fetch(FetchDescriptor<StoredBathEvent>()).map(\.lastSyncedAt)
     }
 
     private func allLastErrorCodes() throws -> [String?] {
@@ -273,7 +290,8 @@ public final class SwiftDataSyncStateRepository: SyncStateRepository {
             modelContext.fetch(FetchDescriptor<StoredBreastFeedEvent>()).map(\.lastSyncErrorCode) +
             modelContext.fetch(FetchDescriptor<StoredBottleFeedEvent>()).map(\.lastSyncErrorCode) +
             modelContext.fetch(FetchDescriptor<StoredSleepEvent>()).map(\.lastSyncErrorCode) +
-            modelContext.fetch(FetchDescriptor<StoredNappyEvent>()).map(\.lastSyncErrorCode)
+            modelContext.fetch(FetchDescriptor<StoredNappyEvent>()).map(\.lastSyncErrorCode) +
+            modelContext.fetch(FetchDescriptor<StoredBathEvent>()).map(\.lastSyncErrorCode)
     }
 
     private func apply(
@@ -347,6 +365,17 @@ public final class SwiftDataSyncStateRepository: SyncStateRepository {
         lastSyncedAt: Date?,
         lastSyncErrorCode: String?,
         to model: StoredNappyEvent
+    ) {
+        model.syncStateRawValue = state.rawValue
+        model.lastSyncedAt = lastSyncedAt
+        model.lastSyncErrorCode = lastSyncErrorCode
+    }
+
+    private func apply(
+        state: SyncState,
+        lastSyncedAt: Date?,
+        lastSyncErrorCode: String?,
+        to model: StoredBathEvent
     ) {
         model.syncStateRawValue = state.rawValue
         model.lastSyncedAt = lastSyncedAt

--- a/Packages/BabyTrackerPersistence/Sources/BabyTrackerPersistence/SwiftDataUserIdentityRepository.swift
+++ b/Packages/BabyTrackerPersistence/Sources/BabyTrackerPersistence/SwiftDataUserIdentityRepository.swift
@@ -135,6 +135,7 @@ public final class SwiftDataUserIdentityRepository: CloudKitUserIdentityReposito
         try deleteAll(StoredBottleFeedEvent.self)
         try deleteAll(StoredSleepEvent.self)
         try deleteAll(StoredNappyEvent.self)
+        try deleteAll(StoredBathEvent.self)
         try deleteAll(StoredSyncAnchor.self)
         userDefaults.removeObject(forKey: DefaultsKey.localUserID)
     }
@@ -236,6 +237,14 @@ public final class SwiftDataUserIdentityRepository: CloudKitUserIdentityReposito
                 markPendingSync(event, errorCode: nil)
             }
         }
+
+        for event in try modelContext.fetch(FetchDescriptor<StoredBathEvent>()) {
+            if event.createdBy == sourceUserID { event.createdBy = targetUserID }
+            if event.updatedBy == sourceUserID { event.updatedBy = targetUserID }
+            if event.createdBy == targetUserID || event.updatedBy == targetUserID {
+                markPendingSync(event, errorCode: nil)
+            }
+        }
     }
 
     private func markPendingSync(_ storedModel: StoredChild, errorCode: String?) {
@@ -264,6 +273,11 @@ public final class SwiftDataUserIdentityRepository: CloudKitUserIdentityReposito
     }
 
     private func markPendingSync(_ storedModel: StoredNappyEvent, errorCode: String?) {
+        storedModel.syncStateRawValue = SyncState.pendingSync.rawValue
+        storedModel.lastSyncErrorCode = errorCode
+    }
+
+    private func markPendingSync(_ storedModel: StoredBathEvent, errorCode: String?) {
         storedModel.syncStateRawValue = SyncState.pendingSync.rawValue
         storedModel.lastSyncErrorCode = errorCode
     }

--- a/Packages/BabyTrackerPersistence/Sources/BabyTrackerPersistence/SyncRecordType.swift
+++ b/Packages/BabyTrackerPersistence/Sources/BabyTrackerPersistence/SyncRecordType.swift
@@ -8,4 +8,5 @@ public enum SyncRecordType: String, Equatable, Sendable {
     case bottleFeedEvent
     case sleepEvent
     case nappyEvent
+    case bathEvent
 }

--- a/Packages/BabyTrackerSync/Sources/BabyTrackerSync/CloudKitConfiguration.swift
+++ b/Packages/BabyTrackerSync/Sources/BabyTrackerSync/CloudKitConfiguration.swift
@@ -10,6 +10,7 @@ public enum CloudKitConfiguration {
     public static let bottleFeedRecordType = "BottleFeedEvent"
     public static let sleepRecordType = "SleepEvent"
     public static let nappyRecordType = "NappyEvent"
+    public static let bathRecordType = "BathEvent"
 
     public static func container() -> CKContainer {
         CKContainer(identifier: containerIdentifier)

--- a/Packages/BabyTrackerSync/Sources/BabyTrackerSync/CloudKitRecordMapper.swift
+++ b/Packages/BabyTrackerSync/Sources/BabyTrackerSync/CloudKitRecordMapper.swift
@@ -19,6 +19,8 @@ public enum CloudKitRecordMapper {
             metadataFieldKeys + ["startedAt", "endedAt"]
         case CloudKitConfiguration.nappyRecordType:
             metadataFieldKeys + ["type", "peeVolume", "pooVolume", "pooColor"]
+        case CloudKitConfiguration.bathRecordType:
+            metadataFieldKeys + ["shampooUsed", "soapUsed"]
         default:
             []
         }
@@ -102,6 +104,8 @@ public enum CloudKitRecordMapper {
         zoneID: CKRecordZone.ID
     ) -> CKRecord {
         switch event {
+        case let .bath(value):
+            return bathRecord(from: value, zoneID: zoneID)
         case let .breastFeed(value):
             return breastFeedRecord(from: value, zoneID: zoneID)
         case let .bottleFeed(value):
@@ -161,6 +165,8 @@ public enum CloudKitRecordMapper {
 
     public static func event(from record: CKRecord) throws -> BabyEvent {
         switch record.recordType {
+        case CloudKitConfiguration.bathRecordType:
+            return .bath(bath(from: record))
         case CloudKitConfiguration.breastFeedRecordType:
             return .breastFeed(try breastFeed(from: record))
         case CloudKitConfiguration.bottleFeedRecordType:
@@ -253,6 +259,23 @@ public enum CloudKitRecordMapper {
         return record
     }
 
+    private static func bathRecord(
+        from event: BathEvent,
+        zoneID: CKRecordZone.ID
+    ) -> CKRecord {
+        let record = CKRecord(
+            recordType: CloudKitConfiguration.bathRecordType,
+            recordID: CloudKitRecordNames.bathRecordID(
+                eventID: event.id,
+                zoneID: zoneID
+            )
+        )
+        applyMetadata(event.metadata, to: record)
+        record["shampooUsed"] = event.usedShampoo
+        record["soapUsed"] = event.usedSoap
+        return record
+    }
+
     private static func breastFeed(from record: CKRecord) throws -> BreastFeedEvent {
         try BreastFeedEvent(
             metadata: metadata(from: record, prefix: "breastFeed."),
@@ -287,6 +310,14 @@ public enum CloudKitRecordMapper {
             peeVolume: (record["peeVolume"] as? String).flatMap(NappyVolume.init(rawValue:)),
             pooVolume: (record["pooVolume"] as? String).flatMap(NappyVolume.init(rawValue:)),
             pooColor: (record["pooColor"] as? String).flatMap(PooColor.init(rawValue:))
+        )
+    }
+
+    private static func bath(from record: CKRecord) -> BathEvent {
+        BathEvent(
+            metadata: metadata(from: record, prefix: "bath."),
+            usedShampoo: record["shampooUsed"] as? Bool ?? false,
+            usedSoap: record["soapUsed"] as? Bool ?? false
         )
     }
 

--- a/Packages/BabyTrackerSync/Sources/BabyTrackerSync/CloudKitRecordNames.swift
+++ b/Packages/BabyTrackerSync/Sources/BabyTrackerSync/CloudKitRecordNames.swift
@@ -96,4 +96,14 @@ public enum CloudKitRecordNames {
             zoneID: zoneID
         )
     }
+
+    static func bathRecordID(
+        eventID: UUID,
+        zoneID: CKRecordZone.ID
+    ) -> CKRecord.ID {
+        CKRecord.ID(
+            recordName: "bath.\(eventID.uuidString)",
+            zoneID: zoneID
+        )
+    }
 }

--- a/Packages/BabyTrackerSync/Sources/BabyTrackerSync/CloudKitSyncEngine.swift
+++ b/Packages/BabyTrackerSync/Sources/BabyTrackerSync/CloudKitSyncEngine.swift
@@ -1013,7 +1013,8 @@ public final class CloudKitSyncEngine {
         case CloudKitConfiguration.breastFeedRecordType,
              CloudKitConfiguration.bottleFeedRecordType,
              CloudKitConfiguration.sleepRecordType,
-             CloudKitConfiguration.nappyRecordType:
+             CloudKitConfiguration.nappyRecordType,
+             CloudKitConfiguration.bathRecordType:
             let event = try CloudKitRecordMapper.event(from: record)
             if let localEvent = try eventRepository.loadEvent(id: event.id),
                LastWriteWinsResolver.prefersLocal(localEvent.metadata, over: event.metadata) {
@@ -1248,6 +1249,8 @@ public final class CloudKitSyncEngine {
             .sleepEvent
         case .nappy:
             .nappyEvent
+        case .bath:
+            .bathEvent
         }
     }
 
@@ -1349,7 +1352,7 @@ public final class CloudKitSyncEngine {
                     databaseScope: context.databaseScope
                 )
             )
-        case .breastFeedEvent, .bottleFeedEvent, .sleepEvent, .nappyEvent:
+        case .breastFeedEvent, .bottleFeedEvent, .sleepEvent, .nappyEvent, .bathEvent:
             guard let event = try eventRepository.loadEvent(id: reference.recordID) else {
                 return nil
             }

--- a/docs/plans/105-bath-event-type.md
+++ b/docs/plans/105-bath-event-type.md
@@ -1,0 +1,78 @@
+# 105 - Bath Event Type
+
+## Summary
+Add `Bath` as a first-class user event across the existing event system, using the same end-to-end shape as `Nappy`, `Sleep`, `Bottle Feed`, and `Breast Feed`: dedicated domain model, persistence/sync mapping, presentation helpers, editor flow, event visibility/filtering, timeline rendering, and Summary Trends support.
+
+Before implementation starts:
+1. Create `docs/plans/105-bath-event-type.md` with this plan and a `- [ ] Complete` checkbox.
+2. Create a GitHub issue for the feature and reference the new plan doc from the issue.
+
+## Key Changes
+1. Domain and event plumbing
+- Add `BathEvent` in `BabyTrackerDomain` with `metadata`, `usedShampoo`, and `usedSoap`.
+- Extend `BabyEvent` and `BabyEventKind` with `.bath`.
+- Add bath create/update use cases following the existing `Log*UseCase` / `Update*UseCase` pattern.
+- Add any bath-specific validation as simple domain rules only; time is the event `occurredAt`, and both booleans are optional-style flags represented as `Bool`.
+
+2. Persistence and sync
+- Add a `StoredBathEvent` SwiftData model and include it in `BabyTrackerModelStore`.
+- Extend `SwiftDataEventRepository` to save, load, soft-delete, day-filter, and timeline-load bath events alongside the existing event tables.
+- Extend CloudKit config and mapping with a new bath record type plus `shampooUsed` / `soapUsed` fields.
+- Update CloudKit mutable field keys, record creation, record decoding, and any sync-summary/pending-change paths that enumerate event record types.
+- Preserve backward compatibility by only adding a new record/table type; existing event decoding behavior remains unchanged.
+
+3. UI and presentation
+- Add bath title/detail/icon/color handling in the same helpers that currently drive other event types:
+  `BabyEventPresentation`, `BabyEventStyle`, event card state, timeline item state, filter chips, visibility settings, onboarding/customize-events copy, and preview/sample data.
+- Add Bath to Home Quick Log as a normal event button and expose a `BathEditorSheetView` plus corresponding `ChildEventSheet` / `EventActionPayload` cases for quick-log and edit flows.
+- Show bath detail text consistently as the existing cards do, e.g. time plus a concise shampoo/soap summary when true.
+- Update Home recent cards, Home today timeline, All Events, grouped timeline sheets, and timeline day/week views so bath uses its bath-specific styling everywhere colors/icons are already applied.
+- Keep Live Activity logic unchanged except for any safe internal exhaustiveness updates; Bath must not appear in the widget UI or feed live activity content.
+
+4. Filtering and summaries
+- Add Bath to event-type visibility and All Events event-type filtering with no extra bath-only filter section.
+- Update event history pills, empty states, and filter chips so Bath behaves like the other top-level event kinds.
+- Extend trend aggregation with daily bath counts and average daily baths.
+- Add a Bath chart to Summary `Trends` using the existing grouped-by-range day bucketing and chart card styling.
+- Do not add Bath to Summary `Today`.
+- Keep advanced/day-based summary behavior aligned with the current architecture: Bath contributes to overall event/activity totals but does not require a new Today metric card unless an existing generic total already includes all events.
+
+## Public Interfaces / Types
+- Add `BabyEventKind.bath`
+- Add `BabyEvent.bath(BathEvent)`
+- Add `BathEvent`
+- Add `EventActionPayload.editBath(...)`
+- Add `ChildEventSheet.quickLogBath` and `ChildEventSheet.editBath(...)`
+- Add `StoredBathEvent`
+- Add `TrendsSummaryData.dailyBath` and `avgDailyBaths` or equivalent bath trend fields
+
+## Test Plan
+1. Domain tests
+- Bath event creation/update succeeds with valid metadata and booleans.
+- Event filters include/exclude Bath correctly through `eventTypes`.
+
+2. Persistence/sync tests
+- Repository round-trips Bath events.
+- Timeline/day loading includes Bath in the correct sort order.
+- CloudKit mapping round-trips Bath records and leaves existing record mappings unchanged.
+
+3. Feature/UI state tests
+- Presentation helpers return Bath title, detail text, icon, and colors.
+- Event card and timeline view-state builders produce Bath edit payloads.
+- Summary trends calculator produces correct daily bath counts and averages.
+- Existing Today summary tests remain unchanged for non-Bath behavior.
+
+4. UI / preview / regression checks
+- Bath can be created from Home Quick Log and saved.
+- Bath appears on Home, All Events, and Timeline views.
+- All Events filtering by Bath works.
+- Trends shows a Bath chart; Today does not.
+- Live Activity widget still excludes Bath.
+
+## Assumptions
+- Bath is a point-in-time event, not a duration event.
+- Bath creation is exposed through Home Quick Log and event customization flows, because that is the app’s primary creation path.
+- Bath uses a repo-matched default bath icon and a distinct aqua/teal palette, applied anywhere `BabyEventStyle` and related helpers already drive event visuals.
+- No bath-specific Today summary card, live activity surface, or extra filter subsection will be added.
+
+- [x] Complete


### PR DESCRIPTION
## Summary
- add Bath as a first-class event type across domain, persistence, sync, home, all events, timelines, filters, and summary trends
- add Nest import/export and restore coverage for Bath, plus the export-screen copy update
- document the repo checklist for adding future event types, including CloudKit schema follow-up

## Validation
- ran focused xcodebuild tests covering Bath domain, repository, CloudKit mapper, trends, visibility, and timeline integration
- verified CloudKit development schema populated in the dashboard after running against the updated branch

Closes #243
Plan: docs/plans/105-bath-event-type.md