### PR TITLE
[codex] Reuse onboarding event checklist in settings

### DIFF
--- a/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/EventTypeChecklistCardView.swift
+++ b/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/EventTypeChecklistCardView.swift
@@ -1,0 +1,167 @@
+import BabyTrackerDomain
+import SwiftUI
+
+struct EventTypeChecklistCardView: View {
+    let model: AppModel
+    let animateOnAppear: Bool
+
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+    @State private var appearedMask = Array(repeating: false, count: BabyEventKind.allCases.count + 1)
+
+    var body: some View {
+        VStack(spacing: 0) {
+            ForEach(Array(BabyEventKind.allCases.enumerated()), id: \.element) { index, kind in
+                kindRow(kind, appearedIndex: index)
+
+                if kind != BabyEventKind.allCases.last {
+                    Divider()
+                        .padding(.leading, 60)
+                }
+            }
+
+            Divider()
+
+            resetRow
+        }
+        .background(
+            RoundedRectangle(cornerRadius: 18, style: .continuous)
+                .fill(Color(.secondarySystemGroupedBackground))
+        )
+        .clipShape(RoundedRectangle(cornerRadius: 18, style: .continuous))
+        .overlay(
+            RoundedRectangle(cornerRadius: 18, style: .continuous)
+                .stroke(Color(.separator).opacity(0.35), lineWidth: 1)
+        )
+        .onAppear {
+            guard animateOnAppear else {
+                appearedMask = Array(repeating: true, count: appearedMask.count)
+                return
+            }
+            staggerIn()
+        }
+    }
+
+    private func kindRow(_ kind: BabyEventKind, appearedIndex: Int) -> some View {
+        let isEnabled = model.enabledEventKinds.contains(kind)
+        let isOnlyEnabled = isEnabled && model.enabledEventKinds.count == 1
+
+        return Button {
+            guard !isOnlyEnabled else { return }
+            model.setEventKindEnabled(kind, isEnabled: !isEnabled)
+        } label: {
+            HStack(spacing: 14) {
+                Image(systemName: BabyEventStyle.systemImage(for: kind))
+                    .font(.body.weight(.semibold))
+                    .foregroundStyle(BabyEventStyle.accentColor(for: kind))
+                    .frame(width: 32, height: 32)
+                    .background(
+                        BabyEventStyle.backgroundColor(for: kind),
+                        in: RoundedRectangle(cornerRadius: 9, style: .continuous)
+                    )
+
+                VStack(alignment: .leading, spacing: 2) {
+                    Text(title(for: kind))
+                        .font(.body)
+                        .foregroundStyle(.primary)
+
+                    Text(description(for: kind))
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+
+                Spacer()
+
+                Image(systemName: isEnabled ? "checkmark.circle.fill" : "circle")
+                    .font(.title3)
+                    .foregroundStyle(isEnabled ? BabyEventStyle.accentColor(for: kind) : Color(.tertiaryLabel))
+                    .animation(.spring(response: 0.3, dampingFraction: 0.7), value: isEnabled)
+            }
+            .padding(.horizontal, 16)
+            .padding(.vertical, 14)
+            .contentShape(Rectangle())
+            .opacity(isOnlyEnabled ? 0.4 : 1.0)
+        }
+        .buttonStyle(.plain)
+        .accessibilityIdentifier("event-visibility-toggle-\(kind.rawValue)")
+        .opacity(appearedMask[appearedIndex] ? 1 : 0)
+        .offset(y: appearedMask[appearedIndex] ? 0 : 14)
+    }
+
+    private var resetRow: some View {
+        let allEnabled = model.enabledEventKinds.count == BabyEventKind.allCases.count
+        let resetIndex = BabyEventKind.allCases.count
+
+        return Button {
+            for kind in BabyEventKind.allCases {
+                model.setEventKindEnabled(kind, isEnabled: true)
+            }
+        } label: {
+            Text("Reset to all")
+                .font(.subheadline)
+                .foregroundStyle(allEnabled ? Color(.tertiaryLabel) : .secondary)
+                .frame(maxWidth: .infinity)
+                .padding(.vertical, 14)
+                .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .disabled(allEnabled)
+        .accessibilityIdentifier("event-visibility-reset-button")
+        .opacity(appearedMask[resetIndex] ? 1 : 0)
+        .offset(y: appearedMask[resetIndex] ? 0 : 10)
+    }
+
+    private func title(for kind: BabyEventKind) -> String {
+        switch kind {
+        case .bath: "Bath"
+        case .breastFeed: "Breast feed"
+        case .bottleFeed: "Bottle feed"
+        case .sleep: "Sleep"
+        case .nappy: "Nappy"
+        }
+    }
+
+    private func description(for kind: BabyEventKind) -> String {
+        switch kind {
+        case .bath: "Baths with shampoo and soap details"
+        case .breastFeed: "Nursing sessions and duration"
+        case .bottleFeed: "Formula and expressed milk"
+        case .sleep: "Naps and overnight sleeps"
+        case .nappy: "Wet and dirty nappy changes"
+        }
+    }
+
+    private func staggerIn() {
+        if reduceMotion {
+            appearedMask = Array(repeating: true, count: appearedMask.count)
+            return
+        }
+
+        Task { @MainActor in
+            try? await Task.sleep(for: .milliseconds(420))
+            for index in appearedMask.indices {
+                let delay = Double(index) * 0.08
+                withAnimation(.spring(response: 0.42, dampingFraction: 0.78).delay(delay)) {
+                    appearedMask[index] = true
+                }
+            }
+        }
+    }
+}
+
+#Preview("Static") {
+    EventTypeChecklistCardView(
+        model: ChildProfilePreviewFactory.makeModel(),
+        animateOnAppear: false
+    )
+    .padding()
+    .background(Color(.systemGroupedBackground))
+}
+
+#Preview("Animated") {
+    EventTypeChecklistCardView(
+        model: ChildProfilePreviewFactory.makeModel(),
+        animateOnAppear: true
+    )
+    .padding()
+    .background(Color(.systemGroupedBackground))
+}

