### PR TITLE
Add Xcode Cloud PR comment workflow

### DIFF
--- a/.github/workflows/xcode-cloud-dispatch.yml
+++ b/.github/workflows/xcode-cloud-dispatch.yml
@@ -1,0 +1,128 @@
+name: Xcode Cloud PR Comment Dispatch
+
+on:
+  issue_comment:
+    types:
+      - created
+
+permissions:
+  contents: read
+  pull-requests: read
+  issues: write
+
+jobs:
+  dispatch:
+    if: ${{ github.event.issue.pull_request && github.event.comment.body == '/build' }}
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Fetch pull request details
+        id: pr
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const pullRequest = await github.request(context.payload.issue.pull_request.url, {
+              headers: {
+                accept: 'application/vnd.github+json',
+              },
+            });
+
+            const pr = pullRequest.data;
+            const isFork = pr.head.repo.full_name !== pr.base.repo.full_name;
+
+            core.setOutput('head_ref', pr.head.ref);
+            core.setOutput('head_sha', pr.head.sha);
+            core.setOutput('head_repo', pr.head.repo.full_name);
+            core.setOutput('base_repo', pr.base.repo.full_name);
+            core.setOutput('is_fork', isFork ? 'true' : 'false');
+
+      - name: Reject fork pull requests
+        if: ${{ steps.pr.outputs.is_fork == 'true' }}
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const body = [
+              '/build',
+              '',
+              '> Xcode Cloud dispatch only supports pull requests whose head branch exists in the repository linked to the Xcode Cloud workflow.',
+              '> Pull requests from forks are not supported by this workflow.',
+            ].join('\n');
+
+            await github.rest.issues.updateComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              comment_id: context.payload.comment.id,
+              body,
+            });
+
+      - name: Check out pull request commit
+        if: ${{ steps.pr.outputs.is_fork != 'true' }}
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ steps.pr.outputs.head_sha }}
+
+      - name: Trigger Xcode Cloud
+        id: xcode
+        if: ${{ steps.pr.outputs.is_fork != 'true' }}
+        uses: murphb52/xcode-cloud-dispatch-action@main
+        with:
+          apple_key_id: ${{ secrets.APPSTORE_KEY_ID }}
+          apple_issuer_id: ${{ secrets.APPSTORE_ISSUER_ID }}
+          apple_private_key: ${{ secrets.APPSTORE_PRIVATE_KEY }}
+          workflow_id: ${{ vars.XCODE_CLOUD_WORKFLOW_ID }}
+          project_path: ${{ vars.XCODE_CLOUD_PROJECT_PATH }}
+          info_plist_path: ${{ vars.XCODE_CLOUD_INFO_PLIST_PATH }}
+          branch: ${{ steps.pr.outputs.head_ref }}
+          team_id: ${{ vars.APPSTORE_TEAM_ID }}
+          app_id: ${{ vars.APPSTORE_APP_ID }}
+
+      - name: Update comment with success details
+        if: ${{ success() && steps.pr.outputs.is_fork != 'true' }}
+        uses: actions/github-script@v7
+        env:
+          BRANCH_NAME: ${{ steps.pr.outputs.head_ref }}
+          MARKETING_VERSION: ${{ steps.xcode.outputs.marketing_version }}
+          BUILD_NUMBER: ${{ steps.xcode.outputs.build_number }}
+          BUILD_URL: ${{ steps.xcode.outputs.build_url }}
+        with:
+          script: |
+            const lines = [
+              '/build',
+              '',
+              '> Xcode Cloud build started successfully.',
+              `> Branch: \`${process.env.BRANCH_NAME}\``,
+            ];
+
+            if (process.env.MARKETING_VERSION) {
+              lines.push(`> Marketing version: \`${process.env.MARKETING_VERSION}\``);
+            }
+
+            lines.push(`> Build number: \`${process.env.BUILD_NUMBER}\``);
+            lines.push(`> Build URL: ${process.env.BUILD_URL}`);
+
+            await github.rest.issues.updateComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              comment_id: context.payload.comment.id,
+              body: lines.join('\n'),
+            });
+
+      - name: Update comment with failure details
+        if: ${{ failure() && steps.pr.outputs.is_fork != 'true' }}
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+            const body = [
+              '/build',
+              '',
+              '> Xcode Cloud dispatch failed.',
+              `> Review the GitHub Actions logs: ${runUrl}`,
+            ].join('\n');
+
+            await github.rest.issues.updateComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              comment_id: context.payload.comment.id,
+              body,
+            });


### PR DESCRIPTION
This PR adds a GitHub Actions workflow that starts an Xcode Cloud build when someone comments `/build` on a pull request.