### PR TITLE
Refactor Home since-last status card

### DIFF
--- a/Baby TrackerTests/AppModelTests.swift
+++ b/Baby TrackerTests/AppModelTests.swift
@@ -595,7 +595,11 @@ struct AppModelTests {
 
         let child = try #require(harness.model.currentChild)
         #expect(harness.model.activeSleep == nil)
-        let currentStatus = BuildCurrentStatusViewStateUseCase.execute(events: harness.model.events, child: child)
+        let currentStatus = BuildCurrentStatusViewStateUseCase.execute(
+            events: harness.model.events,
+            child: child,
+            enabledEventKinds: harness.model.enabledEventKinds
+        )
         #expect(currentStatus.timeSinceLastFeedAt == feed.metadata.occurredAt)
         #expect(currentStatus.timeSinceLastNappyAt == nil)
         let recentEvents = Array(BuildEventCardsUseCase.execute(events: harness.model.events, preferredFeedVolumeUnit: child.preferredFeedVolumeUnit).prefix(6))
@@ -614,7 +618,7 @@ struct AppModelTests {
     }
 
     @Test
-    func homeStatusUsesLatestFeedAndNappyAndCountsTodayFeeds() throws {
+    func homeStatusUsesLatestFeedAndNappyRows() throws {
         let harness = try Harness()
         defer { harness.cleanUp() }
 
@@ -651,10 +655,15 @@ struct AppModelTests {
         harness.model.load(performLaunchSync: false)
 
         let child = try #require(harness.model.currentChild)
-        let currentStatus = BuildCurrentStatusViewStateUseCase.execute(events: harness.model.events, child: child)
+        let currentStatus = BuildCurrentStatusViewStateUseCase.execute(
+            events: harness.model.events,
+            child: child,
+            enabledEventKinds: harness.model.enabledEventKinds
+        )
         #expect(currentStatus.timeSinceLastFeedAt == latestFeed.metadata.occurredAt)
-        #expect(currentStatus.feedsTodayCount == 2)
         #expect(currentStatus.timeSinceLastNappyAt == latestNappy.metadata.occurredAt)
+        #expect(currentStatus.row(for: .bottleFeed)?.elapsedSinceDate == latestFeed.metadata.occurredAt)
+        #expect(currentStatus.row(for: .nappy)?.elapsedSinceDate == latestNappy.metadata.occurredAt)
     }
 
     @Test
@@ -1452,6 +1461,7 @@ struct AppModelTests {
         #expect(harness.model.events.contains(where: { $0.id == breastFeed.id }))
         #expect(harness.model.events.contains(where: { $0.id == bottleFeed.id }))
         #expect(harness.model.isEventKindEnabled(.breastFeed))
+        #expect(HomeViewModel(appModel: harness.model).currentStatus.row(for: .breastFeed) != nil)
 
         harness.model.setEventKindEnabled(.breastFeed, isEnabled: false)
 
@@ -1459,11 +1469,35 @@ struct AppModelTests {
         #expect(visibilityStore.enabledEventKinds == [.bath, .bottleFeed, .sleep, .nappy])
         #expect(!harness.model.events.contains(where: { $0.id == breastFeed.id }))
         #expect(harness.model.events.contains(where: { $0.id == bottleFeed.id }))
+        #expect(HomeViewModel(appModel: harness.model).currentStatus.row(for: .breastFeed) == nil)
+        #expect(HomeViewModel(appModel: harness.model).currentStatus.visibleEventKinds == [.bath, .bottleFeed, .sleep, .nappy])
 
         harness.model.setEventKindEnabled(.breastFeed, isEnabled: true)
 
         #expect(harness.model.isEventKindEnabled(.breastFeed))
         #expect(harness.model.events.contains(where: { $0.id == breastFeed.id }))
+        #expect(HomeViewModel(appModel: harness.model).currentStatus.row(for: .breastFeed) != nil)
+    }
+
+    @Test
+    func homeStatusIncludesBathWhenBathEventsAreEnabled() throws {
+        let harness = try Harness()
+        defer { harness.cleanUp() }
+
+        let seed = try harness.seedOwnerProfile()
+        let bath = try harness.saveBath(
+            childID: seed.child.id,
+            userID: seed.localUser.id,
+            occurredAt: Date(timeIntervalSince1970: 12_000),
+            usedShampoo: true,
+            usedSoap: true
+        )
+
+        harness.model.load(performLaunchSync: false)
+
+        let status = HomeViewModel(appModel: harness.model).currentStatus
+        #expect(status.row(for: .bath)?.elapsedSinceDate == bath.metadata.occurredAt)
+        #expect(status.row(for: .bath)?.detailText == "Shampoo • Soap")
     }
 
     @Test
@@ -2026,6 +2060,27 @@ extension AppModelTests {
                 milkType: milkType
             )
             try eventRepository.saveEvent(.bottleFeed(event))
+            return event
+        }
+
+        func saveBath(
+            childID: UUID,
+            userID: UUID,
+            occurredAt: Date,
+            usedShampoo: Bool,
+            usedSoap: Bool
+        ) throws -> BathEvent {
+            let event = BathEvent(
+                metadata: EventMetadata(
+                    childID: childID,
+                    occurredAt: occurredAt,
+                    createdAt: occurredAt,
+                    createdBy: userID
+                ),
+                usedShampoo: usedShampoo,
+                usedSoap: usedSoap
+            )
+            try eventRepository.saveEvent(.bath(event))
             return event
         }
 

--- a/Baby TrackerTests/BuildCurrentStatusViewStateUseCaseTests.swift
+++ b/Baby TrackerTests/BuildCurrentStatusViewStateUseCaseTests.swift
@@ -12,151 +12,150 @@ struct BuildCurrentStatusViewStateUseCaseTests {
     }
 
     @Test
-    func returnsNilsWhenNoEvents() throws {
+    func returnsEmptyRowsWhenNoEvents() throws {
         let child = try makeChild()
-        let result = BuildCurrentStatusViewStateUseCase.execute(events: [], child: child)
+        let result = BuildCurrentStatusViewStateUseCase.execute(
+            events: [],
+            child: child,
+            enabledEventKinds: Set(BabyEventKind.allCases)
+        )
 
-        #expect(result.lastBreastFeed == nil)
-        #expect(result.lastBottleFeed == nil)
-        #expect(result.lastNappy == nil)
+        #expect(result.rows.isEmpty)
         #expect(result.lastSleep == nil)
-        #expect(result.feedsTodayCount == 0)
+        #expect(result.visibleEventKinds == BabyEventKind.allCases)
     }
 
     @Test
-    func populatesLastBreastFeedWithDetailText() throws {
+    func enabledBathProducesBathRow() throws {
         let child = try makeChild()
         let t = Date(timeIntervalSince1970: 10_000)
         let events: [BabyEvent] = [
-            .breastFeed(
-                try BreastFeedEvent(
+            .bath(
+                try BathEvent(
                     metadata: EventMetadata(childID: childID, occurredAt: t, createdAt: t, createdBy: userID),
-                    side: .left,
-                    startedAt: t.addingTimeInterval(-600),
-                    endedAt: t
+                    usedShampoo: true,
+                    usedSoap: false
                 )
             ),
         ]
 
-        let result = BuildCurrentStatusViewStateUseCase.execute(events: events, child: child)
+        let result = BuildCurrentStatusViewStateUseCase.execute(
+            events: events,
+            child: child,
+            enabledEventKinds: [.bath]
+        )
 
-        let breastFeed = try #require(result.lastBreastFeed)
-        #expect(breastFeed.kind == .breastFeed)
-        #expect(breastFeed.occurredAt == t)
-        #expect(breastFeed.detailText?.contains("Left") == true)
-        #expect(result.lastBottleFeed == nil)
+        let bath = try #require(result.row(for: .bath))
+        #expect(bath.title == "Last bath")
+        #expect(bath.elapsedSinceDate == t)
+        #expect(bath.detailText == "Shampoo")
     }
 
     @Test
-    func populatesLastBottleFeedWithDetailText() throws {
+    func hiddenEventKindsAreOmittedEvenWhenEventsExist() throws {
         let child = try makeChild()
         let t = Date(timeIntervalSince1970: 10_000)
         let events: [BabyEvent] = [
+            .bath(
+                try BathEvent(
+                    metadata: EventMetadata(childID: childID, occurredAt: t, createdAt: t, createdBy: userID),
+                    usedShampoo: true,
+                    usedSoap: true
+                )
+            ),
+        ]
+
+        let result = BuildCurrentStatusViewStateUseCase.execute(
+            events: events,
+            child: child,
+            enabledEventKinds: [.bottleFeed]
+        )
+
+        #expect(result.row(for: .bath) == nil)
+        #expect(result.visibleEventKinds == [.bottleFeed])
+    }
+
+    @Test
+    func breastFeedAndBottleFeedProduceIndependentRows() throws {
+        let child = try makeChild()
+        let breastTime = Date(timeIntervalSince1970: 10_000)
+        let bottleTime = Date(timeIntervalSince1970: 12_000)
+        let events: [BabyEvent] = [
+            .breastFeed(
+                try BreastFeedEvent(
+                    metadata: EventMetadata(childID: childID, occurredAt: breastTime, createdAt: breastTime, createdBy: userID),
+                    side: .left,
+                    startedAt: breastTime.addingTimeInterval(-600),
+                    endedAt: breastTime
+                )
+            ),
             .bottleFeed(
                 try BottleFeedEvent(
-                    metadata: EventMetadata(childID: childID, occurredAt: t, createdAt: t, createdBy: userID),
+                    metadata: EventMetadata(childID: childID, occurredAt: bottleTime, createdAt: bottleTime, createdBy: userID),
                     amountMilliliters: 150,
                     milkType: .formula
                 )
             ),
         ]
 
-        let result = BuildCurrentStatusViewStateUseCase.execute(events: events, child: child)
+        let result = BuildCurrentStatusViewStateUseCase.execute(
+            events: events,
+            child: child,
+            enabledEventKinds: [.breastFeed, .bottleFeed]
+        )
 
-        let bottleFeed = try #require(result.lastBottleFeed)
-        #expect(bottleFeed.kind == .bottleFeed)
-        #expect(bottleFeed.occurredAt == t)
-        #expect(bottleFeed.detailText?.contains("Formula") == true)
-        #expect(result.lastBreastFeed == nil)
+        #expect(result.row(for: .breastFeed)?.elapsedSinceDate == breastTime)
+        #expect(result.row(for: .breastFeed)?.detailText?.contains("Left") == true)
+        #expect(result.row(for: .bottleFeed)?.elapsedSinceDate == bottleTime)
+        #expect(result.row(for: .bottleFeed)?.detailText?.contains("Formula") == true)
     }
 
     @Test
-    func picksMostRecentBreastFeed() throws {
+    func activeSleepSuppressesCompletedSleepRow() throws {
         let child = try makeChild()
-        let earlier = Date(timeIntervalSince1970: 5_000)
-        let later = Date(timeIntervalSince1970: 10_000)
+        let startedAt = Date(timeIntervalSince1970: 10_000)
+        let activeSleep = try SleepEvent(
+            metadata: EventMetadata(childID: childID, occurredAt: startedAt, createdAt: startedAt, createdBy: userID),
+            startedAt: startedAt,
+            endedAt: nil
+        )
+
+        let result = BuildCurrentStatusViewStateUseCase.execute(
+            events: [],
+            child: child,
+            enabledEventKinds: [.sleep],
+            activeSleep: activeSleep
+        )
+
+        #expect(result.row(for: .sleep) == nil)
+        #expect(result.lastSleep?.isActive == true)
+        #expect(result.lastSleep?.startedAt == startedAt)
+    }
+
+    @Test
+    func completedSleepStillAppearsWithoutActiveSleep() throws {
+        let child = try makeChild()
+        let startedAt = Date(timeIntervalSince1970: 8_000)
+        let endedAt = Date(timeIntervalSince1970: 10_000)
         let events: [BabyEvent] = [
-            .breastFeed(
-                try BreastFeedEvent(
-                    metadata: EventMetadata(childID: childID, occurredAt: earlier, createdAt: earlier, createdBy: userID),
-                    side: .right,
-                    startedAt: earlier.addingTimeInterval(-300),
-                    endedAt: earlier
-                )
-            ),
-            .breastFeed(
-                try BreastFeedEvent(
-                    metadata: EventMetadata(childID: childID, occurredAt: later, createdAt: later, createdBy: userID),
-                    side: .left,
-                    startedAt: later.addingTimeInterval(-900),
-                    endedAt: later
+            .sleep(
+                try SleepEvent(
+                    metadata: EventMetadata(childID: childID, occurredAt: startedAt, createdAt: startedAt, createdBy: userID),
+                    startedAt: startedAt,
+                    endedAt: endedAt
                 )
             ),
         ]
 
-        let result = BuildCurrentStatusViewStateUseCase.execute(events: events, child: child)
+        let result = BuildCurrentStatusViewStateUseCase.execute(
+            events: events,
+            child: child,
+            enabledEventKinds: [.sleep]
+        )
 
-        #expect(result.lastBreastFeed?.occurredAt == later)
-        #expect(result.lastBreastFeed?.detailText?.contains("Left") == true)
-    }
-
-    @Test
-    func populatesLastNappyWithDetailText() throws {
-        let child = try makeChild()
-        let t = Date(timeIntervalSince1970: 10_000)
-        let events: [BabyEvent] = [
-            .nappy(
-                try NappyEvent(
-                    metadata: EventMetadata(childID: childID, occurredAt: t, createdAt: t, createdBy: userID),
-                    type: .poo,
-                    pooVolume: .medium,
-                    pooColor: .yellow
-                )
-            ),
-        ]
-
-        let result = BuildCurrentStatusViewStateUseCase.execute(events: events, child: child)
-
-        let nappy = try #require(result.lastNappy)
-        #expect(nappy.occurredAt == t)
-        #expect(nappy.detailText?.contains("Poo") == true)
-    }
-
-    @Test
-    func countsFeedsTodayAcrossBothTypes() throws {
-        var calendar = Calendar(identifier: .gregorian)
-        calendar.timeZone = TimeZone(secondsFromGMT: 0)!
-        let child = try makeChild()
-        let day = try #require(calendar.date(from: DateComponents(year: 2026, month: 4, day: 1, hour: 12)))
-        let morning = try #require(calendar.date(from: DateComponents(year: 2026, month: 4, day: 1, hour: 8)))
-        let midday = try #require(calendar.date(from: DateComponents(year: 2026, month: 4, day: 1, hour: 11)))
-        let yesterday = try #require(calendar.date(from: DateComponents(year: 2026, month: 3, day: 31, hour: 20)))
-
-        let events: [BabyEvent] = [
-            .breastFeed(
-                try BreastFeedEvent(
-                    metadata: EventMetadata(childID: childID, occurredAt: morning, createdAt: morning, createdBy: userID),
-                    side: .left,
-                    startedAt: morning.addingTimeInterval(-600),
-                    endedAt: morning
-                )
-            ),
-            .bottleFeed(
-                try BottleFeedEvent(
-                    metadata: EventMetadata(childID: childID, occurredAt: midday, createdAt: midday, createdBy: userID),
-                    amountMilliliters: 120
-                )
-            ),
-            .bottleFeed(
-                try BottleFeedEvent(
-                    metadata: EventMetadata(childID: childID, occurredAt: yesterday, createdAt: yesterday, createdBy: userID),
-                    amountMilliliters: 100
-                )
-            ),
-        ]
-
-        let result = BuildCurrentStatusViewStateUseCase.execute(events: events, child: child, day: day, calendar: calendar)
-
-        #expect(result.feedsTodayCount == 2)
+        let sleep = try #require(result.row(for: .sleep))
+        #expect(sleep.elapsedSinceDate == endedAt)
+        #expect(sleep.detailText == "33 min")
+        #expect(result.lastSleep?.isActive == false)
     }
 }

--- a/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/CurrentStatusCardViewState.swift
+++ b/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/CurrentStatusCardViewState.swift
@@ -1,40 +1,33 @@
+import BabyTrackerDomain
 import Foundation
 
 public struct CurrentStatusCardViewState: Equatable, Sendable {
+    public let visibleEventKinds: [BabyEventKind]
+    public let rows: [CurrentStatusRowViewState]
     public let lastSleep: LastSleepSummaryViewState?
-    public let lastBreastFeed: LastEventSummaryViewState?
-    public let lastBottleFeed: LastEventSummaryViewState?
-    public let feedsTodayCount: Int
-    public let lastNappy: LastNappySummaryViewState?
 
     public var timeSinceLastFeedAt: Date? {
-        switch (lastBreastFeed?.occurredAt, lastBottleFeed?.occurredAt) {
-        case let (left?, right?):
-            return max(left, right)
-        case let (left?, nil):
-            return left
-        case let (nil, right?):
-            return right
-        case (nil, nil):
-            return nil
-        }
+        rows
+            .filter { $0.kind == .breastFeed || $0.kind == .bottleFeed }
+            .map(\.elapsedSinceDate)
+            .max()
     }
 
     public var timeSinceLastNappyAt: Date? {
-        lastNappy?.occurredAt
+        row(for: .nappy)?.elapsedSinceDate
     }
 
     public init(
-        lastSleep: LastSleepSummaryViewState?,
-        lastBreastFeed: LastEventSummaryViewState?,
-        lastBottleFeed: LastEventSummaryViewState?,
-        feedsTodayCount: Int,
-        lastNappy: LastNappySummaryViewState?
+        visibleEventKinds: [BabyEventKind],
+        rows: [CurrentStatusRowViewState],
+        lastSleep: LastSleepSummaryViewState?
     ) {
+        self.visibleEventKinds = visibleEventKinds
+        self.rows = rows
         self.lastSleep = lastSleep
-        self.lastBreastFeed = lastBreastFeed
-        self.lastBottleFeed = lastBottleFeed
-        self.feedsTodayCount = feedsTodayCount
-        self.lastNappy = lastNappy
+    }
+
+    public func row(for kind: BabyEventKind) -> CurrentStatusRowViewState? {
+        rows.first { $0.kind == kind }
     }
 }

--- a/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/CurrentStatusRowViewState.swift
+++ b/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/CurrentStatusRowViewState.swift
@@ -1,0 +1,24 @@
+import BabyTrackerDomain
+import Foundation
+
+public struct CurrentStatusRowViewState: Equatable, Sendable {
+    public let kind: BabyEventKind
+    public let title: String
+    public let detailText: String?
+    public let elapsedSinceDate: Date
+    public let emptyValueText: String
+
+    public init(
+        kind: BabyEventKind,
+        title: String,
+        detailText: String?,
+        elapsedSinceDate: Date,
+        emptyValueText: String
+    ) {
+        self.kind = kind
+        self.title = title
+        self.detailText = detailText
+        self.elapsedSinceDate = elapsedSinceDate
+        self.emptyValueText = emptyValueText
+    }
+}

--- a/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/UseCases/BuildCurrentStatusViewStateUseCase.swift
+++ b/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/UseCases/BuildCurrentStatusViewStateUseCase.swift
@@ -2,74 +2,99 @@ import BabyTrackerDomain
 import Foundation
 
 /// Produces the current-status card state for the home screen by composing
-/// the per-type feed calculators, `LastNappySummaryCalculator`, and `LastSleepSummaryCalculator`.
+/// generic per-kind latest-event rows plus the explicit active-sleep exception.
 public enum BuildCurrentStatusViewStateUseCase {
     public static func execute(
         events: [BabyEvent],
         child: Child,
+        enabledEventKinds: Set<BabyEventKind>,
         activeSleep: SleepEvent? = nil,
         day: Date = .now,
         calendar: Calendar = .autoupdatingCurrent
     ) -> CurrentStatusCardViewState {
-        let feedSummary = FeedSummaryCalculator.makeSummary(
-            from: events,
-            preferredFeedVolumeUnit: child.preferredFeedVolumeUnit,
-            on: day,
-            calendar: calendar
-        )
-        let lastNappy = LastNappySummaryCalculator.makeSummary(from: events)
+        let _ = day
+        let _ = calendar
+
+        let visibleEventKinds = BabyEventKind.allCases.filter(enabledEventKinds.contains)
         let lastSleep = LastSleepSummaryCalculator.makeSummary(from: events, activeSleep: activeSleep)
-        let lastBreastFeed = lastBreastFeedSummary(from: events)
-        let lastBottleFeed = lastBottleFeedSummary(from: events, preferredFeedVolumeUnit: child.preferredFeedVolumeUnit)
+
+        let rows = visibleEventKinds.compactMap { kind -> CurrentStatusRowViewState? in
+            switch kind {
+            case .sleep:
+                return completedSleepRow(from: lastSleep)
+            case .bath, .breastFeed, .bottleFeed, .nappy:
+                return latestEventRow(
+                    for: kind,
+                    events: events,
+                    preferredFeedVolumeUnit: child.preferredFeedVolumeUnit
+                )
+            }
+        }
 
         return CurrentStatusCardViewState(
-            lastSleep: lastSleep,
-            lastBreastFeed: lastBreastFeed,
-            lastBottleFeed: lastBottleFeed,
-            feedsTodayCount: feedSummary?.feedsTodayCount ?? 0,
-            lastNappy: lastNappy
+            visibleEventKinds: visibleEventKinds,
+            rows: rows,
+            lastSleep: lastSleep
         )
     }
 
-    private static func lastBreastFeedSummary(from events: [BabyEvent]) -> LastEventSummaryViewState? {
-        let breastFeeds = events.compactMap { event -> BreastFeedEvent? in
-            guard case let .breastFeed(feed) = event else { return nil }
-            return feed
-        }
-
-        guard let last = breastFeeds.max(by: { $0.metadata.occurredAt < $1.metadata.occurredAt }) else {
-            return nil
-        }
-
-        return LastEventSummaryViewState(
-            kind: .breastFeed,
-            title: BabyEventPresentation.title(for: .breastFeed),
-            detailText: BabyEventPresentation.detailText(for: .breastFeed(last)),
-            occurredAt: last.metadata.occurredAt
-        )
-    }
-
-    private static func lastBottleFeedSummary(
-        from events: [BabyEvent],
+    private static func latestEventRow(
+        for kind: BabyEventKind,
+        events: [BabyEvent],
         preferredFeedVolumeUnit: FeedVolumeUnit
-    ) -> LastEventSummaryViewState? {
-        let bottleFeeds = events.compactMap { event -> BottleFeedEvent? in
-            guard case let .bottleFeed(feed) = event else { return nil }
-            return feed
-        }
-
-        guard let last = bottleFeeds.max(by: { $0.metadata.occurredAt < $1.metadata.occurredAt }) else {
+    ) -> CurrentStatusRowViewState? {
+        guard let lastEvent = events
+            .filter({ $0.kind == kind })
+            .max(by: { $0.metadata.occurredAt < $1.metadata.occurredAt }) else {
             return nil
         }
 
-        return LastEventSummaryViewState(
-            kind: .bottleFeed,
-            title: BabyEventPresentation.title(for: .bottleFeed),
+        return CurrentStatusRowViewState(
+            kind: kind,
+            title: rowTitle(for: kind),
             detailText: BabyEventPresentation.detailText(
-                for: .bottleFeed(last),
+                for: lastEvent,
                 preferredFeedVolumeUnit: preferredFeedVolumeUnit
             ),
-            occurredAt: last.metadata.occurredAt
+            elapsedSinceDate: lastEvent.metadata.occurredAt,
+            emptyValueText: emptyValueText(for: kind)
         )
+    }
+
+    private static func completedSleepRow(
+        from summary: LastSleepSummaryViewState?
+    ) -> CurrentStatusRowViewState? {
+        guard let summary,
+              summary.isActive == false,
+              let endedAt = summary.endedAt else {
+            return nil
+        }
+
+        let minutes = max(1, Int(endedAt.timeIntervalSince(summary.startedAt) / 60))
+
+        return CurrentStatusRowViewState(
+            kind: .sleep,
+            title: rowTitle(for: .sleep),
+            detailText: DurationText.short(minutes: minutes, minuteStyle: .word),
+            elapsedSinceDate: endedAt,
+            emptyValueText: emptyValueText(for: .sleep)
+        )
+    }
+
+    static func rowTitle(for kind: BabyEventKind) -> String {
+        "Last \(BabyEventPresentation.title(for: kind).lowercased())"
+    }
+
+    static func emptyValueText(for kind: BabyEventKind) -> String {
+        switch kind {
+        case .bath:
+            "No baths yet"
+        case .breastFeed, .bottleFeed:
+            "No feeds yet"
+        case .sleep:
+            "No sleep yet"
+        case .nappy:
+            "No nappies yet"
+        }
     }
 }

--- a/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/ViewModels/HomeViewModel.swift
+++ b/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/ViewModels/HomeViewModel.swift
@@ -21,9 +21,18 @@ public final class HomeViewModel {
 
     public var currentStatus: CurrentStatusCardViewState {
         guard let child = appModel.currentChild else {
-            return CurrentStatusCardViewState(lastSleep: nil, lastBreastFeed: nil, lastBottleFeed: nil, feedsTodayCount: 0, lastNappy: nil)
+            return CurrentStatusCardViewState(
+                visibleEventKinds: BabyEventKind.allCases,
+                rows: [],
+                lastSleep: nil
+            )
         }
-        return BuildCurrentStatusViewStateUseCase.execute(events: appModel.events, child: child, activeSleep: appModel.activeSleep)
+        return BuildCurrentStatusViewStateUseCase.execute(
+            events: appModel.events,
+            child: child,
+            enabledEventKinds: appModel.enabledEventKinds,
+            activeSleep: appModel.activeSleep
+        )
     }
 
     public var recentEvents: [EventCardViewState] {

--- a/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/ChildHomeView.swift
+++ b/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/ChildHomeView.swift
@@ -227,10 +227,7 @@ public struct ChildHomeView: View {
             .buttonStyle(.plain)
 
             if statusSectionExpanded {
-                CurrentStatusCardView(
-                    status: viewModel.currentStatus,
-                    enabledEventKinds: model.enabledEventKinds
-                )
+                CurrentStatusCardView(status: viewModel.currentStatus)
                 .padding(.top, 10)
                 .transition(.opacity.combined(with: .scale(scale: 0.97, anchor: .top)))
             }

--- a/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/CurrentStatusCardView.swift
+++ b/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/CurrentStatusCardView.swift
@@ -3,106 +3,38 @@ import SwiftUI
 
 public struct CurrentStatusCardView: View {
     let status: CurrentStatusCardViewState
-    let enabledEventKinds: Set<BabyEventKind>
 
-    public init(
-        status: CurrentStatusCardViewState,
-        enabledEventKinds: Set<BabyEventKind> = Set(BabyEventKind.allCases)
-    ) {
+    public init(status: CurrentStatusCardViewState) {
         self.status = status
-        self.enabledEventKinds = enabledEventKinds
     }
 
-    private var showSleepRow: Bool {
-        enabledEventKinds.contains(.sleep) && status.lastSleep?.isActive != true
-    }
-
-    private var showFeedsToday: Bool {
-        enabledEventKinds.contains(.breastFeed) || enabledEventKinds.contains(.bottleFeed)
+    private var displayKinds: [BabyEventKind] {
+        status.visibleEventKinds.filter { kind in
+            kind != .sleep || status.lastSleep?.isActive != true
+        }
     }
 
     public var body: some View {
         VStack(alignment: .leading, spacing: 14) {
-            if showSleepRow {
-                statusRow(
-                    title: "Last sleep",
-                    subtitle: lastSleepDetailText,
-                    systemImage: BabyEventStyle.systemImage(for: .sleep),
-                    iconTint: BabyEventStyle.accentColor(for: .sleep),
-                    identifier: "current-status-sleep"
-                ) {
-                    sleepRowValue
-                }
-                .transition(.opacity.combined(with: .move(edge: .bottom)))
+            ForEach(Array(displayKinds.enumerated()), id: \.element) { index, kind in
+                let row = status.row(for: kind)
 
-                Divider()
-                    .transition(.opacity.combined(with: .move(edge: .bottom)))
-            }
-
-            if enabledEventKinds.contains(.breastFeed) {
                 statusRow(
-                    title: "Last breast feed",
-                    subtitle: status.lastBreastFeed?.detailText,
-                    systemImage: BabyEventStyle.systemImage(for: .breastFeed),
-                    iconTint: BabyEventStyle.accentColor(for: .breastFeed),
-                    identifier: "current-status-last-breast-feed"
+                    title: row?.title ?? BuildCurrentStatusViewStateUseCase.rowTitle(for: kind),
+                    subtitle: row?.detailText,
+                    systemImage: BabyEventStyle.systemImage(for: kind),
+                    iconTint: BabyEventStyle.accentColor(for: kind),
+                    identifier: accessibilityIdentifier(for: kind)
                 ) {
-                    if let lastBreastFeed = status.lastBreastFeed {
-                        relativeTimeText(for: lastBreastFeed.occurredAt)
+                    if let row {
+                        relativeTimeText(for: row.elapsedSinceDate)
                     } else {
-                        Text("No feeds yet")
+                        Text(BuildCurrentStatusViewStateUseCase.emptyValueText(for: kind))
                     }
                 }
 
-                Divider()
-            }
-
-            if enabledEventKinds.contains(.bottleFeed) {
-                statusRow(
-                    title: "Last bottle feed",
-                    subtitle: status.lastBottleFeed?.detailText,
-                    systemImage: BabyEventStyle.systemImage(for: .bottleFeed),
-                    iconTint: BabyEventStyle.accentColor(for: .bottleFeed),
-                    identifier: "current-status-last-bottle-feed"
-                ) {
-                    if let lastBottleFeed = status.lastBottleFeed {
-                        relativeTimeText(for: lastBottleFeed.occurredAt)
-                    } else {
-                        Text("No feeds yet")
-                    }
-                }
-
-                Divider()
-            }
-
-            if enabledEventKinds.contains(.nappy) {
-                statusRow(
-                    title: "Last nappy",
-                    subtitle: status.lastNappy?.detailText,
-                    systemImage: BabyEventStyle.systemImage(for: .nappy),
-                    iconTint: BabyEventStyle.accentColor(for: .nappy),
-                    identifier: "current-status-last-nappy"
-                ) {
-                    if let lastNappy = status.lastNappy {
-                        relativeTimeText(for: lastNappy.occurredAt)
-                    } else {
-                        Text("No nappies yet")
-                    }
-                }
-
-                if showFeedsToday {
+                if index < displayKinds.count - 1 {
                     Divider()
-                }
-            }
-
-            if showFeedsToday {
-                statusRow(
-                    title: "Feeds today",
-                    systemImage: "list.number",
-                    iconTint: BabyEventStyle.accentColor(for: .breastFeed),
-                    identifier: "current-status-feeds-today"
-                ) {
-                    Text("\(status.feedsTodayCount)")
                 }
             }
         }
@@ -116,29 +48,13 @@ public struct CurrentStatusCardView: View {
             RoundedRectangle(cornerRadius: 18, style: .continuous)
                 .stroke(Color(.separator).opacity(0.35), lineWidth: 1)
         )
-        .animation(.easeInOut(duration: 0.35), value: showSleepRow)
-        .animation(.easeInOut(duration: 0.35), value: enabledEventKinds)
+        .animation(.easeInOut(duration: 0.35), value: displayKinds)
         .accessibilityElement(children: .contain)
         .accessibilityIdentifier("current-status-card")
     }
 
-    private var lastSleepDetailText: String? {
-        guard let sleep = status.lastSleep,
-              !sleep.isActive,
-              let endedAt = sleep.endedAt else {
-            return nil
-        }
-        let minutes = max(1, Int(endedAt.timeIntervalSince(sleep.startedAt) / 60))
-        return DurationText.short(minutes: minutes, minuteStyle: .word)
-    }
-
-    @ViewBuilder
-    private var sleepRowValue: some View {
-        if let endedAt = status.lastSleep?.endedAt {
-            relativeTimeText(for: endedAt)
-        } else {
-            Text("No sleep yet")
-        }
+    private func accessibilityIdentifier(for kind: BabyEventKind) -> String {
+        "current-status-\(kind.rawValue)"
     }
 
     private func statusRow<Value: View>(
@@ -185,48 +101,107 @@ public struct CurrentStatusCardView: View {
 }
 
 #Preview("Active sleep (sleep row hidden)") {
-    CurrentStatusCardView(status: CurrentStatusCardViewState(
-        lastSleep: LastSleepSummaryViewState(isActive: true, startedAt: Date().addingTimeInterval(-4_500), endedAt: nil),
-        lastBreastFeed: LastEventSummaryViewState(kind: .breastFeed, title: "Breast Feed", detailText: "20 min • Left", occurredAt: Date().addingTimeInterval(-5_400)),
-        lastBottleFeed: LastEventSummaryViewState(kind: .bottleFeed, title: "Bottle Feed", detailText: "120 mL • Formula", occurredAt: Date().addingTimeInterval(-9_000)),
-        feedsTodayCount: 4,
-        lastNappy: LastNappySummaryViewState(title: "Nappy", detailText: "Poo • Medium • Yellow", occurredAt: Date().addingTimeInterval(-7_200))
-    ))
+    CurrentStatusCardView(
+        status: CurrentStatusCardViewState(
+            visibleEventKinds: BabyEventKind.allCases,
+            rows: [
+                CurrentStatusRowViewState(
+                    kind: .breastFeed,
+                    title: "Last breast feed",
+                    detailText: "20 min • Left",
+                    elapsedSinceDate: Date().addingTimeInterval(-5_400),
+                    emptyValueText: "No feeds yet"
+                ),
+                CurrentStatusRowViewState(
+                    kind: .bottleFeed,
+                    title: "Last bottle feed",
+                    detailText: "120 mL • Formula",
+                    elapsedSinceDate: Date().addingTimeInterval(-9_000),
+                    emptyValueText: "No feeds yet"
+                ),
+                CurrentStatusRowViewState(
+                    kind: .nappy,
+                    title: "Last nappy",
+                    detailText: "Poo • Medium • Yellow",
+                    elapsedSinceDate: Date().addingTimeInterval(-7_200),
+                    emptyValueText: "No nappies yet"
+                ),
+                CurrentStatusRowViewState(
+                    kind: .bath,
+                    title: "Last bath",
+                    detailText: "Shampoo • Soap",
+                    elapsedSinceDate: Date().addingTimeInterval(-10_200),
+                    emptyValueText: "No baths yet"
+                ),
+            ],
+            lastSleep: LastSleepSummaryViewState(
+                isActive: true,
+                startedAt: Date().addingTimeInterval(-4_500),
+                endedAt: nil
+            )
+        )
+    )
     .padding()
 }
 
-#Preview("Not sleeping") {
-    CurrentStatusCardView(status: CurrentStatusCardViewState(
-        lastSleep: LastSleepSummaryViewState(isActive: false, startedAt: Date().addingTimeInterval(-18_000), endedAt: Date().addingTimeInterval(-10_800)),
-        lastBreastFeed: LastEventSummaryViewState(kind: .breastFeed, title: "Breast Feed", detailText: "15 min • Right", occurredAt: Date().addingTimeInterval(-3_600)),
-        lastBottleFeed: LastEventSummaryViewState(kind: .bottleFeed, title: "Bottle Feed", detailText: "180 mL • Breast Milk", occurredAt: Date().addingTimeInterval(-6_300)),
-        feedsTodayCount: 6,
-        lastNappy: LastNappySummaryViewState(title: "Nappy", detailText: "Pee • Light", occurredAt: Date().addingTimeInterval(-5_400))
-    ))
+#Preview("Mixed kinds including Bath") {
+    CurrentStatusCardView(
+        status: CurrentStatusCardViewState(
+            visibleEventKinds: BabyEventKind.allCases,
+            rows: [
+                CurrentStatusRowViewState(
+                    kind: .bath,
+                    title: "Last bath",
+                    detailText: "Bath only",
+                    elapsedSinceDate: Date().addingTimeInterval(-1_800),
+                    emptyValueText: "No baths yet"
+                ),
+                CurrentStatusRowViewState(
+                    kind: .breastFeed,
+                    title: "Last breast feed",
+                    detailText: "15 min • Right",
+                    elapsedSinceDate: Date().addingTimeInterval(-3_600),
+                    emptyValueText: "No feeds yet"
+                ),
+                CurrentStatusRowViewState(
+                    kind: .bottleFeed,
+                    title: "Last bottle feed",
+                    detailText: "180 mL • Breast Milk",
+                    elapsedSinceDate: Date().addingTimeInterval(-6_300),
+                    emptyValueText: "No feeds yet"
+                ),
+                CurrentStatusRowViewState(
+                    kind: .sleep,
+                    title: "Last sleep",
+                    detailText: "2 hr",
+                    elapsedSinceDate: Date().addingTimeInterval(-10_800),
+                    emptyValueText: "No sleep yet"
+                ),
+                CurrentStatusRowViewState(
+                    kind: .nappy,
+                    title: "Last nappy",
+                    detailText: "Pee • Light",
+                    elapsedSinceDate: Date().addingTimeInterval(-5_400),
+                    emptyValueText: "No nappies yet"
+                ),
+            ],
+            lastSleep: LastSleepSummaryViewState(
+                isActive: false,
+                startedAt: Date().addingTimeInterval(-18_000),
+                endedAt: Date().addingTimeInterval(-10_800)
+            )
+        )
+    )
     .padding()
 }
 
 #Preview("No data") {
-    CurrentStatusCardView(status: CurrentStatusCardViewState(
-        lastSleep: nil,
-        lastBreastFeed: nil,
-        lastBottleFeed: nil,
-        feedsTodayCount: 0,
-        lastNappy: nil
-    ))
-    .padding()
-}
-
-#Preview("Bottle only (breast feed hidden)") {
     CurrentStatusCardView(
         status: CurrentStatusCardViewState(
-            lastSleep: LastSleepSummaryViewState(isActive: false, startedAt: Date().addingTimeInterval(-18_000), endedAt: Date().addingTimeInterval(-10_800)),
-            lastBreastFeed: nil,
-            lastBottleFeed: LastEventSummaryViewState(kind: .bottleFeed, title: "Bottle Feed", detailText: "120 mL • Formula", occurredAt: Date().addingTimeInterval(-3_600)),
-            feedsTodayCount: 3,
-            lastNappy: LastNappySummaryViewState(title: "Nappy", detailText: "Pee • Light", occurredAt: Date().addingTimeInterval(-5_400))
-        ),
-        enabledEventKinds: [.sleep, .bottleFeed, .nappy]
+            visibleEventKinds: [.bath, .bottleFeed, .sleep, .nappy],
+            rows: [],
+            lastSleep: nil
+        )
     )
     .padding()
 }

--- a/docs/plans/106-home-since-last-event-driven-refactor.md
+++ b/docs/plans/106-home-since-last-event-driven-refactor.md
@@ -1,0 +1,18 @@
+# 106 - Home Since-Last Event-Driven Refactor
+
+## Summary
+Refactor the Home screen `Since last` card so its rows are derived from enabled event kinds instead of a fixed set of hardcoded metrics. The card should naturally include Bath when enabled, respect event visibility settings, and keep active sleep as the only intentional special case. This work implements GitHub issue `#246`.
+
+## Key Changes
+1. Replace the hardcoded `CurrentStatusCardViewState` fields with a row-driven structure that tracks enabled event kinds, event-backed rows, and the explicit sleep summary needed for active-sleep handling.
+2. Refactor `BuildCurrentStatusViewStateUseCase` to iterate `enabledEventKinds`, build generic latest-event rows for Bath, Breast Feed, Bottle Feed, and Nappy, and keep sleep as the only explicit exception.
+3. Remove the aggregate `Feeds today` row so the card remains a pure since-last surface.
+4. Update `HomeViewModel` and `CurrentStatusCardView` so the Home card renders generically from ordered event kinds and row data while preserving styling, empty placeholders, previews, and accessibility identifiers.
+5. Add regression coverage for Bath, hidden event kinds, independent feed rows, and active-sleep suppression.
+
+## Test Plan
+1. Verify the use case returns row data only for supported enabled event kinds and suppresses the completed sleep row while an active sleep exists.
+2. Verify Home status includes Bath naturally and updates when event visibility settings change.
+3. Verify the SwiftUI card still renders deterministic accessibility identifiers and readable empty placeholders for enabled kinds with no events.
+
+- [x] Complete


### PR DESCRIPTION
## Summary
- refactor the Home Since last card to derive rows from enabled event kinds
- remove the hardcoded Feeds today row and preserve active-sleep special handling
- add Bath coverage, previews, and regression tests for the event-driven status rows

## Testing
- xcodebuild test -scheme "Baby Tracker" -destination "platform=iOS Simulator,name=iPhone 17" -only-testing:"Baby TrackerTests/BuildCurrentStatusViewStateUseCaseTests" -only-testing:"Baby TrackerTests/AppModelTests"

Closes #246
Plan: docs/plans/106-home-since-last-event-driven-refactor.md