### PR TITLE
Add hourly opportunistic background refresh

### DIFF
--- a/Baby Tracker/App/AppContainer.swift
+++ b/Baby Tracker/App/AppContainer.swift
@@ -8,6 +8,7 @@ import Foundation
 struct AppContainer {
     let appModel: AppModel
     let shareAcceptanceHandler: ShareAcceptanceHandler
+    let backgroundRefreshScheduler: any BackgroundRefreshScheduling
 
     init(processInfo: ProcessInfo = .processInfo) {
         let launchConfiguration = LaunchConfiguration(processInfo: processInfo)
@@ -50,6 +51,9 @@ struct AppContainer {
         let localNotificationManager: any LocalNotificationManaging = launchConfiguration.usesUnavailableCloudKitClient ?
             NoOpLocalNotificationManager() :
             SystemLocalNotificationManager()
+        let backgroundRefreshScheduler: any BackgroundRefreshScheduling = launchConfiguration.usesUnavailableCloudKitClient ?
+            NoOpBackgroundRefreshScheduler() :
+            SystemBackgroundRefreshScheduler()
         let hapticFeedbackProvider: any HapticFeedbackProviding = SystemHapticFeedbackProvider()
         let appReviewRequester: any AppReviewRequesting = SystemAppReviewRequester()
         let syncEngine = CloudKitSyncEngine(
@@ -94,6 +98,7 @@ struct AppContainer {
 
         self.appModel = appModel
         self.shareAcceptanceHandler = shareAcceptanceHandler
+        self.backgroundRefreshScheduler = backgroundRefreshScheduler
     }
 
     static let live = AppContainer()
@@ -167,16 +172,19 @@ struct AppContainer {
         _ = processInfo
         return AppContainer(
             appModel: appModel,
-            shareAcceptanceHandler: shareAcceptanceHandler
+            shareAcceptanceHandler: shareAcceptanceHandler,
+            backgroundRefreshScheduler: NoOpBackgroundRefreshScheduler()
         )
     }()
 
     private init(
         appModel: AppModel,
-        shareAcceptanceHandler: ShareAcceptanceHandler
+        shareAcceptanceHandler: ShareAcceptanceHandler,
+        backgroundRefreshScheduler: any BackgroundRefreshScheduling
     ) {
         self.appModel = appModel
         self.shareAcceptanceHandler = shareAcceptanceHandler
+        self.backgroundRefreshScheduler = backgroundRefreshScheduler
     }
 
     private static func seed(

--- a/Baby Tracker/App/AppRootView.swift
+++ b/Baby Tracker/App/AppRootView.swift
@@ -86,6 +86,7 @@ struct AppRootView: View {
                 Task { await model.refreshSyncStatus() }
             } else if newPhase == .background {
                 model.appDidEnterBackground()
+                BackgroundAppRefreshScheduler.shared.scheduleNext()
             }
         }
         .onOpenURL { url in

--- a/Baby Tracker/App/AppRootView.swift
+++ b/Baby Tracker/App/AppRootView.swift
@@ -4,14 +4,15 @@ import SwiftUI
 
 struct AppRootView: View {
     @State private var model: AppModel
-    private let backgroundRefreshScheduler: any BackgroundRefreshScheduling
+    private let scheduleBackgroundRefresh: @MainActor () -> Void
     @Environment(\.scenePhase) private var scenePhase
     @AppStorage(accentColorHexKey) private var accentColorHex: String = accentColorHexDefault
     @AppStorage(debugOptionsUnlockedKey) private var areDebugOptionsVisible = false
 
     init(container: AppContainer) {
         _model = State(initialValue: container.appModel)
-        backgroundRefreshScheduler = container.backgroundRefreshScheduler
+        let scheduler = container.backgroundRefreshScheduler
+        scheduleBackgroundRefresh = { scheduler.scheduleNext() }
     }
 
     var body: some View {
@@ -88,7 +89,7 @@ struct AppRootView: View {
                 Task { await model.refreshSyncStatus() }
             } else if newPhase == .background {
                 model.appDidEnterBackground()
-                backgroundRefreshScheduler.scheduleNext()
+                scheduleBackgroundRefresh()
             }
         }
         .onOpenURL { url in

--- a/Baby Tracker/App/AppRootView.swift
+++ b/Baby Tracker/App/AppRootView.swift
@@ -4,12 +4,14 @@ import SwiftUI
 
 struct AppRootView: View {
     @State private var model: AppModel
+    private let backgroundRefreshScheduler: any BackgroundRefreshScheduling
     @Environment(\.scenePhase) private var scenePhase
     @AppStorage(accentColorHexKey) private var accentColorHex: String = accentColorHexDefault
     @AppStorage(debugOptionsUnlockedKey) private var areDebugOptionsVisible = false
 
     init(container: AppContainer) {
         _model = State(initialValue: container.appModel)
+        backgroundRefreshScheduler = container.backgroundRefreshScheduler
     }
 
     var body: some View {
@@ -86,7 +88,7 @@ struct AppRootView: View {
                 Task { await model.refreshSyncStatus() }
             } else if newPhase == .background {
                 model.appDidEnterBackground()
-                BackgroundAppRefreshScheduler.shared.scheduleNext()
+                backgroundRefreshScheduler.scheduleNext()
             }
         }
         .onOpenURL { url in

--- a/Baby Tracker/App/BabyTrackerApp.swift
+++ b/Baby Tracker/App/BabyTrackerApp.swift
@@ -19,13 +19,10 @@ struct BabyTrackerApp: App {
             )
             return summary.state == .failed ? .failed : .newData
         }
-        BackgroundAppRefreshScheduler.shared.handler = {
-            let summary = await container.appModel.refreshAfterRemoteNotification(
-                isAppInBackground: true
-            )
-            return summary.state != .failed
+        let appModel = container.appModel
+        container.backgroundRefreshScheduler.registerLaunchHandler {
+            await PerformBackgroundRefreshUseCase.execute(refresher: appModel)
         }
-        BackgroundAppRefreshScheduler.shared.registerLaunchHandler()
     }
 
     var body: some Scene {

--- a/Baby Tracker/App/BabyTrackerApp.swift
+++ b/Baby Tracker/App/BabyTrackerApp.swift
@@ -19,6 +19,13 @@ struct BabyTrackerApp: App {
             )
             return summary.state == .failed ? .failed : .newData
         }
+        BackgroundAppRefreshScheduler.shared.handler = {
+            let summary = await container.appModel.refreshAfterRemoteNotification(
+                isAppInBackground: true
+            )
+            return summary.state != .failed
+        }
+        BackgroundAppRefreshScheduler.shared.registerLaunchHandler()
     }
 
     var body: some Scene {

--- a/Baby Tracker/App/BackgroundAppRefreshScheduler.swift
+++ b/Baby Tracker/App/BackgroundAppRefreshScheduler.swift
@@ -1,0 +1,92 @@
+import BabyTrackerDomain
+import BackgroundTasks
+import Foundation
+
+/// Schedules and runs an opportunistic background refresh on top of CloudKit
+/// silent push. Push delivery is best-effort, so this gives the app a second
+/// independent chance to pull caregiver changes while suspended.
+///
+/// iOS treats the requested cadence as a hint, not a guarantee — the system
+/// decides when (and whether) to actually run the task based on usage,
+/// battery, and Low Power Mode.
+@MainActor
+final class BackgroundAppRefreshScheduler {
+    static let shared = BackgroundAppRefreshScheduler()
+
+    /// Must match the identifier listed in Info.plist under
+    /// `BGTaskSchedulerPermittedIdentifiers`.
+    static let taskIdentifier = "com.adappt.BabyTracker.backgroundRefresh"
+
+    private static let earliestRefreshInterval: TimeInterval = 60 * 60
+
+    /// Set by the composition root to perform the actual refresh. Returns
+    /// whether the refresh succeeded so the system can adapt scheduling.
+    var handler: (() async -> Bool)?
+
+    private var didRegisterLaunchHandler = false
+
+    private init() {}
+
+    func registerLaunchHandler() {
+        // BGTaskScheduler must only be registered once per identifier per
+        // process and must be wired before didFinishLaunchingWithOptions
+        // returns.
+        guard !didRegisterLaunchHandler else { return }
+        didRegisterLaunchHandler = true
+
+        BGTaskScheduler.shared.register(
+            forTaskWithIdentifier: Self.taskIdentifier,
+            using: nil
+        ) { [weak self] task in
+            guard let appRefreshTask = task as? BGAppRefreshTask else {
+                task.setTaskCompleted(success: false)
+                return
+            }
+            MainActor.assumeIsolated {
+                self?.handle(task: appRefreshTask)
+            }
+        }
+    }
+
+    func scheduleNext() {
+        let request = BGAppRefreshTaskRequest(identifier: Self.taskIdentifier)
+        request.earliestBeginDate = Date(timeIntervalSinceNow: Self.earliestRefreshInterval)
+        do {
+            try BGTaskScheduler.shared.submit(request)
+            AppLogger.shared.log(
+                .debug,
+                category: "BackgroundRefresh",
+                "Scheduled next background refresh in \(Int(Self.earliestRefreshInterval))s"
+            )
+        } catch {
+            AppLogger.shared.log(
+                .warning,
+                category: "BackgroundRefresh",
+                "Failed to schedule background refresh: \(error.localizedDescription)"
+            )
+        }
+    }
+
+    private func handle(task: BGAppRefreshTask) {
+        // Queue the next request before doing work so a crash or expiration
+        // in this run still leaves a future refresh pending.
+        scheduleNext()
+
+        let work = Task { @MainActor in
+            let success = await handler?() ?? false
+            let cancelled = Task.isCancelled
+            task.setTaskCompleted(success: success && !cancelled)
+            AppLogger.shared.log(
+                .info,
+                category: "BackgroundRefresh",
+                "Background refresh finished — success: \(success), expired: \(cancelled)"
+            )
+        }
+
+        // Expiration runs on a system queue, so we can only do Sendable work
+        // here. Cancelling the task lets the work block log the outcome itself.
+        task.expirationHandler = {
+            work.cancel()
+        }
+    }
+}

--- a/Baby Tracker/App/SystemBackgroundRefreshScheduler.swift
+++ b/Baby Tracker/App/SystemBackgroundRefreshScheduler.swift
@@ -1,35 +1,33 @@
 import BabyTrackerDomain
+import BabyTrackerFeature
 import BackgroundTasks
 import Foundation
 
-/// Schedules and runs an opportunistic background refresh on top of CloudKit
-/// silent push. Push delivery is best-effort, so this gives the app a second
-/// independent chance to pull caregiver changes while suspended.
+/// `BGTaskScheduler`-backed implementation of `BackgroundRefreshScheduling`.
+/// Lives in the app target so the `BackgroundTasks` import stays out of
+/// feature/preview code.
 ///
-/// iOS treats the requested cadence as a hint, not a guarantee — the system
+/// iOS treats the scheduling cadence as a hint, not a guarantee — the system
 /// decides when (and whether) to actually run the task based on usage,
 /// battery, and Low Power Mode.
 @MainActor
-final class BackgroundAppRefreshScheduler {
-    static let shared = BackgroundAppRefreshScheduler()
-
+final class SystemBackgroundRefreshScheduler: BackgroundRefreshScheduling {
     /// Must match the identifier listed in Info.plist under
     /// `BGTaskSchedulerPermittedIdentifiers`.
     static let taskIdentifier = "com.adappt.BabyTracker.backgroundRefresh"
 
     private static let earliestRefreshInterval: TimeInterval = 60 * 60
 
-    /// Set by the composition root to perform the actual refresh. Returns
-    /// whether the refresh succeeded so the system can adapt scheduling.
-    var handler: (() async -> Bool)?
-
+    private var handler: (() async -> Bool)?
     private var didRegisterLaunchHandler = false
 
-    private init() {}
+    init() {}
 
-    func registerLaunchHandler() {
+    func registerLaunchHandler(_ handler: @escaping () async -> Bool) {
+        self.handler = handler
+
         // BGTaskScheduler must only be registered once per identifier per
-        // process and must be wired before didFinishLaunchingWithOptions
+        // process, and must be wired before didFinishLaunchingWithOptions
         // returns.
         guard !didRegisterLaunchHandler else { return }
         didRegisterLaunchHandler = true

--- a/Baby Tracker/App/SystemBackgroundRefreshScheduler.swift
+++ b/Baby Tracker/App/SystemBackgroundRefreshScheduler.swift
@@ -40,7 +40,12 @@ final class SystemBackgroundRefreshScheduler: BackgroundRefreshScheduling {
                 task.setTaskCompleted(success: false)
                 return
             }
-            MainActor.assumeIsolated {
+            // BGTaskScheduler invokes this launch handler on a private
+            // background queue, so we must hop to the main actor before
+            // touching @MainActor state. `MainActor.assumeIsolated` would
+            // trap here because the runtime asserts we are already on the
+            // main queue.
+            Task { @MainActor in
                 self?.handle(task: appRefreshTask)
             }
         }

--- a/Baby Tracker/App/SystemBackgroundRefreshScheduler.swift
+++ b/Baby Tracker/App/SystemBackgroundRefreshScheduler.swift
@@ -18,12 +18,12 @@ final class SystemBackgroundRefreshScheduler: BackgroundRefreshScheduling {
 
     private static let earliestRefreshInterval: TimeInterval = 60 * 60
 
-    private var handler: (() async -> Bool)?
+    private var handler: (@MainActor () async -> Bool)?
     private var didRegisterLaunchHandler = false
 
     init() {}
 
-    func registerLaunchHandler(_ handler: @escaping () async -> Bool) {
+    func registerLaunchHandler(_ handler: @escaping @MainActor () async -> Bool) {
         self.handler = handler
 
         // BGTaskScheduler must only be registered once per identifier per

--- a/Baby Tracker/Info.plist
+++ b/Baby Tracker/Info.plist
@@ -9,6 +9,11 @@
 	<key>UIBackgroundModes</key>
 	<array>
 		<string>remote-notification</string>
+		<string>fetch</string>
+	</array>
+	<key>BGTaskSchedulerPermittedIdentifiers</key>
+	<array>
+		<string>com.adappt.BabyTracker.backgroundRefresh</string>
 	</array>
 	<key>CFBundleURLTypes</key>
 	<array>

--- a/Baby TrackerTests/PerformBackgroundRefreshUseCaseTests.swift
+++ b/Baby TrackerTests/PerformBackgroundRefreshUseCaseTests.swift
@@ -1,0 +1,36 @@
+import BabyTrackerDomain
+import BabyTrackerFeature
+import Testing
+
+@MainActor
+struct PerformBackgroundRefreshUseCaseTests {
+    @Test
+    func reportsSuccessWhenSyncDoesNotFail() async {
+        let refresher = StubBackgroundRefresher(state: .upToDate)
+        let success = await PerformBackgroundRefreshUseCase.execute(refresher: refresher)
+        #expect(success)
+        #expect(refresher.recordedIsAppInBackground == true)
+    }
+
+    @Test
+    func reportsFailureWhenSyncFails() async {
+        let refresher = StubBackgroundRefresher(state: .failed)
+        let success = await PerformBackgroundRefreshUseCase.execute(refresher: refresher)
+        #expect(success == false)
+    }
+}
+
+@MainActor
+private final class StubBackgroundRefresher: BackgroundRefreshing {
+    private let state: SyncState
+    private(set) var recordedIsAppInBackground: Bool?
+
+    init(state: SyncState) {
+        self.state = state
+    }
+
+    func refreshAfterRemoteNotification(isAppInBackground: Bool) async -> SyncStatusSummary {
+        recordedIsAppInBackground = isAppInBackground
+        return SyncStatusSummary(state: state)
+    }
+}

--- a/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/AppModel.swift
+++ b/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/AppModel.swift
@@ -2225,6 +2225,8 @@ public final class AppModel {
     }
 }
 
+extension AppModel: BackgroundRefreshing {}
+
 // MARK: - In-memory demo factory
 
 public extension AppModel {

--- a/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/BackgroundRefreshScheduling.swift
+++ b/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/BackgroundRefreshScheduling.swift
@@ -1,0 +1,16 @@
+import Foundation
+
+/// Abstraction over the platform background-task scheduler so feature code
+/// stays free of `BackgroundTasks` imports. The composition root injects
+/// either the system-backed implementation or a no-op for previews/tests.
+@MainActor
+public protocol BackgroundRefreshScheduling: AnyObject {
+    /// Wires the closure the system should run when iOS hands the app a
+    /// background slot. Implementations must register with the platform
+    /// scheduler before launch finishes.
+    func registerLaunchHandler(_ handler: @escaping () async -> Bool)
+
+    /// Submits the next refresh request. Safe to call repeatedly — later
+    /// calls replace earlier pending requests.
+    func scheduleNext()
+}

--- a/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/BackgroundRefreshScheduling.swift
+++ b/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/BackgroundRefreshScheduling.swift
@@ -4,11 +4,11 @@ import Foundation
 /// stays free of `BackgroundTasks` imports. The composition root injects
 /// either the system-backed implementation or a no-op for previews/tests.
 @MainActor
-public protocol BackgroundRefreshScheduling: AnyObject {
+public protocol BackgroundRefreshScheduling: AnyObject, Sendable {
     /// Wires the closure the system should run when iOS hands the app a
     /// background slot. Implementations must register with the platform
     /// scheduler before launch finishes.
-    func registerLaunchHandler(_ handler: @escaping () async -> Bool)
+    func registerLaunchHandler(_ handler: @escaping @MainActor () async -> Bool)
 
     /// Submits the next refresh request. Safe to call repeatedly — later
     /// calls replace earlier pending requests.

--- a/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/BackgroundRefreshing.swift
+++ b/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/BackgroundRefreshing.swift
@@ -1,0 +1,9 @@
+import BabyTrackerDomain
+import Foundation
+
+/// Decouples the background-refresh use case from `AppModel` so it can be
+/// tested without spinning up the full feature graph.
+@MainActor
+public protocol BackgroundRefreshing: AnyObject {
+    func refreshAfterRemoteNotification(isAppInBackground: Bool) async -> SyncStatusSummary
+}

--- a/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/NoOpBackgroundRefreshScheduler.swift
+++ b/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/NoOpBackgroundRefreshScheduler.swift
@@ -1,0 +1,17 @@
+import Foundation
+
+@MainActor
+public final class NoOpBackgroundRefreshScheduler: BackgroundRefreshScheduling {
+    public private(set) var registeredHandler: (() async -> Bool)?
+    public private(set) var scheduleNextCallCount = 0
+
+    public init() {}
+
+    public func registerLaunchHandler(_ handler: @escaping () async -> Bool) {
+        registeredHandler = handler
+    }
+
+    public func scheduleNext() {
+        scheduleNextCallCount += 1
+    }
+}

--- a/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/NoOpBackgroundRefreshScheduler.swift
+++ b/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/NoOpBackgroundRefreshScheduler.swift
@@ -2,12 +2,12 @@ import Foundation
 
 @MainActor
 public final class NoOpBackgroundRefreshScheduler: BackgroundRefreshScheduling {
-    public private(set) var registeredHandler: (() async -> Bool)?
+    public private(set) var registeredHandler: (@MainActor () async -> Bool)?
     public private(set) var scheduleNextCallCount = 0
 
     public init() {}
 
-    public func registerLaunchHandler(_ handler: @escaping () async -> Bool) {
+    public func registerLaunchHandler(_ handler: @escaping @MainActor () async -> Bool) {
         registeredHandler = handler
     }
 

--- a/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/UseCases/PerformBackgroundRefreshUseCase.swift
+++ b/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/UseCases/PerformBackgroundRefreshUseCase.swift
@@ -1,0 +1,12 @@
+import BabyTrackerDomain
+
+/// Runs the same sync path used by silent push when iOS hands the app a
+/// background-refresh slot. Returns whether the refresh succeeded so the
+/// scheduler can hint the system about future scheduling.
+public enum PerformBackgroundRefreshUseCase {
+    @MainActor
+    public static func execute(refresher: any BackgroundRefreshing) async -> Bool {
+        let summary = await refresher.refreshAfterRemoteNotification(isAppInBackground: true)
+        return summary.state != .failed
+    }
+}

--- a/docs/plans/109-hourly-background-refresh.md
+++ b/docs/plans/109-hourly-background-refresh.md
@@ -1,0 +1,47 @@
+# 109 - Hourly background refresh
+
+## Goal
+
+CloudKit silent push reaches devices roughly half the time in practice, so a
+caregiver's view of "what's the latest" can drift. Add an hourly opportunistic
+background refresh that runs alongside push so the on-device data has a second,
+independent chance to catch up while the app is suspended.
+
+## Approach
+
+Use the modern `BackgroundTasks` framework (`BGAppRefreshTask`). Reuse the
+existing remote-notification refresh entry point so we get sync, reminder
+rescheduling, and live-activity reconciliation for free.
+
+1. Declare a single permitted task identifier
+   (`com.adappt.BabyTracker.backgroundRefresh`) in `Info.plist` and add the
+   `fetch` background mode so iOS will run it.
+2. Add a small `BackgroundAppRefreshScheduler` in the app target that:
+   - registers the launch handler with `BGTaskScheduler.shared` at launch,
+   - schedules the next request with an `earliestBeginDate` ~1 hour out,
+   - on launch handler invocation: runs the refresh closure, completes the
+     `BGTask` with success based on the resulting `SyncStatusSummary`, and
+     immediately schedules the next request.
+3. Wire the refresh closure in `BabyTrackerApp.init` to call
+   `appModel.refreshAfterRemoteNotification(isAppInBackground: true)` — the
+   same path silent push already uses (`AppModel.swift:302`).
+4. Schedule the next request when the scene transitions to `.background`
+   (`AppRootView.swift:84`), so each foreground session leaves a pending
+   request behind.
+
+iOS controls actual run timing — the 1-hour value is a hint. In practice it
+fires opportunistically a few times a day depending on usage, battery, and
+Low Power Mode. That is exactly the gap-filling behaviour we want layered on
+top of push.
+
+## Notes
+
+- `BGTaskScheduler.register` must be called before `application(_:didFinishLaunchingWithOptions:)`
+  returns. Calling it from `BabyTrackerApp.init` satisfies that ordering.
+- No new abstraction over `BGTaskScheduler` itself: the plumbing is short and
+  matches the existing `CloudKitRemoteNotificationBridge` precedent
+  (no protocol seam, no unit tests for OS glue).
+- Reusing `refreshAfterRemoteNotification` keeps reminder rescheduling correct
+  via `scheduleRemoteSyncNotificationIfNeeded()` (`AppModel.swift:304`).
+
+- [x] Complete

--- a/docs/plans/109-hourly-background-refresh.md
+++ b/docs/plans/109-hourly-background-refresh.md
@@ -9,25 +9,32 @@ independent chance to catch up while the app is suspended.
 
 ## Approach
 
-Use the modern `BackgroundTasks` framework (`BGAppRefreshTask`). Reuse the
-existing remote-notification refresh entry point so we get sync, reminder
-rescheduling, and live-activity reconciliation for free.
+Use the modern `BackgroundTasks` framework (`BGAppRefreshTask`). Keep the
+framework import out of feature/preview code by introducing a protocol seam
+and a use case, mirroring the `LocalNotificationManaging`/`SystemLocalNotificationManager`
+pattern already used in this project.
 
 1. Declare a single permitted task identifier
    (`com.adappt.BabyTracker.backgroundRefresh`) in `Info.plist` and add the
    `fetch` background mode so iOS will run it.
-2. Add a small `BackgroundAppRefreshScheduler` in the app target that:
-   - registers the launch handler with `BGTaskScheduler.shared` at launch,
-   - schedules the next request with an `earliestBeginDate` ~1 hour out,
-   - on launch handler invocation: runs the refresh closure, completes the
-     `BGTask` with success based on the resulting `SyncStatusSummary`, and
-     immediately schedules the next request.
-3. Wire the refresh closure in `BabyTrackerApp.init` to call
-   `appModel.refreshAfterRemoteNotification(isAppInBackground: true)` — the
-   same path silent push already uses (`AppModel.swift:302`).
-4. Schedule the next request when the scene transitions to `.background`
-   (`AppRootView.swift:84`), so each foreground session leaves a pending
-   request behind.
+2. In `BabyTrackerFeature`, add:
+   - `BackgroundRefreshScheduling` — protocol exposing
+     `registerLaunchHandler(_:)` and `scheduleNext()`.
+   - `BackgroundRefreshing` — protocol AppModel adopts so the use case
+     doesn't depend on the full feature graph.
+   - `PerformBackgroundRefreshUseCase` — runs the same sync path used by
+     silent push and reports a Bool.
+   - `NoOpBackgroundRefreshScheduler` — for previews and tests.
+3. In the app target, add `SystemBackgroundRefreshScheduler` — the only place
+   that imports `BackgroundTasks`. It registers the launch handler with
+   `BGTaskScheduler.shared`, schedules requests ~1 hour out, and on each run
+   immediately schedules the next request and completes the task based on
+   the use case result.
+4. `AppContainer` exposes `backgroundRefreshScheduler` and selects between
+   the system and no-op implementations using the existing
+   `usesUnavailableCloudKitClient` flag.
+5. `BabyTrackerApp.init` registers the launch handler with the use case;
+   `AppRootView` calls `scheduleNext()` from its existing scenePhase change.
 
 iOS controls actual run timing — the 1-hour value is a hint. In practice it
 fires opportunistically a few times a day depending on usage, battery, and
@@ -38,10 +45,10 @@ top of push.
 
 - `BGTaskScheduler.register` must be called before `application(_:didFinishLaunchingWithOptions:)`
   returns. Calling it from `BabyTrackerApp.init` satisfies that ordering.
-- No new abstraction over `BGTaskScheduler` itself: the plumbing is short and
-  matches the existing `CloudKitRemoteNotificationBridge` precedent
-  (no protocol seam, no unit tests for OS glue).
-- Reusing `refreshAfterRemoteNotification` keeps reminder rescheduling correct
-  via `scheduleRemoteSyncNotificationIfNeeded()` (`AppModel.swift:304`).
+- The protocol seam keeps the `BackgroundTasks` import out of
+  `BabyTrackerFeature` and out of `#Preview` blocks, matching how
+  `LocalNotificationManaging` keeps `UserNotifications` out of feature code.
+- Reusing `refreshAfterRemoteNotification` via `BackgroundRefreshing` keeps
+  reminder rescheduling correct via `scheduleRemoteSyncNotificationIfNeeded()`.
 
 - [x] Complete


### PR DESCRIPTION
## Summary

CloudKit silent push delivery is best-effort, so caregiver data on the device can drift between foreground sessions. This PR layers a `BGAppRefreshTask` alongside push so the app has a second independent chance to pull changes while suspended.

- New `BackgroundAppRefreshScheduler` registers a `BGTaskScheduler` launch handler at app init and submits a request with a ~1 hour `earliestBeginDate` whenever the scene moves to background.
- The handler reuses `AppModel.refreshAfterRemoteNotification(isAppInBackground: true)` so sync, reminder rescheduling, and live-activity reconciliation behave identically to the push path.
- `Info.plist` gains the `fetch` background mode and `BGTaskSchedulerPermittedIdentifiers` entry required for the modern BackgroundTasks framework.

iOS treats the 1h cadence as a hint, not a guarantee — the system schedules opportunistically based on usage, battery, and Low Power Mode. Push remains the primary path; this just narrows the window when push misses.

## Plan

`docs/plans/109-hourly-background-refresh.md`

## Test plan

- [ ] Build the app on iOS 26 simulator and confirm clean compile.
- [ ] Launch on device, background the app, then trigger the task via the LLDB `e -l objc -- (void)[[BGTaskScheduler sharedScheduler] _simulateLaunchForTaskWithIdentifier:@"com.adappt.BabyTracker.backgroundRefresh"]` debugger trick and confirm a sync runs.
- [ ] Verify the timeline shows updated caregiver events after the simulated background refresh.
- [ ] Confirm `AppLogger` shows BackgroundRefresh log lines and no crash on schedule failure (e.g., simulator with no entitlement).

https://claude.ai/code/session_019H6rdwQidprgkhvVUXJPuE

---
_Generated by [Claude Code](https://claude.ai/code/session_019H6rdwQidprgkhvVUXJPuE)_