### PR TITLE
Add GitHub Action to create Release/TestFlight tags from PR comments

### DIFF
--- a/.github/workflows/pr-comment-tags.yml
+++ b/.github/workflows/pr-comment-tags.yml
@@ -1,0 +1,140 @@
+name: PR Comment Tags
+
+on:
+  issue_comment:
+    types:
+      - created
+
+permissions:
+  contents: write
+  issues: write
+  pull-requests: read
+
+jobs:
+  tag:
+    if: ${{ github.event.issue.pull_request && (github.event.comment.body == 'tag Release' || github.event.comment.body == 'tag TestFlight') }}
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Resolve tag request
+        id: request
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const body = context.payload.comment.body.trim();
+            const match = body.match(/^tag (Release|TestFlight)$/);
+
+            if (!match) {
+              core.setFailed('Unsupported tag request. Use `tag Release` or `tag TestFlight`.');
+              return;
+            }
+
+            const allowedAssociations = new Set(['OWNER', 'MEMBER', 'COLLABORATOR']);
+            const authorAssociation = context.payload.comment.author_association;
+
+            if (!allowedAssociations.has(authorAssociation)) {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                body: [
+                  '> Tag request rejected.',
+                  '> Only repository owners, members, and collaborators can create release tags from pull request comments.',
+                ].join('\n'),
+              });
+
+              core.setFailed(`Unauthorized comment author association: ${authorAssociation}`);
+              return;
+            }
+
+            const pullRequest = await github.request(context.payload.issue.pull_request.url, {
+              headers: {
+                accept: 'application/vnd.github+json',
+              },
+            });
+
+            const pr = pullRequest.data;
+            const isFork = pr.head.repo.full_name !== pr.base.repo.full_name;
+
+            if (isFork) {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                body: [
+                  '> Tag request rejected.',
+                  '> Release tags can only be created from pull requests whose head branch is in this repository.',
+                ].join('\n'),
+              });
+
+              core.setFailed('Fork pull requests are not supported for release tag creation.');
+              return;
+            }
+
+            const tagFamily = match[1];
+            const now = new Date();
+            const timestamp = now.toISOString().replace(/[-:]/g, '').replace(/\.\d{3}Z$/, 'Z');
+            const shortSha = pr.head.sha.slice(0, 12);
+            const tagName = `${tagFamily}-${timestamp}-${shortSha}`;
+
+            core.setOutput('tag_family', tagFamily);
+            core.setOutput('tag_name', tagName);
+            core.setOutput('head_sha', pr.head.sha);
+            core.setOutput('head_ref', pr.head.ref);
+
+      - name: Create tag
+        uses: actions/github-script@v7
+        env:
+          TAG_NAME: ${{ steps.request.outputs.tag_name }}
+          HEAD_SHA: ${{ steps.request.outputs.head_sha }}
+        with:
+          script: |
+            await github.rest.git.createRef({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              ref: `refs/tags/${process.env.TAG_NAME}`,
+              sha: process.env.HEAD_SHA,
+            });
+
+      - name: Comment with tag details
+        uses: actions/github-script@v7
+        env:
+          TAG_FAMILY: ${{ steps.request.outputs.tag_family }}
+          TAG_NAME: ${{ steps.request.outputs.tag_name }}
+          HEAD_SHA: ${{ steps.request.outputs.head_sha }}
+          HEAD_REF: ${{ steps.request.outputs.head_ref }}
+        with:
+          script: |
+            const tagUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/tree/${process.env.TAG_NAME}`;
+            const commitUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/commit/${process.env.HEAD_SHA}`;
+            const body = [
+              `> ${process.env.TAG_FAMILY} tag created.`,
+              `> Tag: [\`${process.env.TAG_NAME}\`](${tagUrl})`,
+              `> Branch: \`${process.env.HEAD_REF}\``,
+              `> Commit: [\`${process.env.HEAD_SHA.slice(0, 12)}\`](${commitUrl})`,
+            ].join('\n');
+
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              body,
+            });
+
+      - name: Comment with failure details
+        if: ${{ failure() && steps.request.outcome == 'success' }}
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+            const body = [
+              '> Tag request failed.',
+              `> Review the GitHub Actions logs: ${runUrl}`,
+            ].join('\n');
+
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              body,
+            });

--- a/docs/plans/109-pr-comment-release-tags.md
+++ b/docs/plans/109-pr-comment-release-tags.md
@@ -1,0 +1,16 @@
+# 109 PR Comment Release Tags
+
+## Goal
+
+Add a GitHub Actions workflow that lets maintainers create release trigger tags from a pull request comment.
+
+## Approach
+
+1. Create a new `issue_comment` workflow that only runs for pull request comments matching `tag Release` or `tag TestFlight`.
+2. Resolve the pull request head SHA through the GitHub API so the tag points at the latest commit on the PR branch, not the base branch or a merge ref.
+3. Restrict tag creation to trusted commenters and same-repository pull requests before granting the workflow permission to write tags.
+4. Create a unique lightweight tag using the requested tag family as a prefix, then push it with the workflow token.
+5. Comment back on the PR with either the created tag details or a clear rejection/failure message.
+6. Validate the workflow YAML and review the diff for unrelated changes.
+
+- [x] Complete


### PR DESCRIPTION
### Motivation
- Provide a lightweight, auditable way to drop repository tags for release pipelines from a pull request by commenting `tag Release` or `tag TestFlight` on the PR. 
- Ensure tagging is safe by pointing the tag at the PR head commit and restricting who and which PRs can request tags.

### Description
- Add a new workflow `.github/workflows/pr-comment-tags.yml` that triggers on `issue_comment` events and only runs for comments that equal `tag Release` or `tag TestFlight`. 
- The workflow resolves the PR head via the GitHub API, rejects forked PRs, validates the commenter association (only `OWNER`, `MEMBER`, or `COLLABORATOR`), and constructs a tag named `<Release|TestFlight>-<UTC timestamp>-<short SHA>` which it creates with `refs/tags/<tag>`. 
- The workflow uses `actions/github-script@v7` and requires `contents: write`, `issues: write`, and `pull-requests: read` permissions, and it comments back to the PR with the created tag, branch, and commit details or a clear failure message. 
- Add implementation plan `docs/plans/109-pr-comment-release-tags.md` documenting goals, approach, and completion state.

### Testing
- Verified the workflow YAML can be parsed with `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/pr-comment-tags.yml")'`, which returned `yaml ok`. 
- Ran `git diff --check` to confirm there are no whitespace or basic diff issues and inspected the generated diff for the two new files. 
- Attempted to run `actionlint` via `go` and `npx` but both runs failed due to external registry/proxy restrictions (Go proxy and npm registry returned `403 Forbidden`), so `actionlint` could not be executed in this environment. 
- No GitHub-hosted executions were performed here; the workflow should be validated further by creating a PR and commenting `tag Release`/`tag TestFlight` in a non-fork PR to confirm runtime behavior and permissions.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1ab6f23700832faaa8d84986d54be5)