### PR TITLE
[codex] Redesign timeline day scrolling

### DIFF
--- a/Baby TrackerUITests/Baby_TrackerUITests.swift
+++ b/Baby TrackerUITests/Baby_TrackerUITests.swift
@@ -509,8 +509,8 @@ final class Baby_TrackerUITests: XCTestCase {
 
         openTimelineTab(in: app)
 
-        let timelineScrollView = app.scrollViews["timeline-scroll-view"]
-        XCTAssertTrue(timelineScrollView.waitForExistence(timeout: 5))
+        let timelineVerticalScrollView = app.scrollViews["timeline-vertical-scroll-view"]
+        XCTAssertTrue(timelineVerticalScrollView.waitForExistence(timeout: 5))
 
         let todayTitle = app.staticTexts["timeline-day-title"]
         XCTAssertTrue(todayTitle.waitForExistence(timeout: 5))
@@ -523,18 +523,18 @@ final class Baby_TrackerUITests: XCTestCase {
         let sundayButton = app.buttons["timeline-weekday-0"]
         XCTAssertTrue(sundayButton.waitForExistence(timeout: 5))
 
-        timelineScrollView.swipeRight()
+        app.buttons["timeline-previous-day-button"].tap()
 
         XCTAssertTrue(app.staticTexts["timeline-empty-state"].waitForExistence(timeout: 5))
         XCTAssertTrue(jumpToTodayButton.isEnabled)
 
-        timelineScrollView.swipeLeft()
+        jumpToTodayButton.tap()
 
         XCTAssertEqual(app.staticTexts["timeline-day-title"].label, "Today")
         XCTAssertFalse(jumpToTodayButton.isEnabled)
         XCTAssertTrue(
             app.buttons.matching(
-                NSPredicate(format: "identifier BEGINSWITH %@", "timeline-event-")
+                NSPredicate(format: "identifier BEGINSWITH %@", "timeline-day-grid-item-")
             ).firstMatch.waitForExistence(timeout: 5)
         )
     }
@@ -546,9 +546,8 @@ final class Baby_TrackerUITests: XCTestCase {
 
         openTimelineTab(in: app)
 
-        let timelineScrollView = app.scrollViews["timeline-scroll-view"]
-        XCTAssertTrue(timelineScrollView.waitForExistence(timeout: 5))
-        timelineScrollView.swipeRight()
+        XCTAssertTrue(app.scrollViews["timeline-vertical-scroll-view"].waitForExistence(timeout: 5))
+        app.buttons["timeline-previous-day-button"].tap()
 
         XCTAssertTrue(app.buttons["timeline-jump-to-today-button"].waitForExistence(timeout: 5))
 
@@ -574,7 +573,7 @@ final class Baby_TrackerUITests: XCTestCase {
         openTimelineTab(in: app)
 
         let timelineEvent = app.buttons.matching(
-            NSPredicate(format: "identifier BEGINSWITH %@", "timeline-event-")
+            NSPredicate(format: "identifier BEGINSWITH %@", "timeline-day-grid-item-")
         ).firstMatch
         XCTAssertTrue(timelineEvent.waitForExistence(timeout: 5))
         timelineEvent.tap()
@@ -596,12 +595,24 @@ final class Baby_TrackerUITests: XCTestCase {
         openTimelineTab(in: app)
 
         let activeSleepEvent = app.buttons.matching(
-            NSPredicate(format: "identifier BEGINSWITH %@", "timeline-event-")
+            NSPredicate(format: "identifier BEGINSWITH %@", "timeline-day-grid-item-")
         ).firstMatch
         XCTAssertTrue(activeSleepEvent.waitForExistence(timeout: 5))
         activeSleepEvent.tap()
 
         XCTAssertTrue(app.buttons["save-sleep-button"].waitForExistence(timeout: 5))
+    }
+
+    @MainActor
+    func testTimelineDayModeShowsStickyHeaderAndHorizontalScrollArea() throws {
+        let app = makeApp(scenario: "mixedEventsPreview")
+        app.launch()
+
+        openTimelineTab(in: app)
+
+        XCTAssertTrue(app.scrollViews["timeline-horizontal-scroll-view"].waitForExistence(timeout: 5))
+        XCTAssertTrue(app.scrollViews["timeline-sticky-header"].waitForExistence(timeout: 5))
+        XCTAssertTrue(app.scrollViews["timeline-vertical-scroll-view"].waitForExistence(timeout: 5))
     }
 
     @MainActor

--- a/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/TimelineDayGridPageView.swift
+++ b/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/TimelineDayGridPageView.swift
@@ -3,53 +3,79 @@ import SwiftUI
 public struct TimelineDayGridPageView: View {
     let page: TimelineDayGridPageState
     let canManageEvents: Bool
+    @Binding var horizontalScrollOffset: CGFloat
     let openItem: (TimelineDayGridItemViewState) -> Void
     let deleteItem: (TimelineDayGridItemViewState) -> Void
 
     public init(
         page: TimelineDayGridPageState,
         canManageEvents: Bool,
+        horizontalScrollOffset: Binding<CGFloat>,
         openItem: @escaping (TimelineDayGridItemViewState) -> Void,
         deleteItem: @escaping (TimelineDayGridItemViewState) -> Void
     ) {
         self.page = page
         self.canManageEvents = canManageEvents
+        self._horizontalScrollOffset = horizontalScrollOffset
         self.openItem = openItem
         self.deleteItem = deleteItem
     }
 
     public var body: some View {
-        ScrollViewReader { proxy in
-            ScrollView {
-                VStack(alignment: .leading, spacing: 16) {
-                    if page.grid == nil {
-                        emptyState(
-                            title: page.emptyStateTitle,
-                            message: page.emptyStateMessage
-                        )
-                    }
+        GeometryReader { geometry in
+            let contentWidth = max(0, geometry.size.width - 24)
 
-                    if let grid = page.grid {
-                        TimelineDayGridView(
-                            day: page.date,
-                            grid: grid,
-                            canManageEvents: canManageEvents,
-                            openItem: openItem,
-                            deleteItem: deleteItem
-                        )
+            VStack(spacing: 0) {
+                if let grid = page.grid {
+                    TimelineDayGridHeaderView(
+                        grid: grid,
+                        availableWidth: contentWidth,
+                        horizontalScrollOffset: $horizontalScrollOffset
+                    )
+                    .padding(.horizontal, 12)
+                    .padding(.top, 8)
+                    .padding(.bottom, 12)
+                    .background(.regularMaterial)
+                    .overlay(alignment: .bottom) {
+                        Divider()
                     }
                 }
-                .padding(.horizontal, 12)
-                .padding(.top, 8)
-                .padding(.bottom, 14)
-            }
-            .accessibilityIdentifier("timeline-scroll-view")
-            .background(Color(.systemGroupedBackground).ignoresSafeArea())
-            .onAppear {
-                scrollToVisibleHour(using: proxy)
-            }
-            .onChange(of: page.date) { _, _ in
-                scrollToVisibleHour(using: proxy)
+
+                ScrollViewReader { proxy in
+                    ScrollView {
+                        VStack(alignment: .leading, spacing: 16) {
+                            if page.grid == nil {
+                                emptyState(
+                                    title: page.emptyStateTitle,
+                                    message: page.emptyStateMessage
+                                )
+                            }
+
+                            if let grid = page.grid {
+                                TimelineDayGridView(
+                                    day: page.date,
+                                    grid: grid,
+                                    availableWidth: contentWidth,
+                                    canManageEvents: canManageEvents,
+                                    horizontalScrollOffset: $horizontalScrollOffset,
+                                    openItem: openItem,
+                                    deleteItem: deleteItem
+                                )
+                            }
+                        }
+                        .padding(.horizontal, 12)
+                        .padding(.top, 8)
+                        .padding(.bottom, 14)
+                    }
+                    .accessibilityIdentifier("timeline-vertical-scroll-view")
+                    .background(Color(.systemGroupedBackground).ignoresSafeArea())
+                    .onAppear {
+                        scrollToVisibleHour(using: proxy)
+                    }
+                    .onChange(of: page.date) { _, _ in
+                        scrollToVisibleHour(using: proxy)
+                    }
+                }
             }
         }
     }
@@ -97,6 +123,7 @@ public struct TimelineDayGridPageView: View {
             emptyStateMessage: "Try another day or use Quick Log to add the next event."
         ),
         canManageEvents: true,
+        horizontalScrollOffset: .constant(0),
         openItem: { _ in },
         deleteItem: { _ in }
     )
@@ -184,6 +211,7 @@ public struct TimelineDayGridPageView: View {
             emptyStateMessage: "Try another day or use Quick Log to add the next event."
         ),
         canManageEvents: true,
+        horizontalScrollOffset: .constant(0),
         openItem: { _ in },
         deleteItem: { _ in }
     )

--- a/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/TimelineDayGridView.swift
+++ b/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/TimelineDayGridView.swift
@@ -4,49 +4,45 @@ import SwiftUI
 public struct TimelineDayGridView: View {
     let day: Date
     let grid: TimelineDayGridViewState
+    let availableWidth: CGFloat
     let canManageEvents: Bool
+    @Binding var horizontalScrollOffset: CGFloat
     let openItem: (TimelineDayGridItemViewState) -> Void
     let deleteItem: (TimelineDayGridItemViewState) -> Void
 
-    private let timeColumnWidth: CGFloat = 20
-    private let columnSpacing: CGFloat = 8
-    private let slotHeight: CGFloat = 30
-    private let itemVerticalInset: CGFloat = 3
-    private let initialScrollBottomOffset: CGFloat = 150
+    @State private var bodyScrollPosition = ScrollPosition()
 
     public init(
         day: Date,
         grid: TimelineDayGridViewState,
+        availableWidth: CGFloat,
         canManageEvents: Bool,
+        horizontalScrollOffset: Binding<CGFloat>,
         openItem: @escaping (TimelineDayGridItemViewState) -> Void,
         deleteItem: @escaping (TimelineDayGridItemViewState) -> Void
     ) {
         self.day = day
         self.grid = grid
+        self.availableWidth = availableWidth
         self.canManageEvents = canManageEvents
+        self._horizontalScrollOffset = horizontalScrollOffset
         self.openItem = openItem
         self.deleteItem = deleteItem
     }
 
     public var body: some View {
-        VStack(spacing: 12) {
-            headerRow
+        let layout = TimelineDayGridLayout(
+            availableWidth: availableWidth,
+            columnCount: grid.columns.count
+        )
 
-            GeometryReader { geometry in
-                let columnWidth = max(
-                    72,
-                    (
-                        geometry.size.width
-                        - timeColumnWidth
-                        - (columnSpacing * CGFloat(grid.columns.count))
-                    ) / CGFloat(max(1, grid.columns.count))
-                )
-
+        ZStack(alignment: .topLeading) {
+            ScrollView(.horizontal) {
                 ZStack(alignment: .topLeading) {
-                    slotGrid(columnWidth: columnWidth)
+                    slotGrid(layout: layout)
 
                     if isToday {
-                        currentTimeIndicator(columnWidth: columnWidth)
+                        currentTimeIndicator(layout: layout)
                     }
 
                     ForEach(Array(grid.columns.enumerated()), id: \.element.kind) { index, column in
@@ -58,81 +54,67 @@ public struct TimelineDayGridView: View {
                                 openItem: openItem,
                                 deleteItem: deleteItem
                             )
-                        .frame(width: columnWidth, height: itemHeight(for: item))
-                        .offset(
-                            x: xOffset(for: index, columnWidth: columnWidth),
-                            y: CGFloat(item.startSlotIndex) * slotHeight + itemVerticalInset
-                        )
-                    }
+                            .frame(width: layout.columnWidth, height: itemHeight(for: item))
+                            .offset(
+                                x: xOffset(for: index, layout: layout),
+                                y: CGFloat(item.startSlotIndex) * layout.slotHeight + layout.itemVerticalInset
+                            )
+                        }
                     }
                 }
+                .frame(width: layout.contentWidth, alignment: .leading)
             }
-            .frame(height: CGFloat(slotCount) * slotHeight)
-        }
-    }
-
-    private var headerRow: some View {
-        HStack(alignment: .bottom, spacing: columnSpacing) {
-            Color.clear
-                .frame(width: timeColumnWidth, height: 1)
-
-            ForEach(grid.columns, id: \.kind) { column in
-                let kind = eventKind(for: column.kind)
-
-                HStack(spacing: 6) {
-                    Image(systemName: BabyEventStyle.systemImage(for: kind))
-                        .font(.caption.weight(.semibold))
-
-                    Text(column.title)
-                        .font(.caption.weight(.semibold))
-                        .lineLimit(1)
+            .scrollPosition($bodyScrollPosition)
+            .defaultScrollAnchor(.leading)
+            .accessibilityIdentifier("timeline-horizontal-scroll-view")
+            .onAppear {
+                bodyScrollPosition.scrollTo(x: horizontalScrollOffset)
+            }
+            .onChange(of: horizontalScrollOffset) { _, newValue in
+                bodyScrollPosition.scrollTo(x: newValue)
+            }
+            .onScrollGeometryChange(for: CGFloat.self) { geometry in
+                geometry.contentOffset.x
+            } action: { _, newValue in
+                guard abs(horizontalScrollOffset - newValue) > 0.5 else {
+                    return
                 }
-                .foregroundStyle(BabyEventStyle.accentColor(for: kind))
-                .frame(maxWidth: .infinity)
-                .padding(.vertical, 8)
-                .background(
-                    RoundedRectangle(cornerRadius: 12, style: .continuous)
-                        .fill(BabyEventStyle.backgroundColor(for: kind))
-                )
-                .overlay(
-                    RoundedRectangle(cornerRadius: 12, style: .continuous)
-                        .stroke(
-                            BabyEventStyle.accentColor(for: kind).opacity(0.35),
-                            lineWidth: 1
-                        )
-                )
+
+                horizontalScrollOffset = newValue
             }
+            .padding(.leading, layout.timeColumnWidth + layout.columnSpacing)
+
+            timeColumn(layout: layout)
+                .background(Color(.systemGroupedBackground))
         }
+        .frame(height: CGFloat(slotCount) * layout.slotHeight)
     }
 
-    private func slotGrid(columnWidth: CGFloat) -> some View {
+    private func timeColumn(layout: TimelineDayGridLayout) -> some View {
         VStack(spacing: 0) {
             ForEach(0..<slotCount, id: \.self) { slotIndex in
-                HStack(spacing: columnSpacing) {
+                ZStack(alignment: .topTrailing) {
+                    Rectangle()
+                        .fill(Color(.systemGroupedBackground))
+
                     if slotIndex.isMultiple(of: slotsPerHour) {
                         Text(hourLabel(for: slotIndex / slotsPerHour))
                             .font(.caption.weight(.medium))
                             .foregroundStyle(.secondary)
-                            .frame(width: timeColumnWidth, alignment: .trailing)
+                            .frame(width: layout.timeColumnWidth, alignment: .trailing)
                             .id(hourAnchorID(for: slotIndex / slotsPerHour))
-                    } else {
-                        Color.clear
-                            .frame(width: timeColumnWidth)
                     }
-
-                    ForEach(Array(grid.columns.enumerated()), id: \.offset) { index, column in
-                        slotCell(
-                            column: column,
-                            slotIndex: slotIndex,
-                            isHourBoundary: slotIndex.isMultiple(of: slotsPerHour)
-                        )
-                        .frame(width: columnWidth, height: slotHeight)
-                    }
+                }
+                .frame(width: layout.timeColumnWidth, height: layout.slotHeight)
+                .overlay(alignment: .topTrailing) {
+                    Rectangle()
+                        .fill(slotIndex.isMultiple(of: slotsPerHour) ? Color(.separator) : Color(.separator).opacity(0.25))
+                        .frame(height: 1)
                 }
                 .overlay(alignment: .topLeading) {
                     if slotIndex.isMultiple(of: slotsPerHour) {
                         Color.clear
-                            .frame(width: 1, height: initialScrollBottomOffset)
+                            .frame(width: 1, height: layout.initialScrollBottomOffset)
                             .id(initialScrollAnchorID(for: slotIndex / slotsPerHour))
                     }
                 }
@@ -140,8 +122,24 @@ public struct TimelineDayGridView: View {
         }
     }
 
+    private func slotGrid(layout: TimelineDayGridLayout) -> some View {
+        VStack(spacing: 0) {
+            ForEach(0..<slotCount, id: \.self) { slotIndex in
+                HStack(spacing: layout.columnSpacing) {
+                    ForEach(grid.columns, id: \.kind) { column in
+                        slotCell(
+                            slotIndex: slotIndex,
+                            isHourBoundary: slotIndex.isMultiple(of: slotsPerHour)
+                        )
+                        .frame(width: layout.columnWidth, height: layout.slotHeight)
+                        .id("\(column.kind.rawValue)-slot-\(slotIndex)")
+                    }
+                }
+            }
+        }
+    }
+
     private func slotCell(
-        column: TimelineDayGridColumnViewState,
         slotIndex: Int,
         isHourBoundary: Bool
     ) -> some View {
@@ -155,13 +153,13 @@ public struct TimelineDayGridView: View {
         }
     }
 
-    private func currentTimeIndicator(columnWidth: CGFloat) -> some View {
+    private func currentTimeIndicator(layout: TimelineDayGridLayout) -> some View {
         TimelineView(.periodic(from: .now, by: 60)) { context in
             Rectangle()
                 .fill(Color.red)
-                .frame(width: indicatorWidth(for: columnWidth), height: 1)
+                .frame(width: indicatorWidth(layout: layout), height: 1)
                 .offset(
-                    x: timeColumnWidth + columnSpacing,
+                    x: 0,
                     y: yOffsetForCurrentTime(at: context.date)
                 )
                 .accessibilityHidden(true)
@@ -176,12 +174,12 @@ public struct TimelineDayGridView: View {
         max(1, 60 / grid.slotMinutes)
     }
 
-    private func xOffset(for columnIndex: Int, columnWidth: CGFloat) -> CGFloat {
-        timeColumnWidth + columnSpacing + CGFloat(columnIndex) * (columnWidth + columnSpacing)
+    private func xOffset(for columnIndex: Int, layout: TimelineDayGridLayout) -> CGFloat {
+        CGFloat(columnIndex) * (layout.columnWidth + layout.columnSpacing)
     }
 
-    private func indicatorWidth(for columnWidth: CGFloat) -> CGFloat {
-        (columnWidth * CGFloat(grid.columns.count)) + (columnSpacing * CGFloat(max(0, grid.columns.count - 1)))
+    private func indicatorWidth(layout: TimelineDayGridLayout) -> CGFloat {
+        (layout.columnWidth * CGFloat(grid.columns.count)) + (layout.columnSpacing * CGFloat(max(0, grid.columns.count - 1)))
     }
 
     private func yOffsetForCurrentTime(at date: Date) -> CGFloat {
@@ -190,13 +188,16 @@ public struct TimelineDayGridView: View {
         let currentMinutes = max(0, (components.hour ?? 0) * 60 + (components.minute ?? 0))
         let clampedMinutes = min(24 * 60, currentMinutes)
         let slotsFromStart = CGFloat(clampedMinutes) / CGFloat(grid.slotMinutes)
-        return min(CGFloat(slotCount) * slotHeight, slotsFromStart * slotHeight)
+        return min(
+            CGFloat(slotCount) * TimelineDayGridLayout.slotHeight,
+            slotsFromStart * TimelineDayGridLayout.slotHeight
+        )
     }
 
     private func itemHeight(for item: TimelineDayGridItemViewState) -> CGFloat {
         max(
-            slotHeight - (itemVerticalInset * 2),
-            (CGFloat(item.endSlotIndex - item.startSlotIndex) * slotHeight) - (itemVerticalInset * 2)
+            TimelineDayGridLayout.slotHeight - (TimelineDayGridLayout.itemVerticalInset * 2),
+            (CGFloat(item.endSlotIndex - item.startSlotIndex) * TimelineDayGridLayout.slotHeight) - (TimelineDayGridLayout.itemVerticalInset * 2)
         )
     }
 
@@ -216,6 +217,67 @@ public struct TimelineDayGridView: View {
     private var isToday: Bool {
         Calendar.autoupdatingCurrent.isDateInToday(day)
     }
+}
+
+struct TimelineDayGridHeaderView: View {
+    let grid: TimelineDayGridViewState
+    let availableWidth: CGFloat
+    @Binding var horizontalScrollOffset: CGFloat
+
+    @State private var scrollPosition = ScrollPosition()
+
+    var body: some View {
+        let layout = TimelineDayGridLayout(
+            availableWidth: availableWidth,
+            columnCount: grid.columns.count
+        )
+
+        HStack(alignment: .bottom, spacing: layout.columnSpacing) {
+            Color.clear
+                .frame(width: layout.timeColumnWidth, height: 1)
+
+            ScrollView(.horizontal, showsIndicators: false) {
+                HStack(spacing: layout.columnSpacing) {
+                    ForEach(grid.columns, id: \.kind) { column in
+                        let kind = eventKind(for: column.kind)
+
+                        HStack(spacing: 6) {
+                            Image(systemName: BabyEventStyle.systemImage(for: kind))
+                                .font(.caption.weight(.semibold))
+
+                            Text(column.title)
+                                .font(.caption.weight(.semibold))
+                                .lineLimit(1)
+                        }
+                        .foregroundStyle(BabyEventStyle.accentColor(for: kind))
+                        .frame(width: layout.columnWidth)
+                        .padding(.vertical, 8)
+                        .background(
+                            RoundedRectangle(cornerRadius: 12, style: .continuous)
+                                .fill(BabyEventStyle.backgroundColor(for: kind))
+                        )
+                        .overlay(
+                            RoundedRectangle(cornerRadius: 12, style: .continuous)
+                                .stroke(
+                                    BabyEventStyle.accentColor(for: kind).opacity(0.35),
+                                    lineWidth: 1
+                                )
+                        )
+                    }
+                }
+                .frame(width: layout.contentWidth, alignment: .leading)
+            }
+            .scrollPosition($scrollPosition)
+            .defaultScrollAnchor(.leading)
+            .accessibilityIdentifier("timeline-sticky-header")
+            .onAppear {
+                scrollPosition.scrollTo(x: horizontalScrollOffset)
+            }
+            .onChange(of: horizontalScrollOffset) { _, newValue in
+                scrollPosition.scrollTo(x: newValue)
+            }
+        }
+    }
 
     private func eventKind(for columnKind: TimelineDayGridColumnKind) -> BabyEventKind {
         switch columnKind {
@@ -233,12 +295,45 @@ public struct TimelineDayGridView: View {
     }
 }
 
+private struct TimelineDayGridLayout {
+    static let timeColumnWidth: CGFloat = 20
+    static let columnSpacing: CGFloat = 8
+    static let slotHeight: CGFloat = 30
+    static let itemVerticalInset: CGFloat = 3
+    static let initialScrollBottomOffset: CGFloat = 150
+    static let minimumColumnWidth: CGFloat = 96
+
+    let availableWidth: CGFloat
+    let columnCount: Int
+
+    var timeColumnWidth: CGFloat { Self.timeColumnWidth }
+    var columnSpacing: CGFloat { Self.columnSpacing }
+    var slotHeight: CGFloat { Self.slotHeight }
+    var itemVerticalInset: CGFloat { Self.itemVerticalInset }
+    var initialScrollBottomOffset: CGFloat { Self.initialScrollBottomOffset }
+
+    var columnWidth: CGFloat {
+        let visibleColumnCount = CGFloat(max(1, min(columnCount, 4)))
+        let fittedWidth = (
+            max(0, availableWidth - timeColumnWidth - columnSpacing)
+            - (columnSpacing * CGFloat(max(0, columnCount - 1)))
+        ) / visibleColumnCount
+        return max(Self.minimumColumnWidth, fittedWidth)
+    }
+
+    var contentWidth: CGFloat {
+        (columnWidth * CGFloat(columnCount)) + (columnSpacing * CGFloat(max(0, columnCount - 1)))
+    }
+}
+
 #Preview("Empty Columns") {
     ScrollView {
         TimelineDayGridView(
             day: TimelineDayGridPreviewFactory.day,
             grid: TimelineDayGridPreviewFactory.emptyGrid,
+            availableWidth: 360,
             canManageEvents: false,
+            horizontalScrollOffset: .constant(0),
             openItem: { _ in },
             deleteItem: { _ in }
         )
@@ -252,7 +347,9 @@ public struct TimelineDayGridView: View {
         TimelineDayGridView(
             day: TimelineDayGridPreviewFactory.day,
             grid: TimelineDayGridPreviewFactory.mixedGrid,
+            availableWidth: 360,
             canManageEvents: true,
+            horizontalScrollOffset: .constant(0),
             openItem: { _ in },
             deleteItem: { _ in }
         )
@@ -266,7 +363,9 @@ public struct TimelineDayGridView: View {
         TimelineDayGridView(
             day: TimelineDayGridPreviewFactory.day,
             grid: TimelineDayGridPreviewFactory.groupedGrid,
+            availableWidth: 360,
             canManageEvents: true,
+            horizontalScrollOffset: .constant(0),
             openItem: { _ in },
             deleteItem: { _ in }
         )
@@ -280,7 +379,25 @@ public struct TimelineDayGridView: View {
         TimelineDayGridView(
             day: TimelineDayGridPreviewFactory.previousDay,
             grid: TimelineDayGridPreviewFactory.mixedGrid,
+            availableWidth: 360,
             canManageEvents: true,
+            horizontalScrollOffset: .constant(0),
+            openItem: { _ in },
+            deleteItem: { _ in }
+        )
+        .padding()
+    }
+    .background(Color(.systemGroupedBackground))
+}
+
+#Preview("Narrow Width Overflow") {
+    ScrollView {
+        TimelineDayGridView(
+            day: TimelineDayGridPreviewFactory.day,
+            grid: TimelineDayGridPreviewFactory.mixedGrid,
+            availableWidth: 300,
+            canManageEvents: true,
+            horizontalScrollOffset: .constant(0),
             openItem: { _ in },
             deleteItem: { _ in }
         )

--- a/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/TimelineScreenView.swift
+++ b/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/TimelineScreenView.swift
@@ -11,8 +11,8 @@ public struct TimelineScreenView: View {
     let cancelDelete: () -> Void
 
     @State private var showingDayPicker = false
-    @State private var dragStartPageIndex: Int = 0
     @State private var dayPickerSheetHeight: CGFloat = 420
+    @State private var timelineHorizontalScrollOffset: CGFloat = 0
 
     public init(
         viewModel: TimelineViewModel,
@@ -41,35 +41,14 @@ public struct TimelineScreenView: View {
             }
 
             if viewModel.displayMode == .day {
-                TabView(selection: timelinePageBinding) {
-                    ForEach(Array(viewModel.pages.enumerated()), id: \.offset) { index, page in
-                        TimelineDayGridPageView(
-                            page: page,
-                            canManageEvents: viewModel.canManageEvents,
-                            openItem: openEvent,
-                            deleteItem: deleteEvent
-                        )
-                        .tag(index)
-                    }
-                }
-                .tabViewStyle(.page(indexDisplayMode: .never))
-                .background(Color(.systemGroupedBackground).ignoresSafeArea())
-                .simultaneousGesture(
-                    DragGesture(minimumDistance: 20)
-                        .onChanged { _ in
-                            if dragStartPageIndex != viewModel.selectedPageIndex {
-                                dragStartPageIndex = viewModel.selectedPageIndex
-                            }
-                        }
-                        .onEnded { value in
-                            let swipe = value.translation.width
-                            if swipe > 60 && dragStartPageIndex == 0 {
-                                viewModel.showPreviousDay()
-                            } else if swipe < -60 && dragStartPageIndex == viewModel.pages.count - 1 {
-                                viewModel.showNextDay()
-                            }
-                        }
+                TimelineDayGridPageView(
+                    page: selectedPage,
+                    canManageEvents: viewModel.canManageEvents,
+                    horizontalScrollOffset: $timelineHorizontalScrollOffset,
+                    openItem: openEvent,
+                    deleteItem: deleteEvent
                 )
+                .background(Color(.systemGroupedBackground).ignoresSafeArea())
             } else {
                 TimelineWeekView(
                     columns: viewModel.stripColumns,
@@ -99,6 +78,22 @@ public struct TimelineScreenView: View {
                 Text(event.timestampText)
             }
         }
+    }
+
+    private var selectedPage: TimelineDayGridPageState {
+        guard viewModel.pages.indices.contains(viewModel.selectedPageIndex) else {
+            return TimelineDayGridPageState(
+                date: viewModel.selectedDay,
+                dayTitle: viewModel.selectedDayTitle,
+                shortWeekdayTitle: viewModel.selectedDay.formatted(.dateTime.weekday(.abbreviated)),
+                isToday: Calendar.autoupdatingCurrent.isDateInToday(viewModel.selectedDay),
+                grid: nil,
+                emptyStateTitle: "No events for this day",
+                emptyStateMessage: "Try another day or use Quick Log to add the next event."
+            )
+        }
+
+        return viewModel.pages[viewModel.selectedPageIndex]
     }
 
     private var pinnedDayNavigationHeader: some View {
@@ -251,19 +246,6 @@ public struct TimelineScreenView: View {
                     .fill(Color(.tertiarySystemGroupedBackground))
             )
             .accessibilityIdentifier("timeline-sync-message")
-    }
-
-    private var timelinePageBinding: Binding<Int> {
-        Binding(
-            get: { viewModel.selectedPageIndex },
-            set: { index in
-                guard viewModel.pages.indices.contains(index) else {
-                    return
-                }
-
-                viewModel.showDay(viewModel.pages[index].date)
-            }
-        )
     }
 
     private var timelineDayBinding: Binding<Date> {

--- a/docs/plans/106-redesign-timeline-today-scrolling.md
+++ b/docs/plans/106-redesign-timeline-today-scrolling.md
@@ -1,0 +1,45 @@
+# 106 - Timeline Today Scrolling Redesign
+
+## Summary
+Implement issue [#247](https://github.com/murphb52/BabyTracker/issues/247) by replacing day-mode swipe pagination with a single selected-day timeline grid that scrolls horizontally across event-type columns and keeps the event-type header row visible while the timeline content scrolls vertically.
+
+## Key Changes
+1. Timeline screen navigation
+- Remove the day-mode `TabView` paging container and the `DragGesture` swipe-to-change-day behavior from `TimelineScreenView`.
+- Keep the existing explicit day controls: previous/next buttons, weekday strip, Today button, and calendar picker.
+- In day mode, render only the currently selected `TimelineDayGridPageState`; changing days continues to go through `TimelineViewModel.showPreviousDay()`, `showNextDay()`, `showDay(_:)`, and `jumpToToday()`.
+
+2. Day grid layout and scrolling
+- Refactor `TimelineDayGridPageView` and `TimelineDayGridView` so the grid becomes a two-axis layout with a sticky event-type header row, a horizontally scrollable column area, and the existing time gutter pinned on the left.
+- Use a single shared horizontal scroll position in the feature view layer so the header and body stay aligned and the horizontal position is preserved across day changes and state refreshes while the Timeline screen remains active.
+- Keep the current initial vertical auto-scroll behavior to the visible hour for the selected day.
+- Keep column ordering, column titles, icons, colors, grouping behavior, edit opening, and delete interactions unchanged.
+
+3. View composition and identifiers
+- Keep the domain grid dataset builder unchanged; this is a presentation refactor only.
+- Reuse `TimelineDayGridColumnKind` as the stable horizontal column ordering; do not add new domain identifiers.
+- Add or update accessibility identifiers so UITests can target the sticky header, horizontal column scroll area, and vertical timeline scroll area.
+
+## Test Plan
+1. AppModel and feature regression
+- Keep existing timeline data, ordering, grouping, and event action payload tests passing.
+- Keep day-navigation tests, but validate navigation only through explicit controls instead of swipe gestures.
+
+2. UI tests
+- Replace the current swipe-based day-navigation UITest with coverage that uses previous/next or weekday buttons and verifies the selected day and content update correctly.
+- Keep coverage that the day grid still exposes tappable event items after the layout refactor.
+- Add UITest coverage that the horizontal column scroll area exists in day mode and that returning to Today still shows the selected-day grid.
+
+3. Preview and manual verification
+- Add a narrow-width timeline preview that forces horizontal overflow.
+- Verify sticky headers remain visible while vertically scrolling long timeline content.
+- Verify horizontal position is preserved when switching days and when the selected day refreshes.
+- Verify the current-time indicator, grouped-event sheet, single-event edit opening, and delete confirmation still work.
+
+## Assumptions
+- Keep the current explicit day navigation UI; only swipe-based day changes are removed.
+- The sticky header row contains the existing icon and title chips only.
+- Horizontal position preservation is scoped to the active Timeline screen session and is not persisted across app launches.
+- Week mode is out of scope except for any harmless fallout from removing day-mode paging.
+
+- [x] Complete


### PR DESCRIPTION
## Summary
- remove swipe-based day paging from Timeline day mode and render only the selected day grid
- refactor the day grid into a sticky header plus horizontally scrollable columns with preserved horizontal position
- update UITests and add the implementation plan doc for issue #247

## Why
- the Today timeline needs to scale to more event-type columns without depending on page swipes
- sticky event-type headers make the vertically long timeline easier to scan
- explicit day controls remain available while the grid itself handles horizontal overflow

## Validation
- `xcodebuild -scheme "Baby Tracker" -destination 'platform=iOS Simulator,name=iPhone 17,OS=26.2' build`
- started `xcodebuild -scheme "Baby Tracker" -destination 'platform=iOS Simulator,name=iPhone 17,OS=26.2' test` and confirmed the suite compiled and many tests were passing during execution

## Links
- Closes #247
- Plan: `docs/plans/106-redesign-timeline-today-scrolling.md`
