### PR TITLE
Revamp onboarding character layout

### DIFF
--- a/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/IdentityOnboardingNameStepView.swift
+++ b/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/IdentityOnboardingNameStepView.swift
@@ -7,11 +7,7 @@ struct IdentityOnboardingNameStepView: View {
     var body: some View {
         ScrollView {
             VStack(alignment: .leading, spacing: 24) {
-                AnimatedSymbolSceneView(symbolNames: [
-                    "person.fill",
-                    "heart.fill",
-                    "figure.and.child.holdinghands",
-                ])
+                OnboardingCharacterSceneView(scene: .caregiver)
 
                 VStack(alignment: .leading, spacing: 12) {
                     Text("Let’s set up your profile")

--- a/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/IdentityOnboardingView.swift
+++ b/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/IdentityOnboardingView.swift
@@ -128,9 +128,8 @@ public struct IdentityOnboardingView: View {
                         introPager
                     }
                 }
+                .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
                 .animation(reduceMotion ? nil : .easeInOut(duration: 0.25), value: currentStepIndex)
-
-                Spacer(minLength: 24)
 
                 footer
                     .padding(.horizontal, 24)

--- a/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/InteractiveOnboardingView.swift
+++ b/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/InteractiveOnboardingView.swift
@@ -116,12 +116,11 @@ public struct InteractiveOnboardingView: View {
 
                 stepContent
                     .id(currentStepIndex)
+                    .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
                     .transition(reduceMotion ? .opacity : .asymmetric(
                         insertion: .move(edge: isGoingBack ? .leading : .trailing).combined(with: .opacity),
                         removal: .move(edge: isGoingBack ? .trailing : .leading).combined(with: .opacity)
                     ))
-
-                Spacer(minLength: 24)
 
                 footer
                     .padding(.horizontal, 24)
@@ -207,7 +206,8 @@ public struct InteractiveOnboardingView: View {
         case .quickLogDemo:
             OnboardingDemoPageContainer(
                 title: "We're here to help",
-                message: "Log quickly, spot patterns, and stay in sync with your partner without carrying it all in your head."
+                message: "Log quickly, spot patterns, and stay in sync with your partner without carrying it all in your head.",
+                characterScene: .quickLog
             ) {
                 VStack(spacing: 10) {
                     OnboardingSupportHighlightsView()
@@ -221,7 +221,8 @@ public struct InteractiveOnboardingView: View {
         case .timelineDemo:
             OnboardingDemoPageContainer(
                 title: "See the whole picture",
-                message: "The timeline fills in as you log, so you can see the rhythm of any day at a glance."
+                message: "The timeline fills in as you log, so you can see the rhythm of any day at a glance.",
+                characterScene: .timeline
             ) {
                 OnboardingTimelineDemoView()
             }
@@ -229,7 +230,8 @@ public struct InteractiveOnboardingView: View {
         case .chartsDemo:
             OnboardingDemoPageContainer(
                 title: "Spot the patterns",
-                message: "The Summary tab turns raw events into charts so you can see what's changing week by week."
+                message: "The Summary tab turns raw events into charts so you can see what's changing week by week.",
+                characterScene: .charts
             ) {
                 OnboardingChartsDemoView()
             }
@@ -237,7 +239,8 @@ public struct InteractiveOnboardingView: View {
         case .liveActivityDemo:
             OnboardingDemoPageContainer(
                 title: "Stay updated from your Lock Screen",
-                message: "See the latest feed, sleep, and nappy timings without unlocking your phone."
+                message: "See the latest feed, sleep, and nappy timings without unlocking your phone.",
+                characterScene: .liveActivity
             ) {
                 OnboardingLiveActivityDemoView()
             }
@@ -245,7 +248,8 @@ public struct InteractiveOnboardingView: View {
         case .notificationsDemo:
             OnboardingDemoPageContainer(
                 title: "Get helpful alerts",
-                message: "Know when feeds, sleep, and changes are logged, even when you're away from the app."
+                message: "Know when feeds, sleep, and changes are logged, even when you're away from the app.",
+                characterScene: .notifications
             ) {
                 OnboardingNotificationsDemoView()
             }

--- a/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/OnboardingAddBabyStepView.swift
+++ b/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/OnboardingAddBabyStepView.swift
@@ -18,11 +18,7 @@ struct OnboardingAddBabyStepView: View {
     var body: some View {
         ScrollView {
             VStack(alignment: .leading, spacing: 24) {
-                AnimatedSymbolSceneView(symbolNames: [
-                    "teddybear.fill",
-                    "moon.zzz.fill",
-                    "heart.fill",
-                ])
+                OnboardingCharacterSceneView(scene: .babySetup)
 
                 VStack(alignment: .leading, spacing: 12) {
                     Text("Now let's add your baby")

--- a/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/OnboardingAppPreviewStepView.swift
+++ b/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/OnboardingAppPreviewStepView.swift
@@ -29,14 +29,9 @@ struct OnboardingAppPreviewStepView: View {
     var body: some View {
         ScrollView {
             VStack(alignment: .leading, spacing: 12) {
-                // Symbol scene
-                AnimatedSymbolSceneView(symbolNames: [
-                    "checkmark.seal.fill",
-                    "star.fill",
-                    "heart.fill",
-                ])
-                .opacity(appearedMask[0] ? 1 : 0)
-                .offset(y: appearedMask[0] ? 0 : 18)
+                OnboardingCharacterSceneView(scene: .appPreview)
+                    .opacity(appearedMask[0] ? 1 : 0)
+                    .offset(y: appearedMask[0] ? 0 : 18)
 
                 // Welcome heading
                 VStack(alignment: .leading, spacing: 6) {

--- a/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/OnboardingCharacterSceneView.swift
+++ b/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/OnboardingCharacterSceneView.swift
@@ -1,0 +1,227 @@
+import SwiftUI
+
+/// A small looping character vignette that gives each onboarding page a consistent visual anchor.
+struct OnboardingCharacterSceneView: View {
+    let scene: OnboardingCharacterScene
+
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+    @State private var isAnimating = false
+
+    var body: some View {
+        ZStack {
+            RoundedRectangle(cornerRadius: 28, style: .continuous)
+                .fill(scene.tint.opacity(0.14))
+                .overlay(alignment: .topTrailing) {
+                    Image(systemName: scene.backgroundSymbolName)
+                        .font(.system(size: 42, weight: .semibold))
+                        .foregroundStyle(scene.tint.opacity(0.18))
+                        .padding(18)
+                }
+
+            HStack(spacing: 18) {
+                character
+
+                VStack(alignment: .leading, spacing: 8) {
+                    Label(scene.caption, systemImage: scene.foregroundSymbolName)
+                        .font(.subheadline.weight(.semibold))
+                        .foregroundStyle(scene.tint)
+                        .lineLimit(2)
+
+                    Text(scene.detail)
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                        .fixedSize(horizontal: false, vertical: true)
+                }
+
+                Spacer(minLength: 0)
+            }
+            .padding(18)
+        }
+        .frame(maxWidth: .infinity)
+        .frame(height: 132)
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel(scene.accessibilityLabel)
+        .onAppear { startAnimation() }
+    }
+
+    private var character: some View {
+        ZStack {
+            Circle()
+                .fill(.white.opacity(0.9))
+                .frame(width: 78, height: 78)
+                .shadow(color: scene.tint.opacity(0.18), radius: 14, y: 8)
+
+            Circle()
+                .fill(scene.tint.opacity(0.95))
+                .frame(width: 58, height: 58)
+                .overlay(alignment: .topLeading) {
+                    Circle()
+                        .fill(.white.opacity(0.28))
+                        .frame(width: 18, height: 18)
+                        .padding(10)
+                }
+
+            HStack(spacing: 9) {
+                Circle()
+                    .fill(.white)
+                    .frame(width: 8, height: 8)
+                Circle()
+                    .fill(.white)
+                    .frame(width: 8, height: 8)
+            }
+            .offset(y: -5)
+
+            Capsule()
+                .fill(.white.opacity(0.9))
+                .frame(width: 22, height: 5)
+                .offset(y: 13)
+
+            Image(systemName: scene.foregroundSymbolName)
+                .font(.system(size: 23, weight: .bold))
+                .foregroundStyle(scene.tint)
+                .padding(11)
+                .background(.white, in: Circle())
+                .offset(x: 35, y: isAnimating ? -32 : -24)
+                .rotationEffect(.degrees(isAnimating ? 9 : -7))
+        }
+        .offset(y: isAnimating ? -5 : 5)
+        .scaleEffect(isAnimating ? 1.02 : 0.98)
+        .animation(reduceMotion ? nil : .easeInOut(duration: 1.15).repeatForever(autoreverses: true), value: isAnimating)
+    }
+
+    private func startAnimation() {
+        guard !reduceMotion else {
+            isAnimating = true
+            return
+        }
+        isAnimating = true
+    }
+}
+
+enum OnboardingCharacterScene: Equatable {
+    case tiredMemory
+    case quickLog
+    case timeline
+    case charts
+    case sharing
+    case privacy
+    case liveActivity
+    case notifications
+    case caregiver
+    case babySetup
+    case customize
+    case firstEvent
+    case appPreview
+
+    init(introPageID: String) {
+        switch introPageID {
+        case "app-help": self = .quickLog
+        case "sharing": self = .sharing
+        case "security": self = .privacy
+        default: self = .tiredMemory
+        }
+    }
+
+    var caption: String {
+        switch self {
+        case .tiredMemory: return "A calm place to remember"
+        case .quickLog: return "Tiny taps, useful history"
+        case .timeline: return "The day comes together"
+        case .charts: return "Patterns become clearer"
+        case .sharing: return "Caregivers stay in sync"
+        case .privacy: return "Private by default"
+        case .liveActivity: return "Glanceable updates"
+        case .notifications: return "Helpful nudges"
+        case .caregiver: return "Your caregiver profile"
+        case .babySetup: return "Your baby’s space"
+        case .customize: return "Track what matters"
+        case .firstEvent: return "Start with one log"
+        case .appPreview: return "Ready for real days"
+        }
+    }
+
+    var detail: String {
+        switch self {
+        case .tiredMemory: return "Nest keeps the details close when sleep is short."
+        case .quickLog: return "Log feeds, nappies, sleep, and more in seconds."
+        case .timeline: return "A friendly timeline shows how the day is unfolding."
+        case .charts: return "Summaries turn busy days into easy-to-read trends."
+        case .sharing: return "Everyone sees the same latest timeline."
+        case .privacy: return "Your data stays with you and invited caregivers."
+        case .liveActivity: return "See what just happened from the Lock Screen."
+        case .notifications: return "Know when something important is logged."
+        case .caregiver: return "Add your name so shared logs feel personal."
+        case .babySetup: return "Create the profile your logs will belong to."
+        case .customize: return "Pick the event buttons that fit your family."
+        case .firstEvent: return "Try a real event before entering the app."
+        case .appPreview: return "You’re set up and ready to use Nest."
+        }
+    }
+
+    var tint: Color {
+        switch self {
+        case .tiredMemory: return .indigo
+        case .quickLog: return .mint
+        case .timeline: return .blue
+        case .charts: return .purple
+        case .sharing: return .teal
+        case .privacy: return .green
+        case .liveActivity: return .orange
+        case .notifications: return .pink
+        case .caregiver: return .cyan
+        case .babySetup: return .accentColor
+        case .customize: return .brown
+        case .firstEvent: return .yellow
+        case .appPreview: return .accentColor
+        }
+    }
+
+    var foregroundSymbolName: String {
+        switch self {
+        case .tiredMemory: return "moon.zzz.fill"
+        case .quickLog: return "plus.circle.fill"
+        case .timeline: return "list.bullet.rectangle.portrait.fill"
+        case .charts: return "chart.line.uptrend.xyaxis"
+        case .sharing: return "person.2.fill"
+        case .privacy: return "lock.shield.fill"
+        case .liveActivity: return "iphone.gen3.radiowaves.left.and.right"
+        case .notifications: return "bell.badge.fill"
+        case .caregiver: return "person.crop.circle.fill"
+        case .babySetup: return "teddybear.fill"
+        case .customize: return "slider.horizontal.3"
+        case .firstEvent: return "sparkles"
+        case .appPreview: return "house.fill"
+        }
+    }
+
+    var backgroundSymbolName: String {
+        switch self {
+        case .tiredMemory: return "clock.badge.questionmark.fill"
+        case .quickLog: return "checkmark.circle.fill"
+        case .timeline: return "calendar"
+        case .charts: return "chart.bar.xaxis"
+        case .sharing: return "arrow.triangle.2.circlepath"
+        case .privacy: return "icloud.fill"
+        case .liveActivity: return "lock.rectangle.stack.fill"
+        case .notifications: return "badge.fill"
+        case .caregiver: return "heart.fill"
+        case .babySetup: return "star.fill"
+        case .customize: return "line.3.horizontal.decrease.circle.fill"
+        case .firstEvent: return "hand.tap.fill"
+        case .appPreview: return "party.popper.fill"
+        }
+    }
+
+    var accessibilityLabel: String {
+        "Animated onboarding character. \(caption). \(detail)"
+    }
+}
+
+#Preview("Onboarding Character") {
+    VStack(spacing: 16) {
+        OnboardingCharacterSceneView(scene: .quickLog)
+        OnboardingCharacterSceneView(scene: .charts)
+    }
+    .padding()
+    .background(Color(.systemGroupedBackground))
+}

--- a/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/OnboardingCustomizeEventsStepView.swift
+++ b/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/OnboardingCustomizeEventsStepView.swift
@@ -9,6 +9,7 @@ struct OnboardingCustomizeEventsStepView: View {
     var body: some View {
         ScrollView {
             VStack(alignment: .leading, spacing: 28) {
+                OnboardingCharacterSceneView(scene: .customize)
                 header
                 kindCard
             }

--- a/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/OnboardingDemoPageContainer.swift
+++ b/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/OnboardingDemoPageContainer.swift
@@ -1,14 +1,15 @@
 import SwiftUI
 
-/// Animated page wrapper used by the three feature-demo steps (Quick Log, Timeline, Charts).
+/// Animated page wrapper used by feature-demo steps.
 ///
 /// Title and body text stagger in on appear. The `demo` content is responsible for its
 /// own entry animation so per-element timing is preserved. The page indicator lives in
 /// `InteractiveOnboardingView`'s footer so it stays pinned just above the Continue button
-/// across all four intro pages.
+/// across all intro pages.
 struct OnboardingDemoPageContainer<Demo: View>: View {
     let title: String
     let message: String
+    let characterScene: OnboardingCharacterScene
     let demo: () -> Demo
 
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
@@ -18,35 +19,45 @@ struct OnboardingDemoPageContainer<Demo: View>: View {
     init(
         title: String,
         message: String,
+        characterScene: OnboardingCharacterScene,
         @ViewBuilder demo: @escaping () -> Demo
     ) {
         self.title = title
         self.message = message
+        self.characterScene = characterScene
         self.demo = demo
     }
 
     var body: some View {
-        VStack(spacing: 0) {
-            VStack(alignment: .leading, spacing: 12) {
-                Text(title)
-                    .font(.largeTitle.weight(.bold))
-                    .fixedSize(horizontal: false, vertical: true)
-                    .opacity(titleAppeared ? 1 : 0)
+        ScrollView {
+            VStack(spacing: 0) {
+                VStack(alignment: .leading, spacing: 16) {
+                    OnboardingCharacterSceneView(scene: characterScene)
 
-                Text(message)
-                    .font(.title3)
-                    .foregroundStyle(.secondary)
-                    .fixedSize(horizontal: false, vertical: true)
-                    .opacity(messageAppeared ? 1 : 0)
-            }
-            .frame(maxWidth: .infinity, alignment: .leading)
-            .padding(.horizontal, 24)
-            .padding(.top, 32)
-            .padding(.bottom, 20)
+                    VStack(alignment: .leading, spacing: 12) {
+                        Text(title)
+                            .font(.largeTitle.weight(.bold))
+                            .fixedSize(horizontal: false, vertical: true)
+                            .opacity(titleAppeared ? 1 : 0)
 
-            demo()
+                        Text(message)
+                            .font(.title3)
+                            .foregroundStyle(.secondary)
+                            .fixedSize(horizontal: false, vertical: true)
+                            .opacity(messageAppeared ? 1 : 0)
+                    }
+                    .frame(minHeight: 132, alignment: .topLeading)
+                }
+                .frame(maxWidth: .infinity, alignment: .leading)
                 .padding(.horizontal, 24)
+                .padding(.top, 32)
+                .padding(.bottom, 20)
+
+                demo()
+                    .padding(.horizontal, 24)
+            }
         }
+        .scrollBounceBehavior(.basedOnSize)
         .onAppear {
             animateIn()
         }
@@ -71,7 +82,8 @@ struct OnboardingDemoPageContainer<Demo: View>: View {
 #Preview {
     OnboardingDemoPageContainer(
         title: "Log anything in 2 taps",
-        message: "Tap one button, fill in the details, done. No fumbling around."
+        message: "Tap one button, fill in the details, done. No fumbling around.",
+        characterScene: .quickLog
     ) {
         Color.accentColor.opacity(0.1)
             .frame(height: 180)

--- a/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/OnboardingFirstEventStepView.swift
+++ b/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/OnboardingFirstEventStepView.swift
@@ -31,6 +31,8 @@ struct OnboardingFirstEventStepView: View {
     var body: some View {
         ScrollView {
             VStack(alignment: .leading, spacing: 24) {
+                OnboardingCharacterSceneView(scene: .firstEvent)
+
                 VStack(alignment: .leading, spacing: 12) {
                     Text("Log your first event")
                         .font(.largeTitle.weight(.bold))

--- a/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/OnboardingIntroStepView.swift
+++ b/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/OnboardingIntroStepView.swift
@@ -8,7 +8,7 @@ struct OnboardingIntroStepView: View {
         VStack(alignment: .leading, spacing: 24) {
             Spacer(minLength: 24)
 
-            OnboardingIntroIconSceneView(page: page)
+            OnboardingCharacterSceneView(scene: OnboardingCharacterScene(introPageID: page.id))
 
             VStack(alignment: .leading, spacing: 12) {
                 Text(page.title)

--- a/docs/plans/109-onboarding-character-layout-revamp.md
+++ b/docs/plans/109-onboarding-character-layout-revamp.md
@@ -1,0 +1,29 @@
+# 109 Onboarding Character Layout Revamp
+
+## Goal
+
+Revamp onboarding so every step feels visually consistent and stable while adding a small animated character vignette that reflects each page's content.
+
+## Approach
+
+1. Add a reusable SwiftUI character scene for onboarding pages.
+   - Keep it lightweight and local to the onboarding presentation layer.
+   - Use simple SwiftUI animation instead of adding video asset management or playback complexity.
+   - Provide variants that match the page topic, such as quick logging, timeline, charts, notifications, profile setup, baby setup, and app preview.
+2. Update intro and demo onboarding page wrappers to show the character scene above each page's title and body copy.
+3. Update setup and interactive steps so the same character treatment appears on every onboarding page.
+4. Make the interactive onboarding layout reserve a consistent content area between the top bar and footer.
+   - Keep the footer pinned so Continue and setup buttons do not jump between steps.
+   - Allow individual step content to scroll inside the reserved area when needed.
+5. Keep changes focused on onboarding presentation and preserve existing flow behavior.
+6. Build and run relevant package tests before committing.
+
+## Acceptance criteria
+
+1. Every interactive onboarding page includes an animated character scene that represents the step content.
+2. The footer buttons remain in a stable vertical position as users move between onboarding pages.
+3. Existing onboarding actions and skip behavior continue to work.
+4. Relevant previews remain present for touched SwiftUI views.
+5. The implementation avoids unnecessary abstraction and does not introduce video playback dependencies.
+
+- [x] Complete


### PR DESCRIPTION
### Motivation
- Provide a consistent, friendly visual anchor on every onboarding page and avoid introducing heavyweight video playback by using a lightweight looping SwiftUI vignette. 
- Keep onboarding content height stable so footer actions (Continue / Get Started / Add Baby) do not jump between steps as the user moves through the flow. 

### Description
- Added a reusable `OnboardingCharacterSceneView` and `OnboardingCharacterScene` enum to provide per-step character vignettes, captions, tinting, symbols, reduced-motion support, and accessibility labeling (`Packages/.../OnboardingCharacterSceneView.swift`).
- Updated demo page wrapper `OnboardingDemoPageContainer` to accept a `characterScene` and render the character above the title/body, made the demo container scrollable, and reserved a `minHeight` so title/body + character always occupy the same area.
- Replaced prior symbol/scene widgets with the new character view across onboarding pages including intro pages, quick-log/timeline/charts/live-activity/notifications demos, caregiver name step, baby setup, customize events, first-event, and app preview so every onboarding step shows the vignette and shares a consistent layout (`Packages/.../Views/*Onboarding*.swift`).
- Stabilized layout in onboarding shells by giving the step content a fixed reserved area (`.frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)`) so the footer remains pinned across step transitions (changes in `InteractiveOnboardingView` and `IdentityOnboardingView`).
- Added a plan document describing the change and acceptance criteria at `docs/plans/109-onboarding-character-layout-revamp.md` and preserved `#Preview` entries for the touched views.

### Testing
- Ran `git diff --check` which succeeded with no whitespace errors.
- Attempted `swift test --package-path Packages/BabyTrackerFeature` but it failed due to the environment using Swift 6.1.3 while the package specifies Swift tools version 6.2, so package tests could not run here.
- Attempted `./scripts/validate.sh` / `xcodebuild` but the environment does not include `xcodebuild`, so full workspace validation could not run here.
- Attempted `swiftc -typecheck` on the new view but the Linux Swift toolchain in this environment does not include the `SwiftUI` module, so typechecking UI code could not be completed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a065339306c832fb04dc39c59c1c6b0)