### PR TITLE
Only open sleep sheet from the widget's Stop Sleep button

### DIFF
--- a/Baby Tracker Live Activities/FeedLiveActivityWidget.swift
+++ b/Baby Tracker Live Activities/FeedLiveActivityWidget.swift
@@ -10,7 +10,6 @@ struct FeedLiveActivityWidget: Widget {
             FeedLiveActivityContentView(state: context.state)
                 .activityBackgroundTint(Color(red: 0.12, green: 0.15, blue: 0.24))
                 .activitySystemActionForegroundColor(.white)
-                .widgetURL(FeedLiveActivityDeepLink.endSleepURL(childID: context.state.childID))
         } dynamicIsland: { context in
             DynamicIsland {
                 DynamicIslandExpandedRegion(.center) {


### PR DESCRIPTION
## Summary

- The Live Activity widget declared a widget-wide `.widgetURL(FeedLiveActivityDeepLink.endSleepURL(...))`, so tapping anywhere on the lock-screen banner or Dynamic Island launched the app with the end-sleep deep link — opening the sleep sheet even when no sleep session was active. That's the "random" sheet the user was seeing on app open.
- Removed the unconditional `widgetURL` from `FeedLiveActivityWidget`. The explicit `Link("Stop Sleep", destination: stopSleepURL)` inside `FeedLiveActivityContentView` already targets the same deep link and only renders when `activeSleepStartedAt != nil`, so it is now the only path that opens the sheet.
- Tapping the body of the Live Activity now falls back to the default behavior — opening the app to its current state, with no sheet.

## Test plan

- [ ] Start a sleep session, expand the Live Activity, tap the body (not the button) → app opens, no sleep sheet.
- [ ] Start a sleep session, tap the "Stop Sleep" button in the Live Activity → app opens with the end-sleep sheet for the correct child.
- [ ] With no active sleep, tap the lock-screen Live Activity / Dynamic Island → app opens, no sheet.
- [ ] Other entries (app icon, notifications) → app opens normally with no sheet.

https://claude.ai/code/session_01EkaKwNiRNzxEwzP4JXzeZN

---
_Generated by [Claude Code](https://claude.ai/code/session_01EkaKwNiRNzxEwzP4JXzeZN)_