--- a/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/EventVisibilitySettingsView.swift
+++ b/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/EventVisibilitySettingsView.swift
@@ -1,4 +1,3 @@
-import BabyTrackerDomain
 import SwiftUI
 
 public struct EventVisibilitySettingsView: View {
@@ -9,37 +8,32 @@ public struct EventVisibilitySettingsView: View {
     }
 
     public var body: some View {
-        List {
-            Section {
-                ForEach(BabyEventKind.allCases, id: \.self) { kind in
-                    eventToggleRow(for: kind)
+        ScrollView {
+            VStack(alignment: .leading, spacing: 24) {
+                VStack(alignment: .leading, spacing: 12) {
+                    Text("Choose what you'd like to track")
+                        .font(.title2.weight(.bold))
+
+                    Text("Turn event types on or off across the app. Your existing data stays safe, and you can re-enable any event again whenever you need it.")
+                        .font(.body)
+                        .foregroundStyle(.secondary)
+                        .fixedSize(horizontal: false, vertical: true)
                 }
-            } footer: {
-                Text("Disabled events stay hidden across the app, but your existing data is never deleted. Re-enable an event at any time to see it again.")
+
+                EventTypeChecklistCardView(
+                    model: model,
+                    animateOnAppear: false
+                )
             }
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .padding(.horizontal, 20)
+            .padding(.top, 24)
+            .padding(.bottom, 12)
         }
-        .listStyle(.insetGrouped)
+        .background(Color(.systemGroupedBackground))
+        .scrollBounceBehavior(.basedOnSize)
         .navigationTitle("Customize Events")
         .navigationBarTitleDisplayMode(.inline)
-    }
-
-    private func eventToggleRow(for kind: BabyEventKind) -> some View {
-        let isEnabled = model.isEventKindEnabled(kind)
-        let isOnlyEnabled = isEnabled && model.enabledEventKinds.count == 1
-
-        return Toggle(isOn: Binding(
-            get: { model.isEventKindEnabled(kind) },
-            set: { model.setEventKindEnabled(kind, isEnabled: $0) }
-        )) {
-            HStack(spacing: 12) {
-                Image(systemName: BabyEventStyle.systemImage(for: kind))
-                    .foregroundStyle(BabyEventStyle.accentColor(for: kind))
-                    .frame(width: 24)
-                Text(BabyEventPresentation.title(for: kind))
-            }
-        }
-        .disabled(isOnlyEnabled)
-        .accessibilityIdentifier("event-visibility-toggle-\(kind.rawValue)")
     }
 }
 

--- a/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/OnboardingCustomizeEventsStepView.swift
+++ b/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/OnboardingCustomizeEventsStepView.swift
@@ -1,11 +1,10 @@
-import BabyTrackerDomain
 import SwiftUI
 
 struct OnboardingCustomizeEventsStepView: View {
     let model: AppModel
 
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
-    @State private var appearedMask: [Bool] = Array(repeating: false, count: 2 + BabyEventKind.allCases.count + 1)
+    @State private var appearedMask = Array(repeating: false, count: 2)
 
     var body: some View {
         ScrollView {
@@ -43,119 +42,10 @@ struct OnboardingCustomizeEventsStepView: View {
     // MARK: - Kind card
 
     private var kindCard: some View {
-        VStack(spacing: 0) {
-            ForEach(Array(BabyEventKind.allCases.enumerated()), id: \.element) { index, kind in
-                kindRow(kind, appearedIndex: index + 2)
-
-                if kind != BabyEventKind.allCases.last {
-                    Divider()
-                        .padding(.leading, 60)
-                }
-            }
-
-            Divider()
-
-            resetRow
-        }
-        .background(
-            RoundedRectangle(cornerRadius: 18, style: .continuous)
-                .fill(Color(.secondarySystemGroupedBackground))
+        EventTypeChecklistCardView(
+            model: model,
+            animateOnAppear: true
         )
-        .clipShape(RoundedRectangle(cornerRadius: 18, style: .continuous))
-        .overlay(
-            RoundedRectangle(cornerRadius: 18, style: .continuous)
-                .stroke(Color(.separator).opacity(0.35), lineWidth: 1)
-        )
-    }
-
-    // MARK: - Kind row
-
-    private func kindRow(_ kind: BabyEventKind, appearedIndex: Int) -> some View {
-        let isEnabled = model.enabledEventKinds.contains(kind)
-        let isOnlyEnabled = isEnabled && model.enabledEventKinds.count == 1
-
-        return Button {
-            guard !isOnlyEnabled else { return }
-            model.setEventKindEnabled(kind, isEnabled: !isEnabled)
-        } label: {
-            HStack(spacing: 14) {
-                Image(systemName: BabyEventStyle.systemImage(for: kind))
-                    .font(.body.weight(.semibold))
-                    .foregroundStyle(BabyEventStyle.accentColor(for: kind))
-                    .frame(width: 32, height: 32)
-                    .background(BabyEventStyle.backgroundColor(for: kind), in: RoundedRectangle(cornerRadius: 9, style: .continuous))
-
-                VStack(alignment: .leading, spacing: 2) {
-                    Text(kindTitle(kind))
-                        .font(.body)
-                        .foregroundStyle(.primary)
-
-                    Text(kindDescription(kind))
-                        .font(.caption)
-                        .foregroundStyle(.secondary)
-                }
-
-                Spacer()
-
-                Image(systemName: isEnabled ? "checkmark.circle.fill" : "circle")
-                    .font(.title3)
-                    .foregroundStyle(isEnabled ? BabyEventStyle.accentColor(for: kind) : Color(.tertiaryLabel))
-                    .animation(.spring(response: 0.3, dampingFraction: 0.7), value: isEnabled)
-            }
-            .padding(.horizontal, 16)
-            .padding(.vertical, 14)
-            .contentShape(Rectangle())
-            .opacity(isOnlyEnabled ? 0.4 : 1.0)
-        }
-        .buttonStyle(.plain)
-        .opacity(appearedMask[appearedIndex] ? 1 : 0)
-        .offset(y: appearedMask[appearedIndex] ? 0 : 14)
-    }
-
-    // MARK: - Reset row
-
-    private var resetRow: some View {
-        let allEnabled = model.enabledEventKinds.count == BabyEventKind.allCases.count
-        let resetIndex = 2 + BabyEventKind.allCases.count
-
-        return Button {
-            for kind in BabyEventKind.allCases {
-                model.setEventKindEnabled(kind, isEnabled: true)
-            }
-        } label: {
-            Text("Reset to all")
-                .font(.subheadline)
-                .foregroundStyle(allEnabled ? Color(.tertiaryLabel) : .secondary)
-                .frame(maxWidth: .infinity)
-                .padding(.vertical, 14)
-                .contentShape(Rectangle())
-        }
-        .buttonStyle(.plain)
-        .disabled(allEnabled)
-        .opacity(appearedMask[resetIndex] ? 1 : 0)
-        .offset(y: appearedMask[resetIndex] ? 0 : 10)
-    }
-
-    // MARK: - Copy
-
-    private func kindTitle(_ kind: BabyEventKind) -> String {
-        switch kind {
-        case .bath: "Bath"
-        case .breastFeed: "Breast feed"
-        case .bottleFeed: "Bottle feed"
-        case .sleep: "Sleep"
-        case .nappy: "Nappy"
-        }
-    }
-
-    private func kindDescription(_ kind: BabyEventKind) -> String {
-        switch kind {
-        case .bath: "Baths with shampoo and soap details"
-        case .breastFeed: "Nursing sessions and duration"
-        case .bottleFeed: "Formula and expressed milk"
-        case .sleep: "Naps and overnight sleeps"
-        case .nappy: "Wet and dirty nappy changes"
-        }
     }
 
     // MARK: - Entrance animation
@@ -172,12 +62,6 @@ struct OnboardingCustomizeEventsStepView: View {
             }
             withAnimation(.spring(response: 0.5, dampingFraction: 0.82).delay(0.08)) {
                 appearedMask[1] = true
-            }
-            for index in 2..<appearedMask.count {
-                let delay = Double(index - 2) * 0.08
-                withAnimation(.spring(response: 0.42, dampingFraction: 0.78).delay(delay)) {
-                    appearedMask[index] = true
-                }
             }
         }
     }

--- a/docs/plans/107-settings-event-type-checklist.md
+++ b/docs/plans/107-settings-event-type-checklist.md
@@ -1,0 +1,9 @@
+# 107 Settings Event Type Checklist
+
+1. Reuse the richer onboarding event-type checklist UI for the settings event visibility screen instead of maintaining a separate plain toggle list.
+2. Extract the shared event-type selection card into a focused SwiftUI view so onboarding and settings stay visually aligned without duplicating row layout and copy.
+3. Keep the existing event visibility behavior intact, including preventing the last enabled event type from being turned off and allowing a reset back to all event types.
+4. Preserve the onboarding presentation while adapting the settings screen to use the fuller checklist-style layout and guidance copy.
+5. Build the affected app target or package path to confirm the refactor compiles cleanly.
+
+- [x] Complete


### PR DESCRIPTION
## Summary
- reuse the richer onboarding event-type checklist UI in Settings
- extract the shared event checklist card so onboarding and settings stay aligned
- add plan `docs/plans/107-settings-event-type-checklist.md`

## Why
The settings screen was still using a simpler toggle list, while onboarding had the fuller checklist presentation. Reusing the onboarding-style control keeps the app more consistent and gives Settings the clearer, more descriptive event selection UI.

## Validation
- `xcodebuild build -scheme 'BabyTrackerFeature' -destination 'generic/platform=iOS Simulator'`

## Notes
- No GitHub issue was created because this was a small, focused UI reuse change.
- Plan: `docs/plans/107-settings-event-type-checklist.md`
