### PR TITLE
Fix BGTaskScheduler launch-handler crash on background refresh

### DIFF
--- a/Baby Tracker/App/SystemBackgroundRefreshScheduler.swift
+++ b/Baby Tracker/App/SystemBackgroundRefreshScheduler.swift
@@ -40,7 +40,12 @@ final class SystemBackgroundRefreshScheduler: BackgroundRefreshScheduling {
                 task.setTaskCompleted(success: false)
                 return
             }
-            MainActor.assumeIsolated {
+            // BGTaskScheduler invokes this launch handler on a private
+            // background queue, so we must hop to the main actor before
+            // touching @MainActor state. `MainActor.assumeIsolated` would
+            // trap here because the runtime asserts we are already on the
+            // main queue.
+            Task { @MainActor in
                 self?.handle(task: appRefreshTask)
             }
         }


### PR DESCRIPTION
## Summary

TestFlight crash `74B2FFA5-37BD-437D-8475-3D63E899DC9A` (build 130) traps in `_dispatch_assert_queue_fail` while iOS is invoking our `BGAppRefreshTask` launch handler.

```
Thread 1 Crashed:
0  libdispatch.dylib            _dispatch_assert_queue_fail
1  libdispatch.dylib            dispatch_assert_queue$V2.cold.1
2  libdispatch.dylib            dispatch_assert_queue
3  libswift_Concurrency.dylib   _swift_task_checkIsolatedSwift
4  libswift_Concurrency.dylib   swift_task_isCurrentExecutorWithFlagsImpl
5  Baby Tracker                 closure #1 in SystemBackgroundRefreshScheduler.registerLaunchHandler(_:)
…
7  BackgroundTasks              -[BGTaskScheduler _runTask:registration:]_block_invoke_5
```

`BGTaskScheduler` invokes the registered launch handler on a private background dispatch queue. The previous implementation called `MainActor.assumeIsolated` from inside that closure to satisfy strict-concurrency isolation when calling the `@MainActor` `handle(task:)`. `assumeIsolated` is an **assertion**, not a hop — it asks dispatch whether the current queue is the main queue and traps when it isn't. So every time iOS launched us into the background to run the refresh, the process crashed at the boundary.

## Fix

Replace `MainActor.assumeIsolated { … }` with `Task { @MainActor in … }` so the work actually hops to the main actor before touching `@MainActor` state. Added a brief comment explaining the failure mode for future readers.

## Notes

- This is stacked on top of #252 since the file only exists on that branch. Cherry-picking the single commit onto #252 (or merging this once #252 lands) restores correct behavior.
- Hard to add a regression test in isolation: `BGTaskScheduler.shared.register` and `BGAppRefreshTask` aren't easily fakeable. The behavior is verifiable via Xcode's debugger trick from the test plan in #252 — before the fix it traps immediately on simulated launch, after the fix the refresh runs and `setTaskCompleted` fires.

## Test plan

- [ ] Build on iOS 26 simulator and confirm clean compile under Swift 6 strict concurrency.
- [ ] Background the app on device, then run `e -l objc -- (void)[[BGTaskScheduler sharedScheduler] _simulateLaunchForTaskWithIdentifier:@"com.adappt.BabyTracker.backgroundRefresh"]` in LLDB and confirm the app does **not** crash and that BackgroundRefresh log lines appear.
- [ ] Confirm `setTaskCompleted` runs to completion (timeline shows refreshed data on next foreground).

https://claude.ai/code/session_01NND8C8TkLMKQsy6E5seQFu

---
_Generated by [Claude Code](https://claude.ai/code/session_01NND8C8TkLMKQsy6E5seQFu)_