### PR TITLE
Add medication tracking

### DIFF
--- a/Baby Tracker Live Activities/BabyEventKindAccentColor.swift
+++ b/Baby Tracker Live Activities/BabyEventKindAccentColor.swift
@@ -14,6 +14,8 @@ extension BabyEventKind {
             Color(red: 0.29, green: 0.33, blue: 0.73)
         case .nappy:
             Color(red: 0.74, green: 0.47, blue: 0.16)
+        case .medication:
+            Color(red: 0.55, green: 0.34, blue: 0.78)
         }
     }
 }

--- a/Baby Tracker Live Activities/FeedLiveActivityContentView.swift
+++ b/Baby Tracker Live Activities/FeedLiveActivityContentView.swift
@@ -120,6 +120,8 @@ struct FeedLiveActivityContentView: View {
             "bed.double"
         case .nappy:
             "checklist"
+        case .medication:
+            "pills.fill"
         }
     }
 

--- a/Baby Tracker Live Activities/FeedLiveActivityWidget.swift
+++ b/Baby Tracker Live Activities/FeedLiveActivityWidget.swift
@@ -64,6 +64,8 @@ struct FeedLiveActivityWidget: Widget {
             metric.isActiveSleep ? "zzz" : "bed.double.fill"
         case .nappy:
             "checklist"
+        case .medication:
+            "pills.fill"
         }
     }
 

--- a/Baby TrackerTests/AppModelTests.swift
+++ b/Baby TrackerTests/AppModelTests.swift
@@ -1466,11 +1466,11 @@ struct AppModelTests {
         harness.model.setEventKindEnabled(.breastFeed, isEnabled: false)
 
         #expect(!harness.model.isEventKindEnabled(.breastFeed))
-        #expect(visibilityStore.enabledEventKinds == [.bath, .bottleFeed, .sleep, .nappy])
+        #expect(visibilityStore.enabledEventKinds == [.bath, .bottleFeed, .sleep, .nappy, .medication])
         #expect(!harness.model.events.contains(where: { $0.id == breastFeed.id }))
         #expect(harness.model.events.contains(where: { $0.id == bottleFeed.id }))
         #expect(HomeViewModel(appModel: harness.model).currentStatus.row(for: .breastFeed) == nil)
-        #expect(HomeViewModel(appModel: harness.model).currentStatus.visibleEventKinds == [.bath, .bottleFeed, .sleep, .nappy])
+        #expect(HomeViewModel(appModel: harness.model).currentStatus.visibleEventKinds == [.bath, .bottleFeed, .sleep, .nappy, .medication])
 
         harness.model.setEventKindEnabled(.breastFeed, isEnabled: true)
 

--- a/Baby TrackerTests/BabyEventStyleTests.swift
+++ b/Baby TrackerTests/BabyEventStyleTests.swift
@@ -8,7 +8,7 @@ import UIKit
 struct BabyEventStyleTests {
     @Test
     func prominentEventSurfacesMaintainReadableContrastAcrossAppearances() {
-        for kind in [BabyEventKind.bath, .breastFeed, .bottleFeed, .sleep, .nappy] {
+        for kind in [BabyEventKind.bath, .breastFeed, .bottleFeed, .sleep, .nappy, .medication] {
             let fill = UIColor(BabyEventStyle.buttonFillColor(for: kind))
             let foreground = UIColor(BabyEventStyle.buttonForegroundColor(for: kind))
 
@@ -19,7 +19,7 @@ struct BabyEventStyleTests {
 
     @Test
     func eventCardsMaintainReadableContrastAcrossAppearances() {
-        for kind in [BabyEventKind.bath, .breastFeed, .bottleFeed, .sleep, .nappy] {
+        for kind in [BabyEventKind.bath, .breastFeed, .bottleFeed, .sleep, .nappy, .medication] {
             let fill = UIColor(BabyEventStyle.cardFillColor(for: kind))
             let foreground = UIColor(BabyEventStyle.cardForegroundColor(for: kind))
             let secondaryForeground = UIColor(BabyEventStyle.cardSecondaryForegroundColor(for: kind))

--- a/Baby TrackerTests/CloudKitRecordMapperTests.swift
+++ b/Baby TrackerTests/CloudKitRecordMapperTests.swift
@@ -173,6 +173,52 @@ struct CloudKitRecordMapperTests {
     }
 
     @Test
+    func medicationMapperRoundTripsCustomUnit() throws {
+        let childID = UUID()
+        let userID = UUID()
+        let occurredAt = Date(timeIntervalSince1970: 4_200)
+        let zoneID = CloudKitRecordNames.zoneID(
+            for: childID,
+            ownerName: "probe-owner"
+        )
+        let medication = try MedicationEvent(
+            metadata: EventMetadata(
+                childID: childID,
+                occurredAt: occurredAt,
+                createdAt: occurredAt,
+                createdBy: userID
+            ),
+            medicineName: "Calpol",
+            amount: 2.5,
+            unit: .custom,
+            customUnitLabel: "puff"
+        )
+
+        let record = CloudKitRecordMapper.eventRecord(
+            from: .medication(medication),
+            zoneID: zoneID
+        )
+
+        #expect(record.recordType == CloudKitConfiguration.medicationRecordType)
+        #expect(record["medicineName"] as? String == "Calpol")
+        #expect(record["amount"] as? Double == 2.5)
+        #expect(record["unit"] as? String == MedicationUnit.custom.rawValue)
+        #expect(record["customUnitLabel"] as? String == "puff")
+
+        let mappedEvent = try CloudKitRecordMapper.event(from: record)
+
+        switch mappedEvent {
+        case let .medication(event):
+            #expect(event.medicineName == "Calpol")
+            #expect(event.amount == 2.5)
+            #expect(event.unit == .custom)
+            #expect(event.customUnitLabel == "puff")
+        default:
+            Issue.record("Expected a medication event")
+        }
+    }
+
+    @Test
     func sleepMapperRoundTripsOpenEndedAndCompletedSessions() throws {
         let childID = UUID()
         let userID = UUID()

--- a/Baby TrackerTests/EventRepositoryTests.swift
+++ b/Baby TrackerTests/EventRepositoryTests.swift
@@ -282,6 +282,44 @@ struct EventRepositoryTests {
     }
 
     @Test
+    func medicationEventsRoundTripWithAmountAndUnit() throws {
+        let harness = try RepositoryHarness()
+        defer { harness.cleanUp() }
+
+        let childID = UUID()
+        let userID = UUID()
+        let occurredAt = Date(timeIntervalSince1970: 11_000)
+
+        let medication = try MedicationEvent(
+            metadata: EventMetadata(
+                childID: childID,
+                occurredAt: occurredAt,
+                createdAt: occurredAt,
+                createdBy: userID
+            ),
+            medicineName: "Ibuprofen (Nurofen)",
+            amount: 2.5,
+            unit: .ml
+        )
+
+        try harness.repository.saveEvent(.medication(medication))
+
+        let timeline = try harness.repository.loadTimeline(for: childID, includingDeleted: false)
+        #expect(timeline.map(\.kind) == [.medication])
+
+        let reloaded = try #require(try harness.repository.loadEvent(id: medication.id))
+        switch reloaded {
+        case let .medication(event):
+            #expect(event.medicineName == "Ibuprofen (Nurofen)")
+            #expect(event.amount == 2.5)
+            #expect(event.unit == .ml)
+            #expect(event.customUnitLabel == nil)
+        default:
+            Issue.record("Expected a medication event")
+        }
+    }
+
+    @Test
     func savingEditedEventUpdatesExistingRecordInPlace() throws {
         let harness = try RepositoryHarness()
         defer { harness.cleanUp() }

--- a/Baby TrackerTests/TestDoubles/InMemoryEventRepository.swift
+++ b/Baby TrackerTests/TestDoubles/InMemoryEventRepository.swift
@@ -79,6 +79,9 @@ final class InMemoryEventRepository: EventRepository {
         case var .nappy(e):
             e.metadata.markDeleted(at: deletedAt, by: deletedBy)
             store.events[id] = .nappy(e)
+        case var .medication(e):
+            e.metadata.markDeleted(at: deletedAt, by: deletedBy)
+            store.events[id] = .medication(e)
         }
         store.syncStates[id]?.state = .pendingSync
     }
@@ -90,6 +93,7 @@ final class InMemoryEventRepository: EventRepository {
         case .bottleFeed: return .bottleFeedEvent
         case .sleep: return .sleepEvent
         case .nappy: return .nappyEvent
+        case .medication: return .medicationEvent
         }
     }
 }

--- a/Packages/BabyTrackerDomain/Sources/BabyTrackerDomain/BabyEvent.swift
+++ b/Packages/BabyTrackerDomain/Sources/BabyTrackerDomain/BabyEvent.swift
@@ -6,6 +6,7 @@ public enum BabyEvent: Equatable, Identifiable, Sendable {
     case bottleFeed(BottleFeedEvent)
     case sleep(SleepEvent)
     case nappy(NappyEvent)
+    case medication(MedicationEvent)
 
     public var id: UUID {
         metadata.id
@@ -23,6 +24,8 @@ public enum BabyEvent: Equatable, Identifiable, Sendable {
             event.metadata
         case let .nappy(event):
             event.metadata
+        case let .medication(event):
+            event.metadata
         }
     }
 
@@ -38,6 +41,8 @@ public enum BabyEvent: Equatable, Identifiable, Sendable {
             .sleep
         case .nappy:
             .nappy
+        case .medication:
+            .medication
         }
     }
 }

--- a/Packages/BabyTrackerDomain/Sources/BabyTrackerDomain/BabyEventError.swift
+++ b/Packages/BabyTrackerDomain/Sources/BabyTrackerDomain/BabyEventError.swift
@@ -3,6 +3,8 @@ import Foundation
 public enum BabyEventError: LocalizedError, Equatable, Sendable {
     case invalidDateRange
     case invalidBottleAmount
+    case invalidMedicationAmount
+    case invalidMedicationName
     case activeSleepAlreadyInProgress
     case noActiveSleepInProgress
     case sleepAlreadyActive
@@ -13,6 +15,10 @@ public enum BabyEventError: LocalizedError, Equatable, Sendable {
             "End time must be later than the start time."
         case .invalidBottleAmount:
             "Bottle feeds must record a positive amount."
+        case .invalidMedicationAmount:
+            "Medication doses must record a positive amount."
+        case .invalidMedicationName:
+            "Medication must have a name."
         case .activeSleepAlreadyInProgress:
             "A sleep session is already in progress."
         case .noActiveSleepInProgress:

--- a/Packages/BabyTrackerDomain/Sources/BabyTrackerDomain/BabyEventKind.swift
+++ b/Packages/BabyTrackerDomain/Sources/BabyTrackerDomain/BabyEventKind.swift
@@ -6,4 +6,5 @@ public enum BabyEventKind: String, CaseIterable, Codable, Equatable, Hashable, S
     case bottleFeed
     case sleep
     case nappy
+    case medication
 }

--- a/Packages/BabyTrackerDomain/Sources/BabyTrackerDomain/EventFilter.swift
+++ b/Packages/BabyTrackerDomain/Sources/BabyTrackerDomain/EventFilter.swift
@@ -74,6 +74,9 @@ public struct EventFilter: Equatable, Sendable {
         case .bath:
             break
 
+        case .medication:
+            break
+
         case let .bottleFeed(bottle):
             if !milkTypes.isEmpty {
                 guard let milkType = bottle.milkType, milkTypes.contains(milkType) else {

--- a/Packages/BabyTrackerDomain/Sources/BabyTrackerDomain/ImportableEvent.swift
+++ b/Packages/BabyTrackerDomain/Sources/BabyTrackerDomain/ImportableEvent.swift
@@ -7,6 +7,7 @@ public enum ImportableEvent: Equatable, Sendable, Identifiable {
     case breastFeed(BreastFeedImport)
     case sleep(SleepImport)
     case nappy(NappyImport)
+    case medication(MedicationImport)
 
     public var id: UUID { metadata.id }
 
@@ -17,6 +18,7 @@ public enum ImportableEvent: Equatable, Sendable, Identifiable {
         case .breastFeed(let e): return e.metadata
         case .sleep(let e): return e.metadata
         case .nappy(let e): return e.metadata
+        case .medication(let e): return e.metadata
         }
     }
 
@@ -29,6 +31,7 @@ public enum ImportableEvent: Equatable, Sendable, Identifiable {
         case .breastFeed: return .breastFeed
         case .sleep: return .sleep
         case .nappy: return .nappy
+        case .medication: return .medication
         }
     }
 
@@ -62,6 +65,8 @@ public enum ImportableEvent: Equatable, Sendable, Identifiable {
             return DurationText.short(minutes: durationMinutes)
         case .nappy(let e):
             return e.type.displayName
+        case .medication(let e):
+            return "\(e.medicineName) · \(e.displayAmount)"
         }
     }
 
@@ -72,6 +77,7 @@ public enum ImportableEvent: Equatable, Sendable, Identifiable {
         case .breastFeed: return "Breast Feed"
         case .sleep: return "Sleep"
         case .nappy: return "Nappy"
+        case .medication: return "Medication"
         }
     }
 }
@@ -115,6 +121,46 @@ public struct BathImport: Equatable, Sendable {
         self.metadata = metadata
         self.usedShampoo = usedShampoo
         self.usedSoap = usedSoap
+    }
+}
+
+public struct MedicationImport: Equatable, Sendable {
+    public let metadata: ImportEventMetadata
+    public let medicineName: String
+    public let amount: Double
+    public let unit: MedicationUnit
+    public let customUnitLabel: String?
+
+    public init(
+        metadata: ImportEventMetadata,
+        medicineName: String,
+        amount: Double,
+        unit: MedicationUnit,
+        customUnitLabel: String?
+    ) {
+        self.metadata = metadata
+        self.medicineName = medicineName
+        self.amount = amount
+        self.unit = unit
+        self.customUnitLabel = customUnitLabel
+    }
+
+    /// Amount + unit for display (e.g. "2.5 ml"), resolving the custom unit label.
+    public var displayAmount: String {
+        let amountText: String
+        let rounded = (amount * 100).rounded() / 100
+        if rounded == rounded.rounded() {
+            amountText = String(Int(rounded))
+        } else {
+            amountText = String(rounded)
+        }
+        let unitText: String
+        if unit == .custom, let label = customUnitLabel, !label.isEmpty {
+            unitText = label
+        } else {
+            unitText = unit.shortTitle
+        }
+        return "\(amountText) \(unitText)"
     }
 }
 

--- a/Packages/BabyTrackerDomain/Sources/BabyTrackerDomain/MedicationCatalog.swift
+++ b/Packages/BabyTrackerDomain/Sources/BabyTrackerDomain/MedicationCatalog.swift
@@ -8,7 +8,6 @@ public enum MedicationCatalog {
         "Paracetamol (Calpol)",
         "Ibuprofen (Nurofen)",
         "Vitamin D drops",
-        "Gripe water",
         "Teething gel"
     ]
 

--- a/Packages/BabyTrackerDomain/Sources/BabyTrackerDomain/MedicationCatalog.swift
+++ b/Packages/BabyTrackerDomain/Sources/BabyTrackerDomain/MedicationCatalog.swift
@@ -1,0 +1,32 @@
+import Foundation
+
+/// Seed data and age-based defaults for the medication editor.
+public enum MedicationCatalog {
+    /// Common children's medicines surfaced as quick-pick chips before any history exists.
+    /// History-derived names take precedence and are de-duplicated against this list.
+    public static let commonMedicines: [String] = [
+        "Paracetamol (Calpol)",
+        "Ibuprofen (Nurofen)",
+        "Vitamin D drops",
+        "Gripe water",
+        "Teething gel"
+    ]
+
+    /// Default ml quick-pick amounts, chosen by the child's age. These are defaults only;
+    /// history-based smart suggestions are surfaced ahead of them by the UI.
+    public static func defaultMillilitreAmounts(
+        forBirthDate birthDate: Date?,
+        referenceDate: Date = Date(),
+        calendar: Calendar = .current
+    ) -> [Double] {
+        guard let birthDate else { return [2.5, 5, 7.5, 10] }
+        let months = calendar.dateComponents([.month], from: birthDate, to: referenceDate).month ?? 12
+        if months < 12 {
+            return [1, 2.5, 5]
+        }
+        if months < 48 {
+            return [2.5, 5, 7.5, 10]
+        }
+        return [5, 10, 15, 20]
+    }
+}

--- a/Packages/BabyTrackerDomain/Sources/BabyTrackerDomain/MedicationEvent.swift
+++ b/Packages/BabyTrackerDomain/Sources/BabyTrackerDomain/MedicationEvent.swift
@@ -1,0 +1,89 @@
+import Foundation
+
+/// A single dose of medication given to a child.
+///
+/// Records which medicine was given, how much, and in what unit. When `unit == .custom`,
+/// `customUnitLabel` holds the caregiver's free-text unit (e.g. "puff", "sachet").
+public struct MedicationEvent: Equatable, Identifiable, Sendable {
+    public var metadata: EventMetadata
+    public var medicineName: String
+    public var amount: Double
+    public var unit: MedicationUnit
+    public var customUnitLabel: String?
+
+    public var id: UUID {
+        metadata.id
+    }
+
+    public init(
+        metadata: EventMetadata,
+        medicineName: String,
+        amount: Double,
+        unit: MedicationUnit,
+        customUnitLabel: String? = nil
+    ) throws {
+        let trimmedName = medicineName.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmedName.isEmpty else {
+            throw BabyEventError.invalidMedicationName
+        }
+        guard amount > 0 else {
+            throw BabyEventError.invalidMedicationAmount
+        }
+
+        self.metadata = metadata
+        self.medicineName = trimmedName
+        self.amount = amount
+        self.unit = unit
+        self.customUnitLabel = MedicationEvent.normalizedCustomLabel(customUnitLabel, unit: unit)
+    }
+
+    public func updating(
+        occurredAt: Date,
+        medicineName: String,
+        amount: Double,
+        unit: MedicationUnit,
+        customUnitLabel: String?,
+        updatedAt: Date = Date(),
+        updatedBy: UUID
+    ) throws -> MedicationEvent {
+        var metadata = metadata
+        metadata.occurredAt = occurredAt
+        metadata.markUpdated(at: updatedAt, by: updatedBy)
+
+        return try MedicationEvent(
+            metadata: metadata,
+            medicineName: medicineName,
+            amount: amount,
+            unit: unit,
+            customUnitLabel: customUnitLabel
+        )
+    }
+
+    /// The unit text to show after the amount, resolving the custom label when present.
+    public var displayUnit: String {
+        switch unit {
+        case .custom:
+            if let label = customUnitLabel, !label.isEmpty {
+                return label
+            }
+            return MedicationUnit.custom.shortTitle
+        default:
+            return unit.shortTitle
+        }
+    }
+
+    /// The dose amount without a trailing `.0` (e.g. "5", "2.5").
+    public var formattedAmount: String {
+        let rounded = (amount * 100).rounded() / 100
+        if rounded == rounded.rounded() {
+            return String(Int(rounded))
+        }
+        return String(rounded)
+    }
+
+    private static func normalizedCustomLabel(_ label: String?, unit: MedicationUnit) -> String? {
+        guard unit == .custom else { return nil }
+        let trimmed = label?.trimmingCharacters(in: .whitespacesAndNewlines)
+        return (trimmed?.isEmpty == false) ? trimmed : nil
+    }
+}

--- a/Packages/BabyTrackerDomain/Sources/BabyTrackerDomain/MedicationUnit.swift
+++ b/Packages/BabyTrackerDomain/Sources/BabyTrackerDomain/MedicationUnit.swift
@@ -1,0 +1,45 @@
+import Foundation
+
+/// The unit a medication dose is measured in.
+///
+/// `custom` is paired with a free-text label on ``MedicationEvent`` (`customUnitLabel`),
+/// mirroring how `MilkType.other` carries no associated value and relies on a sibling field.
+public enum MedicationUnit: String, CaseIterable, Codable, Sendable {
+    case ml
+    case mg
+    case drops
+    case tablet
+    case custom
+
+    /// Long-form title used in pickers.
+    public var title: String {
+        switch self {
+        case .ml:
+            "Millilitres (ml)"
+        case .mg:
+            "Milligrams (mg)"
+        case .drops:
+            "Drops"
+        case .tablet:
+            "Tablets / capsules"
+        case .custom:
+            "Custom"
+        }
+    }
+
+    /// Compact title appended after a dose amount (e.g. "5 ml").
+    public var shortTitle: String {
+        switch self {
+        case .ml:
+            "ml"
+        case .mg:
+            "mg"
+        case .drops:
+            "drops"
+        case .tablet:
+            "tablet(s)"
+        case .custom:
+            "unit"
+        }
+    }
+}

--- a/Packages/BabyTrackerDomain/Sources/BabyTrackerDomain/NestExportData.swift
+++ b/Packages/BabyTrackerDomain/Sources/BabyTrackerDomain/NestExportData.swift
@@ -43,6 +43,7 @@ public enum NestEventExport: Codable, Sendable {
     case bottleFeed(NestBottleFeedExport)
     case sleep(NestSleepExport)
     case nappy(NestNappyExport)
+    case medication(NestMedicationExport)
 
     private enum CodingKeys: String, CodingKey {
         case type
@@ -55,6 +56,8 @@ public enum NestEventExport: Codable, Sendable {
         case amountMilliliters, milkType
         // nappy
         case nappyType, peeVolume, pooVolume, pooColor
+        // medication
+        case medicineName, amount, unit, customUnitLabel
     }
 
     public init(from decoder: any Decoder) throws {
@@ -114,6 +117,18 @@ public enum NestEventExport: Codable, Sendable {
                 pooVolume: try c.decodeIfPresent(String.self, forKey: .pooVolume).flatMap(NappyVolume.init(rawValue:)),
                 pooColor: try c.decodeIfPresent(String.self, forKey: .pooColor).flatMap(PooColor.init(rawValue:))
             ))
+        case "medication":
+            let unitRaw = try c.decodeIfPresent(String.self, forKey: .unit)
+            let unit = unitRaw.flatMap(MedicationUnit.init(rawValue:)) ?? .custom
+            self = .medication(NestMedicationExport(
+                id: id,
+                occurredAt: occurredAt,
+                notes: notes,
+                medicineName: try c.decode(String.self, forKey: .medicineName),
+                amount: try c.decode(Double.self, forKey: .amount),
+                unit: unit,
+                customUnitLabel: try c.decodeIfPresent(String.self, forKey: .customUnitLabel)
+            ))
         default:
             throw DecodingError.dataCorrupted(
                 .init(codingPath: decoder.codingPath, debugDescription: "Unknown event type: \(type)")
@@ -169,6 +184,16 @@ public enum NestEventExport: Codable, Sendable {
             try c.encodeIfPresent(e.peeVolume?.rawValue, forKey: .peeVolume)
             try c.encodeIfPresent(e.pooVolume?.rawValue, forKey: .pooVolume)
             try c.encodeIfPresent(e.pooColor?.rawValue, forKey: .pooColor)
+
+        case .medication(let e):
+            try c.encode("medication", forKey: .type)
+            try c.encode(e.id, forKey: .id)
+            try c.encode(e.occurredAt, forKey: .occurredAt)
+            try c.encode(e.notes, forKey: .notes)
+            try c.encode(e.medicineName, forKey: .medicineName)
+            try c.encode(e.amount, forKey: .amount)
+            try c.encode(e.unit.rawValue, forKey: .unit)
+            try c.encodeIfPresent(e.customUnitLabel, forKey: .customUnitLabel)
         }
     }
 }
@@ -268,5 +293,33 @@ public struct NestNappyExport: Sendable {
         self.peeVolume = peeVolume
         self.pooVolume = pooVolume
         self.pooColor = pooColor
+    }
+}
+
+public struct NestMedicationExport: Sendable {
+    public let id: UUID
+    public let occurredAt: Date
+    public let notes: String
+    public let medicineName: String
+    public let amount: Double
+    public let unit: MedicationUnit
+    public let customUnitLabel: String?
+
+    public init(
+        id: UUID,
+        occurredAt: Date,
+        notes: String,
+        medicineName: String,
+        amount: Double,
+        unit: MedicationUnit,
+        customUnitLabel: String?
+    ) {
+        self.id = id
+        self.occurredAt = occurredAt
+        self.notes = notes
+        self.medicineName = medicineName
+        self.amount = amount
+        self.unit = unit
+        self.customUnitLabel = customUnitLabel
     }
 }

--- a/Packages/BabyTrackerDomain/Sources/BabyTrackerDomain/NestJSONParser.swift
+++ b/Packages/BabyTrackerDomain/Sources/BabyTrackerDomain/NestJSONParser.swift
@@ -86,6 +86,24 @@ public struct NestJSONParser {
                 pooVolume: e.pooVolume,
                 pooColor: e.pooColor
             ))
+
+        case .medication(let e):
+            guard e.amount > 0 else {
+                skippedReasons.append("Medication at \(e.occurredAt.formatted()): amount must be greater than zero")
+                return nil
+            }
+            guard !e.medicineName.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+                skippedReasons.append("Medication at \(e.occurredAt.formatted()): name is missing")
+                return nil
+            }
+            let metadata = ImportEventMetadata(occurredAt: e.occurredAt, notes: e.notes.isEmpty ? nil : e.notes)
+            return .medication(MedicationImport(
+                metadata: metadata,
+                medicineName: e.medicineName,
+                amount: e.amount,
+                unit: e.unit,
+                customUnitLabel: e.customUnitLabel
+            ))
         }
     }
 }

--- a/Packages/BabyTrackerDomain/Sources/BabyTrackerDomain/TimelineDayGridColumnKind.swift
+++ b/Packages/BabyTrackerDomain/Sources/BabyTrackerDomain/TimelineDayGridColumnKind.swift
@@ -6,4 +6,5 @@ public enum TimelineDayGridColumnKind: String, CaseIterable, Equatable, Sendable
     case bath
     case bottleFeed
     case breastFeed
+    case medication
 }

--- a/Packages/BabyTrackerDomain/Sources/BabyTrackerDomain/UseCases/BuildRemoteCaregiverNotificationUseCase.swift
+++ b/Packages/BabyTrackerDomain/Sources/BabyTrackerDomain/UseCases/BuildRemoteCaregiverNotificationUseCase.swift
@@ -76,6 +76,8 @@ public struct BuildRemoteCaregiverNotificationUseCase: Sendable {
             return "\(change.actorDisplayName) logged a bottle feed at \(formatTime(event.metadata.occurredAt))."
         case let .breastFeed(event):
             return "\(change.actorDisplayName) logged a breast feed at \(formatTime(event.metadata.occurredAt))."
+        case let .medication(event):
+            return "\(change.actorDisplayName) logged \(event.medicineName) at \(formatTime(event.metadata.occurredAt))."
         }
     }
 
@@ -91,6 +93,8 @@ public struct BuildRemoteCaregiverNotificationUseCase: Sendable {
             return "\(change.actorDisplayName) deleted a bottle feed log."
         case .breastFeed:
             return "\(change.actorDisplayName) deleted a breast feed log."
+        case let .medication(event):
+            return "\(change.actorDisplayName) deleted a \(event.medicineName) log."
         }
     }
 

--- a/Packages/BabyTrackerDomain/Sources/BabyTrackerDomain/UseCases/BuildTimelineDayGridDatasetUseCase.swift
+++ b/Packages/BabyTrackerDomain/Sources/BabyTrackerDomain/UseCases/BuildTimelineDayGridDatasetUseCase.swift
@@ -177,12 +177,14 @@ public struct BuildTimelineDayGridDatasetUseCase {
             return .bottleFeed
         case .breastFeed:
             return .breastFeed
+        case .medication:
+            return .medication
         }
     }
 
     private func occupiesSingleSlot(_ event: BabyEvent) -> Bool {
         switch event {
-        case .bath, .bottleFeed, .nappy:
+        case .bath, .bottleFeed, .nappy, .medication:
             true
         case .breastFeed, .sleep:
             false
@@ -193,6 +195,8 @@ public struct BuildTimelineDayGridDatasetUseCase {
         switch event {
         case let .bath(bath):
             bath.metadata.occurredAt
+        case let .medication(medication):
+            medication.metadata.occurredAt
         case let .breastFeed(feed):
             feed.startedAt
         case let .bottleFeed(feed):
@@ -211,6 +215,8 @@ public struct BuildTimelineDayGridDatasetUseCase {
         switch event {
         case let .bath(bath):
             bath.metadata.occurredAt.addingTimeInterval(TimeInterval(slotMinutes * 60))
+        case let .medication(medication):
+            medication.metadata.occurredAt.addingTimeInterval(TimeInterval(slotMinutes * 60))
         case let .breastFeed(feed):
             feed.endedAt
         case let .bottleFeed(feed):

--- a/Packages/BabyTrackerDomain/Sources/BabyTrackerDomain/UseCases/BuildTimelineStripDatasetUseCase.swift
+++ b/Packages/BabyTrackerDomain/Sources/BabyTrackerDomain/UseCases/BuildTimelineStripDatasetUseCase.swift
@@ -131,6 +131,8 @@ public struct BuildTimelineStripDatasetUseCase {
             return 3
         case .bottleFeed:
             return 2
+        case .medication:
+            return 2
         case .nappy:
             return 1
         case nil:
@@ -150,6 +152,8 @@ public struct BuildTimelineStripDatasetUseCase {
         switch event {
         case let .bath(bath):
             return bath.metadata.occurredAt
+        case let .medication(medication):
+            return medication.metadata.occurredAt
         case let .breastFeed(feed):
             return feed.startedAt
         case let .bottleFeed(feed):
@@ -168,6 +172,8 @@ public struct BuildTimelineStripDatasetUseCase {
         switch event {
         case let .bath(bath):
             return bath.metadata.occurredAt.addingTimeInterval(TimeInterval(slotMinutes * 60))
+        case let .medication(medication):
+            return medication.metadata.occurredAt.addingTimeInterval(TimeInterval(slotMinutes * 60))
         case let .breastFeed(feed):
             return feed.endedAt
         case let .bottleFeed(feed):

--- a/Packages/BabyTrackerDomain/Sources/BabyTrackerDomain/UseCases/ExportEventsUseCase.swift
+++ b/Packages/BabyTrackerDomain/Sources/BabyTrackerDomain/UseCases/ExportEventsUseCase.swift
@@ -102,6 +102,16 @@ public struct ExportEventsUseCase: UseCase {
                 pooVolume: e.pooVolume,
                 pooColor: e.pooColor
             ))
+        case .medication(let e):
+            return .medication(NestMedicationExport(
+                id: e.metadata.id,
+                occurredAt: e.metadata.occurredAt,
+                notes: e.metadata.notes,
+                medicineName: e.medicineName,
+                amount: e.amount,
+                unit: e.unit,
+                customUnitLabel: e.customUnitLabel
+            ))
         }
     }
 }

--- a/Packages/BabyTrackerDomain/Sources/BabyTrackerDomain/UseCases/FetchRecentMedicineNamesUseCase.swift
+++ b/Packages/BabyTrackerDomain/Sources/BabyTrackerDomain/UseCases/FetchRecentMedicineNamesUseCase.swift
@@ -1,0 +1,43 @@
+import Foundation
+
+/// Returns the distinct medicine names previously logged for a child, most-recent first.
+/// Used to build quick-pick chips in the medication editor alongside the seeded catalog.
+@MainActor
+public struct FetchRecentMedicineNamesUseCase: UseCase {
+    public struct Input {
+        public let childID: UUID
+        public let limit: Int
+
+        public init(childID: UUID, limit: Int = 8) {
+            self.childID = childID
+            self.limit = limit
+        }
+    }
+
+    private let eventRepository: any EventRepository
+
+    public init(eventRepository: any EventRepository) {
+        self.eventRepository = eventRepository
+    }
+
+    public func execute(_ input: Input) throws -> [String] {
+        let timeline = try eventRepository.loadTimeline(for: input.childID, includingDeleted: false)
+
+        let medications = timeline
+            .compactMap { event -> MedicationEvent? in
+                guard case let .medication(medication) = event else { return nil }
+                return medication
+            }
+            .sorted { $0.metadata.occurredAt > $1.metadata.occurredAt }
+
+        var seen = Set<String>()
+        var names: [String] = []
+        for medication in medications {
+            let key = medication.medicineName.lowercased()
+            guard seen.insert(key).inserted else { continue }
+            names.append(medication.medicineName)
+            if names.count >= input.limit { break }
+        }
+        return names
+    }
+}

--- a/Packages/BabyTrackerDomain/Sources/BabyTrackerDomain/UseCases/ImportChildWithEventsUseCase.swift
+++ b/Packages/BabyTrackerDomain/Sources/BabyTrackerDomain/UseCases/ImportChildWithEventsUseCase.swift
@@ -135,6 +135,15 @@ public struct ImportChildWithEventsUseCase {
                 pooVolume: e.pooVolume,
                 pooColor: e.pooColor
             ))
+        case .medication(let e):
+            guard e.amount > 0, !e.medicineName.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else { return nil }
+            return .medication(MedicationImport(
+                metadata: ImportEventMetadata(occurredAt: e.occurredAt, notes: e.notes.isEmpty ? nil : e.notes),
+                medicineName: e.medicineName,
+                amount: e.amount,
+                unit: e.unit,
+                customUnitLabel: e.customUnitLabel
+            ))
         }
     }
 }

--- a/Packages/BabyTrackerDomain/Sources/BabyTrackerDomain/UseCases/ImportEventsUseCase.swift
+++ b/Packages/BabyTrackerDomain/Sources/BabyTrackerDomain/UseCases/ImportEventsUseCase.swift
@@ -92,7 +92,31 @@ public struct ImportEventsUseCase {
             try saveSleep(e, childID: childID, localUserID: localUserID, membership: membership)
         case .nappy(let e):
             try saveNappy(e, childID: childID, localUserID: localUserID, membership: membership)
+        case .medication(let e):
+            try saveMedication(e, childID: childID, localUserID: localUserID, membership: membership)
         }
+    }
+
+    private func saveMedication(
+        _ e: MedicationImport,
+        childID: UUID,
+        localUserID: UUID,
+        membership: Membership
+    ) throws {
+        _ = try LogMedicationUseCase(
+            eventRepository: eventRepository,
+            hapticFeedbackProvider: NoOpHapticFeedbackProvider()
+        )
+            .execute(.init(
+                childID: childID,
+                localUserID: localUserID,
+                occurredAt: e.metadata.occurredAt,
+                medicineName: e.medicineName,
+                amount: e.amount,
+                unit: e.unit,
+                customUnitLabel: e.customUnitLabel,
+                membership: membership
+            ))
     }
 
     private func saveBottleFeed(

--- a/Packages/BabyTrackerDomain/Sources/BabyTrackerDomain/UseCases/LogMedicationUseCase.swift
+++ b/Packages/BabyTrackerDomain/Sources/BabyTrackerDomain/UseCases/LogMedicationUseCase.swift
@@ -1,0 +1,69 @@
+import Foundation
+
+@MainActor
+public struct LogMedicationUseCase: UseCase {
+    public struct Input {
+        public let childID: UUID
+        public let localUserID: UUID
+        public let occurredAt: Date
+        public let medicineName: String
+        public let amount: Double
+        public let unit: MedicationUnit
+        public let customUnitLabel: String?
+        public let membership: Membership
+
+        public init(
+            childID: UUID,
+            localUserID: UUID,
+            occurredAt: Date,
+            medicineName: String,
+            amount: Double,
+            unit: MedicationUnit,
+            customUnitLabel: String?,
+            membership: Membership
+        ) {
+            self.childID = childID
+            self.localUserID = localUserID
+            self.occurredAt = occurredAt
+            self.medicineName = medicineName
+            self.amount = amount
+            self.unit = unit
+            self.customUnitLabel = customUnitLabel
+            self.membership = membership
+        }
+    }
+
+    private let eventRepository: any EventRepository
+    private let hapticFeedbackProvider: any HapticFeedbackProviding
+
+    public init(
+        eventRepository: any EventRepository,
+        hapticFeedbackProvider: any HapticFeedbackProviding = NoOpHapticFeedbackProvider()
+    ) {
+        self.eventRepository = eventRepository
+        self.hapticFeedbackProvider = hapticFeedbackProvider
+    }
+
+    public func execute(_ input: Input) throws -> BabyEvent {
+        guard ChildAccessPolicy.canPerform(.logEvent, membership: input.membership) else {
+            throw ChildProfileValidationError.insufficientPermissions
+        }
+
+        let event = try MedicationEvent(
+            metadata: EventMetadata(
+                childID: input.childID,
+                occurredAt: input.occurredAt,
+                createdAt: .now,
+                createdBy: input.localUserID
+            ),
+            medicineName: input.medicineName,
+            amount: input.amount,
+            unit: input.unit,
+            customUnitLabel: input.customUnitLabel
+        )
+
+        try eventRepository.saveEvent(.medication(event))
+        hapticFeedbackProvider.play(.actionSucceeded)
+        return .medication(event)
+    }
+}

--- a/Packages/BabyTrackerDomain/Sources/BabyTrackerDomain/UseCases/RestoreDeletedEventUseCase.swift
+++ b/Packages/BabyTrackerDomain/Sources/BabyTrackerDomain/UseCases/RestoreDeletedEventUseCase.swift
@@ -47,6 +47,9 @@ public struct RestoreDeletedEventUseCase: UseCase {
         case var .nappy(feed):
             feed.metadata.restoreDeleted(by: userID)
             return .nappy(feed)
+        case var .medication(medication):
+            medication.metadata.restoreDeleted(by: userID)
+            return .medication(medication)
         }
     }
 }

--- a/Packages/BabyTrackerDomain/Sources/BabyTrackerDomain/UseCases/UpdateMedicationUseCase.swift
+++ b/Packages/BabyTrackerDomain/Sources/BabyTrackerDomain/UseCases/UpdateMedicationUseCase.swift
@@ -1,0 +1,67 @@
+import Foundation
+
+@MainActor
+public struct UpdateMedicationUseCase: UseCase {
+    public struct Input {
+        public let eventID: UUID
+        public let localUserID: UUID
+        public let occurredAt: Date
+        public let medicineName: String
+        public let amount: Double
+        public let unit: MedicationUnit
+        public let customUnitLabel: String?
+        public let membership: Membership
+
+        public init(
+            eventID: UUID,
+            localUserID: UUID,
+            occurredAt: Date,
+            medicineName: String,
+            amount: Double,
+            unit: MedicationUnit,
+            customUnitLabel: String?,
+            membership: Membership
+        ) {
+            self.eventID = eventID
+            self.localUserID = localUserID
+            self.occurredAt = occurredAt
+            self.medicineName = medicineName
+            self.amount = amount
+            self.unit = unit
+            self.customUnitLabel = customUnitLabel
+            self.membership = membership
+        }
+    }
+
+    private let eventRepository: any EventRepository
+    private let hapticFeedbackProvider: any HapticFeedbackProviding
+
+    public init(
+        eventRepository: any EventRepository,
+        hapticFeedbackProvider: any HapticFeedbackProviding = NoOpHapticFeedbackProvider()
+    ) {
+        self.eventRepository = eventRepository
+        self.hapticFeedbackProvider = hapticFeedbackProvider
+    }
+
+    public func execute(_ input: Input) throws {
+        guard ChildAccessPolicy.canPerform(.editEvent, membership: input.membership) else {
+            throw ChildProfileValidationError.insufficientPermissions
+        }
+        guard let event = try eventRepository.loadEvent(id: input.eventID),
+              case let .medication(medication) = event else {
+            return
+        }
+
+        let updatedEvent = try medication.updating(
+            occurredAt: input.occurredAt,
+            medicineName: input.medicineName,
+            amount: input.amount,
+            unit: input.unit,
+            customUnitLabel: input.customUnitLabel,
+            updatedBy: input.localUserID
+        )
+        try eventRepository.saveEvent(.medication(updatedEvent))
+        hapticFeedbackProvider.play(.actionSucceeded)
+    }
+}

--- a/Packages/BabyTrackerDomain/Tests/BabyTrackerDomainTests/MedicationImportExportTests.swift
+++ b/Packages/BabyTrackerDomain/Tests/BabyTrackerDomainTests/MedicationImportExportTests.swift
@@ -1,0 +1,142 @@
+import XCTest
+@testable import BabyTrackerDomain
+
+final class MedicationImportExportTests: XCTestCase {
+    func testNestJSONRoundTripsMedicationWithCustomUnit() throws {
+        let occurredAt = Date(timeIntervalSince1970: 12_345)
+        let exportData = NestExportData(
+            exportedAt: Date(timeIntervalSince1970: 20_000),
+            child: NestChildExport(
+                id: UUID(uuidString: "11111111-2222-3333-4444-555555555555")!,
+                name: "Robin",
+                birthDate: nil
+            ),
+            events: [
+                .medication(NestMedicationExport(
+                    id: UUID(uuidString: "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee")!,
+                    occurredAt: occurredAt,
+                    notes: "After lunch",
+                    medicineName: "Calpol",
+                    amount: 2.5,
+                    unit: .custom,
+                    customUnitLabel: "puff"
+                ))
+            ]
+        )
+
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .iso8601
+        let data = try encoder.encode(exportData)
+
+        let result = NestJSONParser().parse(data: data)
+
+        XCTAssertEqual(result.skippedCount, 0)
+        XCTAssertEqual(result.events.count, 1)
+
+        guard case let .medication(medication)? = result.events.first else {
+            return XCTFail("Expected parsed event to be a medication")
+        }
+
+        XCTAssertEqual(medication.metadata.occurredAt, occurredAt)
+        XCTAssertEqual(medication.metadata.notes, "After lunch")
+        XCTAssertEqual(medication.medicineName, "Calpol")
+        XCTAssertEqual(medication.amount, 2.5)
+        XCTAssertEqual(medication.unit, .custom)
+        XCTAssertEqual(medication.customUnitLabel, "puff")
+    }
+
+    func testNestJSONParserSkipsMedicationWithNonPositiveAmount() throws {
+        let exportData = NestExportData(
+            exportedAt: Date(timeIntervalSince1970: 20_000),
+            child: NestChildExport(id: UUID(), name: "Robin", birthDate: nil),
+            events: [
+                .medication(NestMedicationExport(
+                    id: UUID(),
+                    occurredAt: Date(timeIntervalSince1970: 1_000),
+                    notes: "",
+                    medicineName: "Calpol",
+                    amount: 0,
+                    unit: .ml,
+                    customUnitLabel: nil
+                ))
+            ]
+        )
+
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .iso8601
+        let data = try encoder.encode(exportData)
+
+        let result = NestJSONParser().parse(data: data)
+
+        XCTAssertEqual(result.events.count, 0)
+        XCTAssertEqual(result.skippedCount, 1)
+    }
+
+    @MainActor
+    func testExportEventsUseCaseEncodesMedication() throws {
+        let childID = UUID()
+        let userID = UUID()
+        let child = try Child(name: "Robin", createdBy: userID)
+        let medication = try MedicationEvent(
+            metadata: EventMetadata(
+                childID: child.id,
+                occurredAt: Date(timeIntervalSince1970: 5_000),
+                createdAt: Date(timeIntervalSince1970: 5_000),
+                createdBy: userID
+            ),
+            medicineName: "Vitamin D drops",
+            amount: 1,
+            unit: .drops
+        )
+
+        let repository = MedicationStubEventRepository(events: [.medication(medication)])
+        let data = try ExportEventsUseCase(eventRepository: repository)
+            .execute(.init(child: child, membership: Membership.owner(childID: child.id, userID: userID, createdAt: Date())))
+
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        let decoded = try decoder.decode(NestExportData.self, from: data)
+
+        XCTAssertEqual(decoded.events.count, 1)
+        guard case let .medication(exported)? = decoded.events.first else {
+            return XCTFail("Expected exported event to be a medication")
+        }
+        XCTAssertEqual(exported.medicineName, "Vitamin D drops")
+        XCTAssertEqual(exported.amount, 1)
+        XCTAssertEqual(exported.unit, .drops)
+
+        _ = childID
+    }
+}
+
+@MainActor
+private final class MedicationStubEventRepository: EventRepository {
+    private var events: [BabyEvent]
+
+    init(events: [BabyEvent]) {
+        self.events = events
+    }
+
+    func saveEvent(_ event: BabyEvent) throws {
+        events.removeAll { $0.id == event.id }
+        events.append(event)
+    }
+
+    func loadEvent(id: UUID) throws -> BabyEvent? {
+        events.first { $0.id == id }
+    }
+
+    func loadTimeline(for childID: UUID, includingDeleted: Bool) throws -> [BabyEvent] {
+        events.filter { $0.metadata.childID == childID }
+    }
+
+    func loadEvents(for childID: UUID, on day: Date, calendar: Calendar, includingDeleted: Bool) throws -> [BabyEvent] {
+        events.filter {
+            $0.metadata.childID == childID &&
+            calendar.isDate($0.metadata.occurredAt, inSameDayAs: day)
+        }
+    }
+
+    func loadActiveSleepEvent(for childID: UUID) throws -> SleepEvent? { nil }
+    func softDeleteEvent(id: UUID, deletedAt: Date, deletedBy: UUID) throws {}
+}

--- a/Packages/BabyTrackerDomain/Tests/BabyTrackerDomainTests/MedicationUseCaseTests.swift
+++ b/Packages/BabyTrackerDomain/Tests/BabyTrackerDomainTests/MedicationUseCaseTests.swift
@@ -1,0 +1,173 @@
+import BabyTrackerDomain
+import Foundation
+import Testing
+
+@MainActor
+struct MedicationUseCaseTests {
+    @Test
+    func logMedicationPersistsEvent() throws {
+        let childID = UUID()
+        let userID = UUID()
+        let repository = StubMedicationEventRepository()
+        let membership = Membership.owner(childID: childID, userID: userID)
+
+        let event = try LogMedicationUseCase(eventRepository: repository).execute(.init(
+            childID: childID,
+            localUserID: userID,
+            occurredAt: Date(timeIntervalSince1970: 1_000),
+            medicineName: "Calpol",
+            amount: 5,
+            unit: .ml,
+            customUnitLabel: nil,
+            membership: membership
+        ))
+
+        guard case let .medication(medication) = event else {
+            Issue.record("Expected a medication event")
+            return
+        }
+        #expect(medication.medicineName == "Calpol")
+        #expect(medication.amount == 5)
+        #expect(medication.unit == .ml)
+        #expect(repository.savedEvents.count == 1)
+    }
+
+    @Test
+    func logMedicationRejectsNonPositiveAmount() {
+        let childID = UUID()
+        let userID = UUID()
+        let repository = StubMedicationEventRepository()
+        let membership = Membership.owner(childID: childID, userID: userID)
+
+        #expect(throws: BabyEventError.invalidMedicationAmount) {
+            _ = try LogMedicationUseCase(eventRepository: repository).execute(.init(
+                childID: childID,
+                localUserID: userID,
+                occurredAt: Date(),
+                medicineName: "Calpol",
+                amount: 0,
+                unit: .ml,
+                customUnitLabel: nil,
+                membership: membership
+            ))
+        }
+    }
+
+    @Test
+    func logMedicationRejectsEmptyName() {
+        let childID = UUID()
+        let userID = UUID()
+        let repository = StubMedicationEventRepository()
+        let membership = Membership.owner(childID: childID, userID: userID)
+
+        #expect(throws: BabyEventError.invalidMedicationName) {
+            _ = try LogMedicationUseCase(eventRepository: repository).execute(.init(
+                childID: childID,
+                localUserID: userID,
+                occurredAt: Date(),
+                medicineName: "   ",
+                amount: 5,
+                unit: .ml,
+                customUnitLabel: nil,
+                membership: membership
+            ))
+        }
+    }
+
+    @Test
+    func updateMedicationModifiesStoredEvent() throws {
+        let childID = UUID()
+        let userID = UUID()
+        let repository = StubMedicationEventRepository()
+        let membership = Membership.owner(childID: childID, userID: userID)
+
+        let logged = try LogMedicationUseCase(eventRepository: repository).execute(.init(
+            childID: childID,
+            localUserID: userID,
+            occurredAt: Date(timeIntervalSince1970: 1_000),
+            medicineName: "Calpol",
+            amount: 5,
+            unit: .ml,
+            customUnitLabel: nil,
+            membership: membership
+        ))
+
+        try UpdateMedicationUseCase(eventRepository: repository).execute(.init(
+            eventID: logged.id,
+            localUserID: userID,
+            occurredAt: Date(timeIntervalSince1970: 2_000),
+            medicineName: "Nurofen",
+            amount: 2.5,
+            unit: .custom,
+            customUnitLabel: "sachet",
+            membership: membership
+        ))
+
+        guard case let .medication(updated)? = try repository.loadEvent(id: logged.id) else {
+            Issue.record("Expected a medication event")
+            return
+        }
+        #expect(updated.medicineName == "Nurofen")
+        #expect(updated.amount == 2.5)
+        #expect(updated.unit == .custom)
+        #expect(updated.customUnitLabel == "sachet")
+    }
+
+    @Test
+    func fetchRecentMedicineNamesReturnsDistinctMostRecentFirst() throws {
+        let childID = UUID()
+        let userID = UUID()
+        let repository = StubMedicationEventRepository()
+
+        func make(name: String, secondsAgo: TimeInterval) throws -> BabyEvent {
+            .medication(try MedicationEvent(
+                metadata: EventMetadata(
+                    childID: childID,
+                    occurredAt: Date(timeIntervalSinceNow: -secondsAgo),
+                    createdBy: userID
+                ),
+                medicineName: name,
+                amount: 5,
+                unit: .ml
+            ))
+        }
+
+        try repository.saveEvent(make(name: "Calpol", secondsAgo: 30))
+        try repository.saveEvent(make(name: "Nurofen", secondsAgo: 20))
+        try repository.saveEvent(make(name: "calpol", secondsAgo: 10))
+
+        let names = try FetchRecentMedicineNamesUseCase(eventRepository: repository)
+            .execute(.init(childID: childID))
+
+        // Most recent "calpol" first, then Nurofen; the older "Calpol" is de-duped case-insensitively.
+        #expect(names == ["calpol", "Nurofen"])
+    }
+}
+
+@MainActor
+private final class StubMedicationEventRepository: EventRepository {
+    private(set) var savedEvents: [BabyEvent] = []
+
+    func saveEvent(_ event: BabyEvent) throws {
+        savedEvents.removeAll { $0.id == event.id }
+        savedEvents.append(event)
+    }
+
+    func loadEvent(id: UUID) throws -> BabyEvent? {
+        savedEvents.first { $0.id == id }
+    }
+
+    func loadTimeline(for childID: UUID, includingDeleted: Bool) throws -> [BabyEvent] {
+        savedEvents.filter { $0.metadata.childID == childID }
+    }
+
+    func loadEvents(for childID: UUID, on day: Date, calendar: Calendar, includingDeleted: Bool) throws -> [BabyEvent] {
+        savedEvents.filter {
+            $0.metadata.childID == childID &&
+            calendar.isDate($0.metadata.occurredAt, inSameDayAs: day)
+        }
+    }
+
+    func loadActiveSleepEvent(for childID: UUID) throws -> SleepEvent? { nil }
+    func softDeleteEvent(id: UUID, deletedAt: Date, deletedBy: UUID) throws {}
+}

--- a/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/AppModel.swift
+++ b/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/AppModel.swift
@@ -714,6 +714,34 @@ public final class AppModel {
     }
 
     @discardableResult
+    public func logMedication(
+        occurredAt: Date,
+        medicineName: String,
+        amount: Double,
+        unit: MedicationUnit,
+        customUnitLabel: String?
+    ) -> Bool {
+        perform(onSuccess: handleSuccessfulEventLog) {
+            guard let currentChild, let currentMembership else { throw ChildProfileValidationError.insufficientPermissions }
+            guard let localUser else { throw ChildProfileValidationError.insufficientPermissions }
+            _ = try LogMedicationUseCase(
+                eventRepository: eventRepository,
+                hapticFeedbackProvider: hapticFeedbackProvider
+            )
+                .execute(.init(
+                    childID: currentChild.id,
+                    localUserID: localUser.id,
+                    occurredAt: occurredAt,
+                    medicineName: medicineName,
+                    amount: amount,
+                    unit: unit,
+                    customUnitLabel: customUnitLabel,
+                    membership: currentMembership
+                ))
+        }
+    }
+
+    @discardableResult
     public func logBottleFeed(
         amountMilliliters: Int,
         occurredAt: Date,
@@ -889,6 +917,35 @@ public final class AppModel {
     }
 
     @discardableResult
+    public func updateMedication(
+        id: UUID,
+        occurredAt: Date,
+        medicineName: String,
+        amount: Double,
+        unit: MedicationUnit,
+        customUnitLabel: String?
+    ) -> Bool {
+        perform {
+            guard let currentMembership else { throw ChildProfileValidationError.insufficientPermissions }
+            guard let localUser else { throw ChildProfileValidationError.insufficientPermissions }
+            try UpdateMedicationUseCase(
+                eventRepository: eventRepository,
+                hapticFeedbackProvider: hapticFeedbackProvider
+            )
+                .execute(.init(
+                    eventID: id,
+                    localUserID: localUser.id,
+                    occurredAt: occurredAt,
+                    medicineName: medicineName,
+                    amount: amount,
+                    unit: unit,
+                    customUnitLabel: customUnitLabel,
+                    membership: currentMembership
+                ))
+        }
+    }
+
+    @discardableResult
     public func updateBottleFeed(
         id: UUID,
         amountMilliliters: Int,
@@ -968,6 +1025,18 @@ public final class AppModel {
         guard let currentChild else { return [] }
         return (try? FetchSmartBottleAmountsUseCase(eventRepository: eventRepository)
             .execute(.init(childID: currentChild.id, referenceTime: Date()))) ?? []
+    }
+
+    /// Medicine names previously logged for the current child, most-recent first.
+    public func recentMedicineNames() -> [String] {
+        guard let currentChild else { return [] }
+        return (try? FetchRecentMedicineNamesUseCase(eventRepository: eventRepository)
+            .execute(.init(childID: currentChild.id))) ?? []
+    }
+
+    /// Default ml quick-pick amounts for the current child, chosen by age.
+    public func medicationMillilitreAmounts() -> [Double] {
+        MedicationCatalog.defaultMillilitreAmounts(forBirthDate: currentChild?.birthDate)
     }
 
     public func updateBottleQuickAmounts(_ amounts: [Int]?) {
@@ -1556,6 +1625,8 @@ public final class AppModel {
             return "Bottle"
         case .breastFeed:
             return "Breast"
+        case .medication:
+            return "Medication"
         }
     }
 
@@ -1566,6 +1637,7 @@ public final class AppModel {
         case .bath: return .bath
         case .bottleFeed: return .bottleFeed
         case .breastFeed: return .breastFeed
+        case .medication: return .medication
         }
     }
 
@@ -1584,6 +1656,8 @@ public final class AppModel {
             return "Started \(shortTimeText(for: sleep.startedAt))"
         case let .nappy(nappy):
             return shortTimeText(for: nappy.metadata.occurredAt)
+        case let .medication(medication):
+            return shortTimeText(for: medication.metadata.occurredAt)
         }
     }
 
@@ -1628,6 +1702,12 @@ public final class AppModel {
             return (
                 title: DurationText.short(minutes: durationMinutes, minuteStyle: .word),
                 detailText: "",
+                timeText: ""
+            )
+        case let .medication(medication):
+            return (
+                title: medication.medicineName,
+                detailText: "\(medication.formattedAmount) \(medication.displayUnit)",
                 timeText: ""
             )
         }
@@ -1687,6 +1767,14 @@ public final class AppModel {
                 peeVolume: nappy.peeVolume,
                 pooVolume: nappy.pooVolume,
                 pooColor: nappy.pooColor
+            )
+        case let .medication(medication):
+            return .editMedication(
+                occurredAt: medication.metadata.occurredAt,
+                medicineName: medication.medicineName,
+                amount: medication.amount,
+                unit: medication.unit,
+                customUnitLabel: medication.customUnitLabel
             )
         }
     }

--- a/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/BabyEventPresentation.swift
+++ b/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/BabyEventPresentation.swift
@@ -18,6 +18,8 @@ public enum BabyEventPresentation {
             "Sleep"
         case .nappy:
             "Nappy"
+        case .medication:
+            "Medication"
         }
     }
 
@@ -36,6 +38,8 @@ public enum BabyEventPresentation {
             sleepDetailText(for: event)
         case let .nappy(event):
             nappyDetailText(for: event)
+        case let .medication(event):
+            medicationDetailText(for: event)
         }
     }
 
@@ -64,6 +68,8 @@ public enum BabyEventPresentation {
             "moon.zzz.fill"
         case .nappy:
             "checklist.checked"
+        case .medication:
+            "pills.fill"
         }
     }
 
@@ -81,6 +87,12 @@ public enum BabyEventPresentation {
         }
 
         return parts.isEmpty ? "Bath only" : parts.joined(separator: " • ")
+    }
+
+    private static func medicationDetailText(
+        for event: MedicationEvent
+    ) -> String {
+        "\(event.medicineName) • \(event.formattedAmount) \(event.displayUnit)"
     }
 
     private static func breastFeedDetailText(

--- a/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/EventActionPayload.swift
+++ b/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/EventActionPayload.swift
@@ -30,5 +30,12 @@ public enum EventActionPayload: Equatable, Sendable {
         startedAt: Date,
         endedAt: Date
     )
+    case editMedication(
+        occurredAt: Date,
+        medicineName: String,
+        amount: Double,
+        unit: MedicationUnit,
+        customUnitLabel: String?
+    )
     case endSleep(startedAt: Date)
 }

--- a/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/EventCardViewState.swift
+++ b/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/EventCardViewState.swift
@@ -129,6 +129,25 @@ public struct EventCardViewState: Equatable, Identifiable, Sendable {
                 pooVolume: nappy.pooVolume,
                 pooColor: nappy.pooColor
             )
+        case let .medication(medication):
+            id = medication.id
+            kind = .medication
+            title = BabyEventPresentation.title(for: event)
+            detailText = BabyEventPresentation.detailText(
+                for: event,
+                preferredFeedVolumeUnit: preferredFeedVolumeUnit
+            ) ?? ""
+            self.timestampText = timestampText ?? medication.metadata.occurredAt.formatted(
+                date: .abbreviated,
+                time: .shortened
+            )
+            actionPayload = .editMedication(
+                occurredAt: medication.metadata.occurredAt,
+                medicineName: medication.medicineName,
+                amount: medication.amount,
+                unit: medication.unit,
+                customUnitLabel: medication.customUnitLabel
+            )
         }
     }
 }

--- a/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/RecentFeedEventViewState.swift
+++ b/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/RecentFeedEventViewState.swift
@@ -45,7 +45,7 @@ public struct RecentFeedEventViewState: Equatable, Identifiable, Sendable {
                 occurredAt: feed.metadata.occurredAt,
                 milkType: feed.milkType
             )
-        case .bath, .sleep, .nappy:
+        case .bath, .sleep, .nappy, .medication:
             return nil
         }
     }

--- a/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/SummaryMetricsCalculator.swift
+++ b/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/SummaryMetricsCalculator.swift
@@ -147,7 +147,7 @@ public enum SummaryMetricsCalculator {
             switch event {
             case .breastFeed, .bottleFeed:
                 event
-            case .bath, .sleep, .nappy:
+            case .bath, .sleep, .nappy, .medication:
                 nil
             }
         }
@@ -252,7 +252,7 @@ public enum SummaryMetricsCalculator {
             return max(1, Int(feed.endedAt.timeIntervalSince(feed.startedAt) / 60))
         case .bottleFeed:
             return nil
-        case .bath, .sleep, .nappy:
+        case .bath, .sleep, .nappy, .medication:
             return nil
         }
     }

--- a/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/TimelineDayGridItemViewState.swift
+++ b/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/TimelineDayGridItemViewState.swift
@@ -72,6 +72,8 @@ public struct TimelineDayGridItemViewState: Equatable, Identifiable, Sendable {
             .bottleFeed
         case .breastFeed:
             .breastFeed
+        case .medication:
+            .medication
         }
     }
 }

--- a/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/TodaySummaryCalculator.swift
+++ b/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/TodaySummaryCalculator.swift
@@ -64,7 +64,7 @@ public enum TodaySummaryCalculator {
         let allFeedEvents = todayEvents.filter {
             switch $0 {
             case .breastFeed, .bottleFeed: true
-            case .bath, .sleep, .nappy: false
+            case .bath, .sleep, .nappy, .medication: false
             }
         }
         let averageFeedInterval = averageFeedIntervalMinutes(for: allFeedEvents)

--- a/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/UseCases/BuildCurrentStatusViewStateUseCase.swift
+++ b/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/UseCases/BuildCurrentStatusViewStateUseCase.swift
@@ -22,7 +22,7 @@ public enum BuildCurrentStatusViewStateUseCase {
             switch kind {
             case .sleep:
                 return completedSleepRow(from: lastSleep)
-            case .bath, .breastFeed, .bottleFeed, .nappy:
+            case .bath, .breastFeed, .bottleFeed, .nappy, .medication:
                 return latestEventRow(
                     for: kind,
                     events: events,
@@ -95,6 +95,8 @@ public enum BuildCurrentStatusViewStateUseCase {
             "No sleep yet"
         case .nappy:
             "No nappies yet"
+        case .medication:
+            "No medications yet"
         }
     }
 }

--- a/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/ViewModels/HomeViewModel.swift
+++ b/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/ViewModels/HomeViewModel.swift
@@ -105,6 +105,10 @@ public final class HomeViewModel {
                 id = nappy.id
                 kind = .nappy
                 occurredAt = nappy.metadata.occurredAt
+            case let .medication(medication):
+                id = medication.id
+                kind = .medication
+                occurredAt = medication.metadata.occurredAt
             }
 
             return HomeTimelineEventViewState(

--- a/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/BabyEventStyle.swift
+++ b/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/BabyEventStyle.swift
@@ -104,6 +104,17 @@ public enum BabyEventStyle {
                 prominentForeground: adaptiveColor(light: rgb(1.00, 1.00, 1.00), dark: rgb(1.00, 0.98, 0.94)),
                 prominentBorder: adaptiveColor(light: rgba(0.74, 0.47, 0.16, 0.82), dark: rgba(0.96, 0.77, 0.46, 0.72))
             )
+        case .medication:
+            EventPalette(
+                accent: adaptiveColor(light: rgb(0.55, 0.34, 0.78), dark: rgb(0.78, 0.64, 0.98)),
+                badgeFill: adaptiveColor(light: rgba(0.55, 0.34, 0.78, 0.14), dark: rgba(0.55, 0.34, 0.78, 0.28)),
+                cardFill: adaptiveColor(light: rgb(0.96, 0.93, 0.99), dark: rgb(0.20, 0.13, 0.31)),
+                cardForeground: adaptiveColor(light: rgb(0.30, 0.16, 0.46), dark: rgb(0.97, 0.95, 1.00)),
+                cardSecondaryForeground: adaptiveColor(light: rgb(0.42, 0.27, 0.58), dark: rgb(0.87, 0.80, 0.97)),
+                prominentFill: adaptiveColor(light: rgb(0.45, 0.26, 0.67), dark: rgb(0.39, 0.24, 0.59)),
+                prominentForeground: adaptiveColor(light: rgb(1.00, 1.00, 1.00), dark: rgb(0.98, 0.96, 1.00)),
+                prominentBorder: adaptiveColor(light: rgba(0.55, 0.34, 0.78, 0.82), dark: rgba(0.78, 0.64, 0.98, 0.72))
+            )
         }
     }
 

--- a/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/ChildEventSheet.swift
+++ b/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/ChildEventSheet.swift
@@ -3,6 +3,7 @@ import Foundation
 
 public enum ChildEventSheet: Identifiable {
     case quickLogBath
+    case quickLogMedication(recentNames: [String], millilitreAmounts: [Double])
     case quickLogBreastFeed
     case quickLogBottleFeed(smartSuggestions: [Int])
     case startSleep(suggestions: [(label: String, date: Date)])
@@ -42,6 +43,14 @@ public enum ChildEventSheet: Identifiable {
         usedShampoo: Bool,
         usedSoap: Bool
     )
+    case editMedication(
+        id: UUID,
+        occurredAt: Date,
+        medicineName: String,
+        amount: Double,
+        unit: MedicationUnit,
+        customUnitLabel: String?
+    )
 
     public init(id: UUID, actionPayload: EventActionPayload) {
         switch actionPayload {
@@ -51,6 +60,15 @@ public enum ChildEventSheet: Identifiable {
                 occurredAt: occurredAt,
                 usedShampoo: usedShampoo,
                 usedSoap: usedSoap
+            )
+        case let .editMedication(occurredAt, medicineName, amount, unit, customUnitLabel):
+            self = .editMedication(
+                id: id,
+                occurredAt: occurredAt,
+                medicineName: medicineName,
+                amount: amount,
+                unit: unit,
+                customUnitLabel: customUnitLabel
             )
         case let .editBreastFeed(durationMinutes, endTime, side, leftDurationSeconds, rightDurationSeconds):
             self = .editBreastFeed(
@@ -92,6 +110,8 @@ public enum ChildEventSheet: Identifiable {
         switch self {
         case .quickLogBath:
             "quick-log-bath"
+        case .quickLogMedication:
+            "quick-log-medication"
         case .quickLogBreastFeed:
             "quick-log-breast-feed"
         case .quickLogBottleFeed:
@@ -114,6 +134,8 @@ public enum ChildEventSheet: Identifiable {
             "edit-nappy-\(id.uuidString)"
         case let .editBath(id, _, _, _):
             "edit-bath-\(id.uuidString)"
+        case let .editMedication(id, _, _, _, _, _):
+            "edit-medication-\(id.uuidString)"
         }
     }
 }

--- a/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/ChildHomeView.swift
+++ b/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/ChildHomeView.swift
@@ -12,6 +12,7 @@ public struct ChildHomeView: View {
     let quickLogSleep: () -> Void
     let quickLogNappy: () -> Void
     let quickLogBath: () -> Void
+    let quickLogMedication: () -> Void
     let openProfile: () -> Void
 
     @State private var statusSectionExpanded: Bool
@@ -30,6 +31,7 @@ public struct ChildHomeView: View {
         quickLogSleep: @escaping () -> Void,
         quickLogNappy: @escaping () -> Void,
         quickLogBath: @escaping () -> Void,
+        quickLogMedication: @escaping () -> Void,
         openProfile: @escaping () -> Void
     ) {
         self.model = model
@@ -42,6 +44,7 @@ public struct ChildHomeView: View {
         self.quickLogSleep = quickLogSleep
         self.quickLogNappy = quickLogNappy
         self.quickLogBath = quickLogBath
+        self.quickLogMedication = quickLogMedication
         self.openProfile = openProfile
 
         let defaults = UserDefaults.standard
@@ -362,6 +365,14 @@ public struct ChildHomeView: View {
                 accessibilityIdentifier: "quick-log-bath-button",
                 action: quickLogBath
             )
+        case .medication:
+            quickLogButton(
+                title: "Medication",
+                systemImage: BabyEventStyle.systemImage(for: .medication),
+                kind: .medication,
+                accessibilityIdentifier: "quick-log-medication-button",
+                action: quickLogMedication
+            )
         }
     }
 
@@ -453,6 +464,7 @@ private func makeHomeView(from model: AppModel) -> some View {
             quickLogSleep: {},
             quickLogNappy: {},
             quickLogBath: {},
+            quickLogMedication: {},
             openProfile: {}
         )
     }

--- a/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/ChildProfileImportView.swift
+++ b/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/ChildProfileImportView.swift
@@ -413,6 +413,7 @@ private struct ImportEventRow: View {
         case .bottleFeed: return "waterbottle.fill"
         case .breastFeed: return "figure.seated.side.air.upper"
         case .nappy: return "checklist.checked"
+        case .medication: return "pills.fill"
         }
     }
 
@@ -423,6 +424,7 @@ private struct ImportEventRow: View {
         case .bottleFeed: return .blue
         case .breastFeed: return .pink
         case .nappy: return .orange
+        case .medication: return .purple
         }
     }
 }

--- a/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/ChildProfileNestImportView.swift
+++ b/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/ChildProfileNestImportView.swift
@@ -132,6 +132,7 @@ public struct ChildProfileNestImportView: View {
                 let bottleCount = state.taggedEvents.filter { if case .bottleFeed = $0.event { true } else { false } }.count
                 let breastCount = state.taggedEvents.filter { if case .breastFeed = $0.event { true } else { false } }.count
                 let nappyCount = state.taggedEvents.filter { if case .nappy = $0.event { true } else { false } }.count
+                let medicationCount = state.taggedEvents.filter { if case .medication = $0.event { true } else { false } }.count
 
                 if bathCount > 0 {
                     eventCountRow(icon: "drop.fill", label: "Baths", count: bathCount, color: .teal)
@@ -147,6 +148,9 @@ public struct ChildProfileNestImportView: View {
                 }
                 if nappyCount > 0 {
                     eventCountRow(icon: "checklist.checked", label: "Nappy changes", count: nappyCount, color: .orange)
+                }
+                if medicationCount > 0 {
+                    eventCountRow(icon: "pills.fill", label: "Medications", count: medicationCount, color: .purple)
                 }
             }
 
@@ -419,6 +423,7 @@ private struct NestImportEventRow: View {
         case .bottleFeed: return "waterbottle.fill"
         case .breastFeed: return "figure.seated.side.air.upper"
         case .nappy: return "checklist.checked"
+        case .medication: return "pills.fill"
         }
     }
 
@@ -429,6 +434,7 @@ private struct NestImportEventRow: View {
         case .bottleFeed: return .blue
         case .breastFeed: return .pink
         case .nappy: return .orange
+        case .medication: return .purple
         }
     }
 }

--- a/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/ChildWorkspaceTabView.swift
+++ b/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/ChildWorkspaceTabView.swift
@@ -42,6 +42,12 @@ public struct ChildWorkspaceTabView: View {
                     activeEventSheet = .quickLogNappy(.mixed)
                 },
                 quickLogBath: { activeEventSheet = .quickLogBath },
+                quickLogMedication: {
+                    activeEventSheet = .quickLogMedication(
+                        recentNames: model.recentMedicineNames(),
+                        millilitreAmounts: model.medicationMillilitreAmounts()
+                    )
+                },
                 openProfile: { showingEditChildSheet = true }
             )
             .tag(ChildWorkspaceTab.home)
@@ -279,6 +285,27 @@ public struct ChildWorkspaceTabView: View {
                     occurredAt: occurredAt,
                     usedShampoo: usedShampoo,
                     usedSoap: usedSoap
+                )
+                if didSave {
+                    activeEventSheet = nil
+                }
+                return didSave
+            }
+        case let .quickLogMedication(recentNames, millilitreAmounts):
+            MedicationEditorSheetView(
+                navigationTitle: "Medication",
+                primaryActionTitle: "Save",
+                childName: childProfileViewModel.childName,
+                recentMedicineNames: recentNames,
+                millilitreAmounts: millilitreAmounts,
+                initialOccurredAt: Date()
+            ) { occurredAt, medicineName, amount, unit, customUnitLabel in
+                let didSave = model.logMedication(
+                    occurredAt: occurredAt,
+                    medicineName: medicineName,
+                    amount: amount,
+                    unit: unit,
+                    customUnitLabel: customUnitLabel
                 )
                 if didSave {
                     activeEventSheet = nil
@@ -557,6 +584,38 @@ public struct ChildWorkspaceTabView: View {
                     occurredAt: updatedOccurredAt,
                     usedShampoo: updatedUsedShampoo,
                     usedSoap: updatedUsedSoap
+                )
+                if didSave {
+                    activeEventSheet = nil
+                }
+                return didSave
+            }
+        case let .editMedication(id, occurredAt, medicineName, amount, unit, customUnitLabel):
+            MedicationEditorSheetView(
+                navigationTitle: "Edit Medication",
+                primaryActionTitle: "Update",
+                childName: childProfileViewModel.childName,
+                recentMedicineNames: model.recentMedicineNames(),
+                millilitreAmounts: model.medicationMillilitreAmounts(),
+                initialOccurredAt: occurredAt,
+                initialMedicineName: medicineName,
+                initialAmount: amount,
+                initialUnit: unit,
+                initialCustomUnitLabel: customUnitLabel,
+                initialTimePreset: .custom,
+                deleteAction: childProfileViewModel.canManageEvents ? {
+                    if model.deleteEvent(id: id) {
+                        activeEventSheet = nil
+                    }
+                } : nil
+            ) { updatedOccurredAt, updatedName, updatedAmount, updatedUnit, updatedCustomUnitLabel in
+                let didSave = model.updateMedication(
+                    id: id,
+                    occurredAt: updatedOccurredAt,
+                    medicineName: updatedName,
+                    amount: updatedAmount,
+                    unit: updatedUnit,
+                    customUnitLabel: updatedCustomUnitLabel
                 )
                 if didSave {
                     activeEventSheet = nil

--- a/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/EventDeleteCandidate.swift
+++ b/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/EventDeleteCandidate.swift
@@ -31,6 +31,8 @@ public struct EventDeleteCandidate: Identifiable {
             return "Delete Sleep?"
         case .nappy:
             return "Delete Nappy?"
+        case .medication:
+            return "Delete Medication?"
         }
     }
 
@@ -44,6 +46,8 @@ public struct EventDeleteCandidate: Identifiable {
             return "Delete Sleep"
         case .nappy:
             return "Delete Nappy"
+        case .medication:
+            return "Delete Medication"
         }
     }
 }

--- a/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/EventHistoryView.swift
+++ b/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/EventHistoryView.swift
@@ -175,7 +175,7 @@ public struct EventHistoryView: View {
         switch event.actionPayload {
         case .endSleep:
             "End"
-        case .editBath, .editBreastFeed, .editBottleFeed, .editNappy, .editSleep:
+        case .editBath, .editBreastFeed, .editBottleFeed, .editNappy, .editSleep, .editMedication:
             "Edit"
         }
     }
@@ -265,7 +265,7 @@ struct ActiveFilterPill: Identifiable {
     static func pills(for filter: EventFilter) -> [ActiveFilterPill] {
         var pills: [ActiveFilterPill] = []
 
-        for kind in [BabyEventKind.bath, .breastFeed, .bottleFeed, .sleep, .nappy]
+        for kind in [BabyEventKind.bath, .breastFeed, .bottleFeed, .sleep, .nappy, .medication]
             where filter.eventTypes.contains(kind) {
             pills.append(ActiveFilterPill(
                 id: "eventType_\(kind.rawValue)",

--- a/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/EventTypeChecklistCardView.swift
+++ b/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/EventTypeChecklistCardView.swift
@@ -117,6 +117,7 @@ struct EventTypeChecklistCardView: View {
         case .bottleFeed: "Bottle feed"
         case .sleep: "Sleep"
         case .nappy: "Nappy"
+        case .medication: "Medication"
         }
     }
 
@@ -127,6 +128,7 @@ struct EventTypeChecklistCardView: View {
         case .bottleFeed: "Formula and expressed milk"
         case .sleep: "Naps and overnight sleeps"
         case .nappy: "Wet and dirty nappy changes"
+        case .medication: "Doses, amounts and units"
         }
     }
 

--- a/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/MedicationEditorSheetView.swift
+++ b/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/MedicationEditorSheetView.swift
@@ -62,103 +62,11 @@ public struct MedicationEditorSheetView: View {
         NavigationStack {
             Form {
                 LoggingSummaryView(sentence: summarySentence)
-
-                Section {
-                    if !medicineSuggestions.isEmpty {
-                        ScrollView(.horizontal, showsIndicators: false) {
-                            HStack(spacing: 8) {
-                                ForEach(medicineSuggestions, id: \.self) { name in
-                                    Button {
-                                        medicineName = name
-                                    } label: {
-                                        Text(name)
-                                            .font(.subheadline.weight(.semibold))
-                                            .padding(.horizontal, 14)
-                                            .padding(.vertical, 8)
-                                            .background(
-                                                Capsule()
-                                                    .fill(isSelectedName(name) ? Self.eventColor : Color(.tertiarySystemGroupedBackground))
-                                            )
-                                            .foregroundStyle(isSelectedName(name) ? Color.white : Color.primary)
-                                    }
-                                    .buttonStyle(.plain)
-                                    .accessibilityIdentifier("medication-name-suggestion-\(name)")
-                                }
-                            }
-                            .padding(.vertical, 2)
-                        }
-                        .listRowInsets(EdgeInsets(top: 8, leading: 12, bottom: 8, trailing: 12))
-                    }
-
-                    TextField("Type a medicine name", text: $medicineName)
-                        .accessibilityIdentifier("medication-name-field")
-                } header: {
-                    Text("Which medicine?")
-                } footer: {
-                    Text(medicineSuggestions.isEmpty
-                        ? "Type the name of the medicine."
-                        : "Tap a recent medicine above, or type a new one.")
-                }
-
-                Section("How much?") {
-                    unitPicker
-
-                    if !amountPresets.isEmpty {
-                        LazyVGrid(columns: amountColumns, spacing: 8) {
-                            ForEach(amountPresets, id: \.self) { amount in
-                                Button {
-                                    amountText = Self.amountText(for: amount)
-                                } label: {
-                                    Text(Self.amountText(for: amount))
-                                        .font(.subheadline.weight(.semibold))
-                                        .frame(maxWidth: .infinity)
-                                        .padding(.vertical, 10)
-                                        .background(
-                                            RoundedRectangle(cornerRadius: 12, style: .continuous)
-                                                .fill(isSelectedAmount(amount) ? Self.eventColor : Color(.tertiarySystemGroupedBackground))
-                                        )
-                                        .foregroundStyle(isSelectedAmount(amount) ? Color.white : Color.primary)
-                                }
-                                .buttonStyle(.plain)
-                                .accessibilityIdentifier("medication-amount-preset-\(Self.amountText(for: amount))")
-                            }
-                        }
-                    }
-
-                    HStack {
-                        TextField("Amount", text: $amountText)
-                            .keyboardType(.decimalPad)
-                            .accessibilityIdentifier("medication-amount-field")
-                        Text(unitDisplay)
-                            .foregroundStyle(.secondary)
-                    }
-
-                    if unit == .custom {
-                        TextField("Unit (e.g. puff, sachet)", text: $customUnitLabel)
-                            .accessibilityIdentifier("medication-custom-unit-field")
-                    }
-                }
-
-                if let validationMessage {
-                    Section {
-                        Text(validationMessage)
-                            .foregroundStyle(.red)
-                    }
-                }
-
-                Section("When?") {
-                    QuickTimeSelectorView(selection: $occurredAt, initialPreset: initialTimePreset, buttonColor: Self.eventColor)
-                        .accessibilityIdentifier("medication-time-selector")
-                }
-
-                if deleteAction != nil {
-                    Section {
-                        Button("Delete Medication", role: .destructive) {
-                            showDeleteConfirmation = true
-                        }
-                        .accessibilityIdentifier("delete-medication-button")
-                    }
-                }
+                medicineSection
+                amountSection
+                validationSection
+                whenSection
+                deleteSection
             }
             .alert("Delete Medication?", isPresented: $showDeleteConfirmation) {
                 Button("Delete", role: .destructive) {
@@ -174,33 +82,158 @@ public struct MedicationEditorSheetView: View {
             .navigationTitle(navigationTitle)
             .navigationBarTitleDisplayMode(.inline)
             .presentationDetents([.large])
-            .toolbar {
-                ToolbarItem(placement: .cancellationAction) {
-                    Button("Cancel") {
-                        dismiss()
-                    }
-                }
-
-                ToolbarItem(placement: .confirmationAction) {
-                    Button(primaryActionTitle) {
-                        guard let amount = parsedAmount, isValid else { return }
-                        let didSave = saveAction(
-                            occurredAt,
-                            medicineName.trimmingCharacters(in: .whitespacesAndNewlines),
-                            amount,
-                            unit,
-                            unit == .custom ? customUnitLabel.trimmingCharacters(in: .whitespacesAndNewlines) : nil
-                        )
-                        if didSave {
-                            dismiss()
-                        }
-                    }
-                    .disabled(!isValid)
-                    .accessibilityIdentifier("save-medication-button")
-                }
-            }
+            .toolbar { toolbarContent }
         }
         .tint(Self.eventColor)
+    }
+
+    @ViewBuilder
+    private var medicineSection: some View {
+        Section {
+            if !medicineSuggestions.isEmpty {
+                medicineSuggestionsRow
+            }
+            TextField("Type a medicine name", text: $medicineName)
+                .accessibilityIdentifier("medication-name-field")
+        } header: {
+            Text("Which medicine?")
+        } footer: {
+            Text(medicineSuggestions.isEmpty
+                ? "Type the name of the medicine."
+                : "Tap a recent medicine above, or type a new one.")
+        }
+    }
+
+    private var medicineSuggestionsRow: some View {
+        ScrollView(.horizontal, showsIndicators: false) {
+            HStack(spacing: 8) {
+                ForEach(medicineSuggestions, id: \.self) { name in
+                    Button {
+                        medicineName = name
+                    } label: {
+                        chipLabel(name, isSelected: isSelectedName(name), shape: Capsule())
+                    }
+                    .buttonStyle(.plain)
+                    .accessibilityIdentifier("medication-name-suggestion-\(name)")
+                }
+            }
+            .padding(.vertical, 2)
+        }
+        .listRowInsets(EdgeInsets(top: 8, leading: 12, bottom: 8, trailing: 12))
+    }
+
+    @ViewBuilder
+    private var amountSection: some View {
+        Section("How much?") {
+            unitPicker
+
+            if !amountPresets.isEmpty {
+                amountPresetGrid
+            }
+
+            HStack {
+                TextField("Amount", text: $amountText)
+                    .keyboardType(.decimalPad)
+                    .accessibilityIdentifier("medication-amount-field")
+                Text(unitDisplay)
+                    .foregroundStyle(.secondary)
+            }
+
+            if unit == .custom {
+                TextField("Unit (e.g. puff, sachet)", text: $customUnitLabel)
+                    .accessibilityIdentifier("medication-custom-unit-field")
+            }
+        }
+    }
+
+    private var amountPresetGrid: some View {
+        LazyVGrid(columns: amountColumns, spacing: 8) {
+            ForEach(amountPresets, id: \.self) { amount in
+                Button {
+                    amountText = Self.amountText(for: amount)
+                } label: {
+                    chipLabel(
+                        Self.amountText(for: amount),
+                        isSelected: isSelectedAmount(amount),
+                        shape: RoundedRectangle(cornerRadius: 12, style: .continuous),
+                        fillWidth: true
+                    )
+                }
+                .buttonStyle(.plain)
+                .accessibilityIdentifier("medication-amount-preset-\(Self.amountText(for: amount))")
+            }
+        }
+    }
+
+    private func chipLabel(
+        _ text: String,
+        isSelected: Bool,
+        shape: some Shape,
+        fillWidth: Bool = false
+    ) -> some View {
+        Text(text)
+            .font(.subheadline.weight(.semibold))
+            .frame(maxWidth: fillWidth ? .infinity : nil)
+            .padding(.horizontal, fillWidth ? 0 : 14)
+            .padding(.vertical, fillWidth ? 10 : 8)
+            .background(shape.fill(isSelected ? Self.eventColor : Color(.tertiarySystemGroupedBackground)))
+            .foregroundStyle(isSelected ? Color.white : Color.primary)
+    }
+
+    @ViewBuilder
+    private var validationSection: some View {
+        if let validationMessage {
+            Section {
+                Text(validationMessage)
+                    .foregroundStyle(.red)
+            }
+        }
+    }
+
+    private var whenSection: some View {
+        Section("When?") {
+            QuickTimeSelectorView(selection: $occurredAt, initialPreset: initialTimePreset, buttonColor: Self.eventColor)
+                .accessibilityIdentifier("medication-time-selector")
+        }
+    }
+
+    @ViewBuilder
+    private var deleteSection: some View {
+        if deleteAction != nil {
+            Section {
+                Button("Delete Medication", role: .destructive) {
+                    showDeleteConfirmation = true
+                }
+                .accessibilityIdentifier("delete-medication-button")
+            }
+        }
+    }
+
+    @ToolbarContentBuilder
+    private var toolbarContent: some ToolbarContent {
+        ToolbarItem(placement: .cancellationAction) {
+            Button("Cancel") {
+                dismiss()
+            }
+        }
+
+        ToolbarItem(placement: .confirmationAction) {
+            Button(primaryActionTitle) {
+                guard let amount = parsedAmount, isValid else { return }
+                let didSave = saveAction(
+                    occurredAt,
+                    medicineName.trimmingCharacters(in: .whitespacesAndNewlines),
+                    amount,
+                    unit,
+                    unit == .custom ? customUnitLabel.trimmingCharacters(in: .whitespacesAndNewlines) : nil
+                )
+                if didSave {
+                    dismiss()
+                }
+            }
+            .disabled(!isValid)
+            .accessibilityIdentifier("save-medication-button")
+        }
     }
 
     private var unitPicker: some View {

--- a/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/MedicationEditorSheetView.swift
+++ b/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/MedicationEditorSheetView.swift
@@ -1,0 +1,319 @@
+import BabyTrackerDomain
+import SwiftUI
+
+public struct MedicationEditorSheetView: View {
+    private static let eventColor = BabyEventStyle.accentColor(for: .medication)
+
+    let navigationTitle: String
+    let primaryActionTitle: String
+    let childName: String
+    let recentMedicineNames: [String]
+    let millilitreAmounts: [Double]
+    let saveAction: (_ occurredAt: Date, _ medicineName: String, _ amount: Double, _ unit: MedicationUnit, _ customUnitLabel: String?) -> Bool
+    let deleteAction: (() -> Void)?
+
+    @Environment(\.dismiss) private var dismiss
+    @State private var occurredAt: Date
+    @State private var medicineName: String
+    @State private var amountText: String
+    @State private var unit: MedicationUnit
+    @State private var customUnitLabel: String
+    @State private var showDeleteConfirmation = false
+    private let initialTimePreset: QuickTimeSelectorView.TimePreset
+
+    private let amountColumns = [
+        GridItem(.flexible(), spacing: 8),
+        GridItem(.flexible(), spacing: 8),
+        GridItem(.flexible(), spacing: 8),
+        GridItem(.flexible(), spacing: 8)
+    ]
+
+    public init(
+        navigationTitle: String,
+        primaryActionTitle: String,
+        childName: String,
+        recentMedicineNames: [String],
+        millilitreAmounts: [Double],
+        initialOccurredAt: Date,
+        initialMedicineName: String = "",
+        initialAmount: Double? = nil,
+        initialUnit: MedicationUnit = .ml,
+        initialCustomUnitLabel: String? = nil,
+        initialTimePreset: QuickTimeSelectorView.TimePreset = .now,
+        deleteAction: (() -> Void)? = nil,
+        saveAction: @escaping (_ occurredAt: Date, _ medicineName: String, _ amount: Double, _ unit: MedicationUnit, _ customUnitLabel: String?) -> Bool
+    ) {
+        self.navigationTitle = navigationTitle
+        self.primaryActionTitle = primaryActionTitle
+        self.childName = childName
+        self.recentMedicineNames = recentMedicineNames
+        self.millilitreAmounts = millilitreAmounts
+        self.deleteAction = deleteAction
+        self.saveAction = saveAction
+        _occurredAt = State(initialValue: initialOccurredAt)
+        _medicineName = State(initialValue: initialMedicineName)
+        _amountText = State(initialValue: initialAmount.map(Self.amountText(for:)) ?? "")
+        _unit = State(initialValue: initialUnit)
+        _customUnitLabel = State(initialValue: initialCustomUnitLabel ?? "")
+        self.initialTimePreset = initialTimePreset
+    }
+
+    public var body: some View {
+        NavigationStack {
+            Form {
+                LoggingSummaryView(sentence: summarySentence)
+
+                Section("Which medicine?") {
+                    if !medicineSuggestions.isEmpty {
+                        ScrollView(.horizontal, showsIndicators: false) {
+                            HStack(spacing: 8) {
+                                ForEach(medicineSuggestions, id: \.self) { name in
+                                    Button {
+                                        medicineName = name
+                                    } label: {
+                                        Text(name)
+                                            .font(.subheadline.weight(.semibold))
+                                            .padding(.horizontal, 14)
+                                            .padding(.vertical, 8)
+                                            .background(
+                                                Capsule()
+                                                    .fill(isSelectedName(name) ? Self.eventColor : Color(.tertiarySystemGroupedBackground))
+                                            )
+                                            .foregroundStyle(isSelectedName(name) ? Color.white : Color.primary)
+                                    }
+                                    .buttonStyle(.plain)
+                                    .accessibilityIdentifier("medication-name-suggestion-\(name)")
+                                }
+                            }
+                            .padding(.vertical, 2)
+                        }
+                        .listRowInsets(EdgeInsets(top: 8, leading: 12, bottom: 8, trailing: 12))
+                    }
+
+                    TextField("Medicine name", text: $medicineName)
+                        .accessibilityIdentifier("medication-name-field")
+                }
+
+                Section("How much?") {
+                    unitPicker
+
+                    if !amountPresets.isEmpty {
+                        LazyVGrid(columns: amountColumns, spacing: 8) {
+                            ForEach(amountPresets, id: \.self) { amount in
+                                Button {
+                                    amountText = Self.amountText(for: amount)
+                                } label: {
+                                    Text(Self.amountText(for: amount))
+                                        .font(.subheadline.weight(.semibold))
+                                        .frame(maxWidth: .infinity)
+                                        .padding(.vertical, 10)
+                                        .background(
+                                            RoundedRectangle(cornerRadius: 12, style: .continuous)
+                                                .fill(isSelectedAmount(amount) ? Self.eventColor : Color(.tertiarySystemGroupedBackground))
+                                        )
+                                        .foregroundStyle(isSelectedAmount(amount) ? Color.white : Color.primary)
+                                }
+                                .buttonStyle(.plain)
+                                .accessibilityIdentifier("medication-amount-preset-\(Self.amountText(for: amount))")
+                            }
+                        }
+                    }
+
+                    HStack {
+                        TextField("Amount", text: $amountText)
+                            .keyboardType(.decimalPad)
+                            .accessibilityIdentifier("medication-amount-field")
+                        Text(unitDisplay)
+                            .foregroundStyle(.secondary)
+                    }
+
+                    if unit == .custom {
+                        TextField("Unit (e.g. puff, sachet)", text: $customUnitLabel)
+                            .accessibilityIdentifier("medication-custom-unit-field")
+                    }
+                }
+
+                if let validationMessage {
+                    Section {
+                        Text(validationMessage)
+                            .foregroundStyle(.red)
+                    }
+                }
+
+                Section("When?") {
+                    QuickTimeSelectorView(selection: $occurredAt, initialPreset: initialTimePreset, buttonColor: Self.eventColor)
+                        .accessibilityIdentifier("medication-time-selector")
+                }
+
+                if deleteAction != nil {
+                    Section {
+                        Button("Delete Medication", role: .destructive) {
+                            showDeleteConfirmation = true
+                        }
+                        .accessibilityIdentifier("delete-medication-button")
+                    }
+                }
+            }
+            .alert("Delete Medication?", isPresented: $showDeleteConfirmation) {
+                Button("Delete", role: .destructive) {
+                    deleteAction?()
+                    dismiss()
+                }
+                Button("Cancel", role: .cancel) {}
+            } message: {
+                Text("This event will be permanently removed.")
+            }
+            .scrollContentBackground(.hidden)
+            .background(Self.eventColor.opacity(0.08))
+            .navigationTitle(navigationTitle)
+            .navigationBarTitleDisplayMode(.inline)
+            .presentationDetents([.large])
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button("Cancel") {
+                        dismiss()
+                    }
+                }
+
+                ToolbarItem(placement: .confirmationAction) {
+                    Button(primaryActionTitle) {
+                        guard let amount = parsedAmount, isValid else { return }
+                        let didSave = saveAction(
+                            occurredAt,
+                            medicineName.trimmingCharacters(in: .whitespacesAndNewlines),
+                            amount,
+                            unit,
+                            unit == .custom ? customUnitLabel.trimmingCharacters(in: .whitespacesAndNewlines) : nil
+                        )
+                        if didSave {
+                            dismiss()
+                        }
+                    }
+                    .disabled(!isValid)
+                    .accessibilityIdentifier("save-medication-button")
+                }
+            }
+        }
+        .tint(Self.eventColor)
+    }
+
+    private var unitPicker: some View {
+        Picker("Unit", selection: $unit) {
+            ForEach(MedicationUnit.allCases, id: \.self) { unit in
+                Text(unitLabel(for: unit)).tag(unit)
+            }
+        }
+        .pickerStyle(.segmented)
+        .accessibilityIdentifier("medication-unit-picker")
+    }
+
+    private func unitLabel(for unit: MedicationUnit) -> String {
+        switch unit {
+        case .ml: "ml"
+        case .mg: "mg"
+        case .drops: "drops"
+        case .tablet: "tablet"
+        case .custom: "custom"
+        }
+    }
+
+    private var unitDisplay: String {
+        if unit == .custom {
+            let trimmed = customUnitLabel.trimmingCharacters(in: .whitespacesAndNewlines)
+            return trimmed.isEmpty ? "unit" : trimmed
+        }
+        return unit.shortTitle
+    }
+
+    /// Quick-pick names: previously logged medicines first, then seeded catalog entries
+    /// not already present (case-insensitive).
+    private var medicineSuggestions: [String] {
+        var seen = Set(recentMedicineNames.map { $0.lowercased() })
+        var names = recentMedicineNames
+        for name in MedicationCatalog.commonMedicines where seen.insert(name.lowercased()).inserted {
+            names.append(name)
+        }
+        return names
+    }
+
+    private var amountPresets: [Double] {
+        switch unit {
+        case .ml:
+            return millilitreAmounts
+        case .tablet:
+            return [0.5, 1, 2]
+        case .drops:
+            return [1, 2, 3, 5]
+        case .mg, .custom:
+            return []
+        }
+    }
+
+    private var parsedAmount: Double? {
+        Double(amountText.trimmingCharacters(in: .whitespacesAndNewlines).replacingOccurrences(of: ",", with: "."))
+    }
+
+    private var isValid: Bool {
+        guard !medicineName.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else { return false }
+        guard let amount = parsedAmount, amount > 0 else { return false }
+        if unit == .custom, customUnitLabel.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+            return false
+        }
+        return true
+    }
+
+    private var validationMessage: String? {
+        guard !amountText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else { return nil }
+        guard let amount = parsedAmount, amount > 0 else {
+            return "Enter an amount greater than zero."
+        }
+        return nil
+    }
+
+    private func isSelectedName(_ name: String) -> Bool {
+        medicineName.caseInsensitiveCompare(name) == .orderedSame
+    }
+
+    private func isSelectedAmount(_ amount: Double) -> Bool {
+        parsedAmount == amount
+    }
+
+    private var summarySentence: AttributedString {
+        let timeText = occurredAt.formatted(date: .omitted, time: .shortened)
+        var sentence = summaryVariable(childName, color: Self.eventColor)
+        sentence += AttributedString(" had ")
+
+        let name = medicineName.trimmingCharacters(in: .whitespacesAndNewlines)
+        sentence += summaryVariable(name.isEmpty ? "medicine" : name, color: Self.eventColor)
+
+        if let amount = parsedAmount, amount > 0 {
+            sentence += AttributedString(" (")
+            sentence += summaryVariable("\(Self.amountText(for: amount)) \(unitDisplay)", color: Self.eventColor)
+            sentence += AttributedString(")")
+        }
+
+        sentence += AttributedString(" at ")
+        sentence += summaryVariable(timeText, color: Self.eventColor)
+        return sentence
+    }
+
+    private static func amountText(for amount: Double) -> String {
+        let rounded = (amount * 100).rounded() / 100
+        if rounded == rounded.rounded() {
+            return String(Int(rounded))
+        }
+        return String(rounded)
+    }
+}
+
+#Preview("Quick Log Medication") {
+    MedicationEditorSheetView(
+        navigationTitle: "Medication",
+        primaryActionTitle: "Save",
+        childName: "Poppy",
+        recentMedicineNames: ["Paracetamol (Calpol)"],
+        millilitreAmounts: [2.5, 5, 7.5, 10],
+        initialOccurredAt: .now,
+        saveAction: { _, _, _, _, _ in true }
+    )
+}

--- a/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/MedicationEditorSheetView.swift
+++ b/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/MedicationEditorSheetView.swift
@@ -15,6 +15,8 @@ public struct MedicationEditorSheetView: View {
     @Environment(\.dismiss) private var dismiss
     @State private var occurredAt: Date
     @State private var medicineName: String
+    @State private var isCustomMedicine: Bool
+    @State private var customMedicineName: String
     @State private var amountText: String
     @State private var unit: MedicationUnit
     @State private var customUnitLabel: String
@@ -50,8 +52,14 @@ public struct MedicationEditorSheetView: View {
         self.millilitreAmounts = millilitreAmounts
         self.deleteAction = deleteAction
         self.saveAction = saveAction
+        let allKnownNames = Set(
+            (recentMedicineNames + MedicationCatalog.commonMedicines).map { $0.lowercased() }
+        )
+        let isCustom = !initialMedicineName.isEmpty && !allKnownNames.contains(initialMedicineName.lowercased())
         _occurredAt = State(initialValue: initialOccurredAt)
-        _medicineName = State(initialValue: initialMedicineName)
+        _medicineName = State(initialValue: isCustom ? "" : initialMedicineName)
+        _isCustomMedicine = State(initialValue: isCustom)
+        _customMedicineName = State(initialValue: isCustom ? initialMedicineName : "")
         _amountText = State(initialValue: initialAmount.map(Self.amountText(for:)) ?? "")
         _unit = State(initialValue: initialUnit)
         _customUnitLabel = State(initialValue: initialCustomUnitLabel ?? "")
@@ -90,17 +98,13 @@ public struct MedicationEditorSheetView: View {
     @ViewBuilder
     private var medicineSection: some View {
         Section {
-            if !medicineSuggestions.isEmpty {
-                medicineSuggestionsRow
+            medicineSuggestionsRow
+            if isCustomMedicine {
+                TextField("Medicine name", text: $customMedicineName)
+                    .accessibilityIdentifier("medication-name-field")
             }
-            TextField("Type a medicine name", text: $medicineName)
-                .accessibilityIdentifier("medication-name-field")
         } header: {
             Text("Which medicine?")
-        } footer: {
-            Text(medicineSuggestions.isEmpty
-                ? "Type the name of the medicine."
-                : "Tap a recent medicine above, or type a new one.")
         }
     }
 
@@ -110,12 +114,21 @@ public struct MedicationEditorSheetView: View {
                 ForEach(medicineSuggestions, id: \.self) { name in
                     Button {
                         medicineName = name
+                        isCustomMedicine = false
                     } label: {
-                        chipLabel(name, isSelected: isSelectedName(name), shape: Capsule())
+                        chipLabel(name, isSelected: !isCustomMedicine && isSelectedName(name), shape: Capsule())
                     }
                     .buttonStyle(.plain)
                     .accessibilityIdentifier("medication-name-suggestion-\(name)")
                 }
+                Button {
+                    isCustomMedicine = true
+                    medicineName = ""
+                } label: {
+                    chipLabel("Custom", isSelected: isCustomMedicine, shape: Capsule())
+                }
+                .buttonStyle(.plain)
+                .accessibilityIdentifier("medication-name-custom")
             }
             .padding(.vertical, 2)
         }
@@ -222,7 +235,7 @@ public struct MedicationEditorSheetView: View {
                 guard let amount = parsedAmount, isValid else { return }
                 let didSave = saveAction(
                     occurredAt,
-                    medicineName.trimmingCharacters(in: .whitespacesAndNewlines),
+                    effectiveMedicineName.trimmingCharacters(in: .whitespacesAndNewlines),
                     amount,
                     unit,
                     unit == .custom ? customUnitLabel.trimmingCharacters(in: .whitespacesAndNewlines) : nil
@@ -292,8 +305,12 @@ public struct MedicationEditorSheetView: View {
         Double(amountText.trimmingCharacters(in: .whitespacesAndNewlines).replacingOccurrences(of: ",", with: "."))
     }
 
+    private var effectiveMedicineName: String {
+        isCustomMedicine ? customMedicineName : medicineName
+    }
+
     private var isValid: Bool {
-        guard !medicineName.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else { return false }
+        guard !effectiveMedicineName.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else { return false }
         guard let amount = parsedAmount, amount > 0 else { return false }
         if unit == .custom, customUnitLabel.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
             return false
@@ -322,7 +339,7 @@ public struct MedicationEditorSheetView: View {
         var sentence = summaryVariable(childName, color: Self.eventColor)
         sentence += AttributedString(" had ")
 
-        let name = medicineName.trimmingCharacters(in: .whitespacesAndNewlines)
+        let name = effectiveMedicineName.trimmingCharacters(in: .whitespacesAndNewlines)
         sentence += summaryVariable(name.isEmpty ? "medicine" : name, color: Self.eventColor)
 
         if let amount = parsedAmount, amount > 0 {

--- a/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/MedicationEditorSheetView.swift
+++ b/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/MedicationEditorSheetView.swift
@@ -63,7 +63,7 @@ public struct MedicationEditorSheetView: View {
             Form {
                 LoggingSummaryView(sentence: summarySentence)
 
-                Section("Which medicine?") {
+                Section {
                     if !medicineSuggestions.isEmpty {
                         ScrollView(.horizontal, showsIndicators: false) {
                             HStack(spacing: 8) {
@@ -90,8 +90,14 @@ public struct MedicationEditorSheetView: View {
                         .listRowInsets(EdgeInsets(top: 8, leading: 12, bottom: 8, trailing: 12))
                     }
 
-                    TextField("Medicine name", text: $medicineName)
+                    TextField("Type a medicine name", text: $medicineName)
                         .accessibilityIdentifier("medication-name-field")
+                } header: {
+                    Text("Which medicine?")
+                } footer: {
+                    Text(medicineSuggestions.isEmpty
+                        ? "Type the name of the medicine."
+                        : "Tap a recent medicine above, or type a new one.")
                 }
 
                 Section("How much?") {

--- a/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/OnboardingAppPreviewStepView.swift
+++ b/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/OnboardingAppPreviewStepView.swift
@@ -128,6 +128,9 @@ struct OnboardingAppPreviewStepView: View {
 
         case let .nappy(e):
             Text(nappyDetail(e))
+
+        case let .medication(e):
+            Text("\(e.medicineName) · \(e.formattedAmount) \(e.displayUnit)")
         }
     }
 
@@ -286,6 +289,7 @@ struct OnboardingAppPreviewStepView: View {
         case .bottleFeed: return "Bottle feed"
         case .sleep:      return "Sleep"
         case .nappy:      return "Nappy"
+        case .medication: return "Medication"
         }
     }
 

--- a/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/OnboardingFirstEventStepView.swift
+++ b/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/OnboardingFirstEventStepView.swift
@@ -105,6 +105,7 @@ struct OnboardingFirstEventStepView: View {
         case .bottleFeed: "Bottle Feed"
         case .sleep: "Start Sleep"
         case .nappy: "Nappy"
+        case .medication: "Medication"
         }
     }
 
@@ -115,6 +116,10 @@ struct OnboardingFirstEventStepView: View {
         case .bottleFeed: .quickLogBottleFeed(smartSuggestions: [])
         case .sleep: .startSleep(suggestions: [])
         case .nappy: .quickLogNappy(.mixed)
+        case .medication: .quickLogMedication(
+            recentNames: [],
+            millilitreAmounts: MedicationCatalog.defaultMillilitreAmounts(forBirthDate: nil)
+        )
         }
     }
 

--- a/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/OnboardingLiveActivityDemoView.swift
+++ b/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/OnboardingLiveActivityDemoView.swift
@@ -317,6 +317,8 @@ struct OnboardingLiveActivityDemoView: View {
             "bed.double"
         case .nappy:
             "checklist"
+        case .medication:
+            "pills.fill"
         }
     }
 
@@ -332,6 +334,8 @@ struct OnboardingLiveActivityDemoView: View {
             Color(red: 0.29, green: 0.33, blue: 0.73)
         case .nappy:
             Color(red: 0.74, green: 0.47, blue: 0.16)
+        case .medication:
+            Color(red: 0.55, green: 0.34, blue: 0.78)
         }
     }
 }

--- a/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/OnboardingTimelineDemoView.swift
+++ b/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/OnboardingTimelineDemoView.swift
@@ -212,6 +212,8 @@ struct OnboardingTimelineDemoView: View {
             baseDelay = 130
         case .nappy:
             baseDelay = 240
+        case .medication:
+            baseDelay = 255
         }
 
         let rowDelay = UInt64(entry.start * 170)

--- a/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/TimelineDayGridView.swift
+++ b/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/TimelineDayGridView.swift
@@ -291,6 +291,8 @@ struct TimelineDayGridHeaderView: View {
             .bottleFeed
         case .breastFeed:
             .breastFeed
+        case .medication:
+            .medication
         }
     }
 }

--- a/Packages/BabyTrackerPersistence/Sources/BabyTrackerPersistence/BabyTrackerModelStore.swift
+++ b/Packages/BabyTrackerPersistence/Sources/BabyTrackerPersistence/BabyTrackerModelStore.swift
@@ -14,6 +14,7 @@ public final class BabyTrackerModelStore {
             StoredSleepEvent.self,
             StoredNappyEvent.self,
             StoredBathEvent.self,
+            StoredMedicationEvent.self,
             StoredCloudKitRecordMetadata.self,
             StoredSyncAnchor.self,
         ])

--- a/Packages/BabyTrackerPersistence/Sources/BabyTrackerPersistence/Models/StoredMedicationEvent.swift
+++ b/Packages/BabyTrackerPersistence/Sources/BabyTrackerPersistence/Models/StoredMedicationEvent.swift
@@ -1,0 +1,61 @@
+import Foundation
+import SwiftData
+
+@Model
+final class StoredMedicationEvent {
+    var id: UUID = UUID()
+    var childID: UUID = UUID()
+    var occurredAt: Date = Date()
+    var createdAt: Date = Date()
+    var createdBy: UUID = UUID()
+    var updatedAt: Date = Date()
+    var updatedBy: UUID = UUID()
+    var notes: String = ""
+    var isDeleted: Bool = false
+    var deletedAt: Date?
+    var medicineName: String = ""
+    var amount: Double = 0
+    var unitRawValue: String = ""
+    var customUnitLabel: String?
+    var syncStateRawValue: String = ""
+    var lastSyncedAt: Date?
+    var lastSyncErrorCode: String?
+
+    init(
+        id: UUID,
+        childID: UUID,
+        occurredAt: Date,
+        createdAt: Date,
+        createdBy: UUID,
+        updatedAt: Date,
+        updatedBy: UUID,
+        notes: String,
+        isDeleted: Bool,
+        deletedAt: Date?,
+        medicineName: String,
+        amount: Double,
+        unitRawValue: String,
+        customUnitLabel: String?,
+        syncStateRawValue: String,
+        lastSyncedAt: Date?,
+        lastSyncErrorCode: String?
+    ) {
+        self.id = id
+        self.childID = childID
+        self.occurredAt = occurredAt
+        self.createdAt = createdAt
+        self.createdBy = createdBy
+        self.updatedAt = updatedAt
+        self.updatedBy = updatedBy
+        self.notes = notes
+        self.isDeleted = isDeleted
+        self.deletedAt = deletedAt
+        self.medicineName = medicineName
+        self.amount = amount
+        self.unitRawValue = unitRawValue
+        self.customUnitLabel = customUnitLabel
+        self.syncStateRawValue = syncStateRawValue
+        self.lastSyncedAt = lastSyncedAt
+        self.lastSyncErrorCode = lastSyncErrorCode
+    }
+}

--- a/Packages/BabyTrackerPersistence/Sources/BabyTrackerPersistence/SwiftDataChildRepository.swift
+++ b/Packages/BabyTrackerPersistence/Sources/BabyTrackerPersistence/SwiftDataChildRepository.swift
@@ -118,6 +118,10 @@ public final class SwiftDataChildRepository: CloudKitChildRepository {
             modelContext.delete(event)
         }
 
+        for event in try modelContext.fetch(FetchDescriptor<StoredMedicationEvent>()) where event.childID == id {
+            modelContext.delete(event)
+        }
+
         if let child = try fetchStoredChild(id: id) {
             modelContext.delete(child)
         }

--- a/Packages/BabyTrackerPersistence/Sources/BabyTrackerPersistence/SwiftDataEventRepository.swift
+++ b/Packages/BabyTrackerPersistence/Sources/BabyTrackerPersistence/SwiftDataEventRepository.swift
@@ -29,6 +29,8 @@ public final class SwiftDataEventRepository: EventRepository {
             try saveSleep(value)
         case let .nappy(value):
             try saveNappy(value)
+        case let .medication(value):
+            try saveMedication(value)
         }
 
         try saveChanges()
@@ -53,6 +55,10 @@ public final class SwiftDataEventRepository: EventRepository {
 
         if let storedEvent = try fetchStoredNappyEvent(id: id) {
             return .nappy(try mapNappy(storedEvent))
+        }
+
+        if let storedEvent = try fetchStoredMedicationEvent(id: id) {
+            return .medication(try mapMedication(storedEvent))
         }
 
         return nil
@@ -124,6 +130,18 @@ public final class SwiftDataEventRepository: EventRepository {
                 )
             }
             .map { .nappy(try mapNappy($0)) })
+        timeline.append(contentsOf: try modelContext.fetch(FetchDescriptor<StoredMedicationEvent>())
+            .filter { storedEvent in
+                storedEvent.childID == childID &&
+                (
+                    includingDeleted ||
+                    !isSoftDeleted(
+                        isDeleted: storedEvent.isDeleted,
+                        deletedAt: storedEvent.deletedAt
+                    )
+                )
+            }
+            .map { .medication(try mapMedication($0)) })
 
         return timeline.sorted { left, right in
             left.metadata.occurredAt > right.metadata.occurredAt
@@ -165,6 +183,8 @@ public final class SwiftDataEventRepository: EventRepository {
             return feed.metadata.occurredAt >= startOfDay && feed.metadata.occurredAt < endOfDay
         case let .nappy(nappy):
             return nappy.metadata.occurredAt >= startOfDay && nappy.metadata.occurredAt < endOfDay
+        case let .medication(medication):
+            return medication.metadata.occurredAt >= startOfDay && medication.metadata.occurredAt < endOfDay
         }
     }
 
@@ -198,6 +218,8 @@ public final class SwiftDataEventRepository: EventRepository {
             markDeleted(storedEvent, deletedAt: deletedAt, deletedBy: deletedBy)
         } else if let storedEvent = try fetchStoredNappyEvent(id: id) {
             markDeleted(storedEvent, deletedAt: deletedAt, deletedBy: deletedBy)
+        } else if let storedEvent = try fetchStoredMedicationEvent(id: id) {
+            markDeleted(storedEvent, deletedAt: deletedAt, deletedBy: deletedBy)
         }
 
         try saveChanges()
@@ -230,6 +252,40 @@ public final class SwiftDataEventRepository: EventRepository {
         applyMetadata(event.metadata, to: storedEvent)
         storedEvent.usedShampoo = event.usedShampoo
         storedEvent.usedSoap = event.usedSoap
+        markPending(storedEvent)
+
+        if existingEvent == nil {
+            modelContext.insert(storedEvent)
+        }
+    }
+
+    private func saveMedication(_ event: MedicationEvent) throws {
+        let existingEvent = try fetchStoredMedicationEvent(id: event.id)
+        let storedEvent = existingEvent ?? StoredMedicationEvent(
+            id: event.id,
+            childID: event.metadata.childID,
+            occurredAt: event.metadata.occurredAt,
+            createdAt: event.metadata.createdAt,
+            createdBy: event.metadata.createdBy,
+            updatedAt: event.metadata.updatedAt,
+            updatedBy: event.metadata.updatedBy,
+            notes: event.metadata.notes,
+            isDeleted: event.metadata.isDeleted,
+            deletedAt: event.metadata.deletedAt,
+            medicineName: event.medicineName,
+            amount: event.amount,
+            unitRawValue: event.unit.rawValue,
+            customUnitLabel: event.customUnitLabel,
+            syncStateRawValue: SyncState.pendingSync.rawValue,
+            lastSyncedAt: nil,
+            lastSyncErrorCode: nil
+        )
+
+        applyMetadata(event.metadata, to: storedEvent)
+        storedEvent.medicineName = event.medicineName
+        storedEvent.amount = event.amount
+        storedEvent.unitRawValue = event.unit.rawValue
+        storedEvent.customUnitLabel = event.customUnitLabel
         markPending(storedEvent)
 
         if existingEvent == nil {
@@ -393,6 +449,11 @@ public final class SwiftDataEventRepository: EventRepository {
             .first { $0.id == id }
     }
 
+    private func fetchStoredMedicationEvent(id: UUID) throws -> StoredMedicationEvent? {
+        try modelContext.fetch(FetchDescriptor<StoredMedicationEvent>())
+            .first { $0.id == id }
+    }
+
     private func mapBath(_ storedEvent: StoredBathEvent) -> BathEvent {
         BathEvent(
             metadata: makeMetadata(
@@ -409,6 +470,29 @@ public final class SwiftDataEventRepository: EventRepository {
             ),
             usedShampoo: storedEvent.usedShampoo,
             usedSoap: storedEvent.usedSoap
+        )
+    }
+
+    private func mapMedication(_ storedEvent: StoredMedicationEvent) throws -> MedicationEvent {
+        let unit = MedicationUnit(rawValue: storedEvent.unitRawValue) ?? .custom
+
+        return try MedicationEvent(
+            metadata: makeMetadata(
+                id: storedEvent.id,
+                childID: storedEvent.childID,
+                occurredAt: storedEvent.occurredAt,
+                createdAt: storedEvent.createdAt,
+                createdBy: storedEvent.createdBy,
+                updatedAt: storedEvent.updatedAt,
+                updatedBy: storedEvent.updatedBy,
+                notes: storedEvent.notes,
+                isDeleted: storedEvent.isDeleted,
+                deletedAt: storedEvent.deletedAt
+            ),
+            medicineName: storedEvent.medicineName,
+            amount: storedEvent.amount,
+            unit: unit,
+            customUnitLabel: storedEvent.customUnitLabel
         )
     }
 
@@ -554,6 +638,18 @@ public final class SwiftDataEventRepository: EventRepository {
         storedEvent.deletedAt = metadata.deletedAt
     }
 
+    private func applyMetadata(_ metadata: EventMetadata, to storedEvent: StoredMedicationEvent) {
+        storedEvent.childID = metadata.childID
+        storedEvent.occurredAt = metadata.occurredAt
+        storedEvent.createdAt = metadata.createdAt
+        storedEvent.createdBy = metadata.createdBy
+        storedEvent.updatedAt = metadata.updatedAt
+        storedEvent.updatedBy = metadata.updatedBy
+        storedEvent.notes = metadata.notes
+        storedEvent.isDeleted = metadata.isDeleted
+        storedEvent.deletedAt = metadata.deletedAt
+    }
+
     private func applyMetadata(_ metadata: EventMetadata, to storedEvent: StoredBreastFeedEvent) {
         storedEvent.childID = metadata.childID
         storedEvent.occurredAt = metadata.occurredAt
@@ -615,6 +711,18 @@ public final class SwiftDataEventRepository: EventRepository {
     }
 
     private func markDeleted(
+        _ storedEvent: StoredMedicationEvent,
+        deletedAt: Date,
+        deletedBy: UUID
+    ) {
+        storedEvent.isDeleted = true
+        storedEvent.deletedAt = deletedAt
+        storedEvent.updatedAt = deletedAt
+        storedEvent.updatedBy = deletedBy
+        markPending(storedEvent)
+    }
+
+    private func markDeleted(
         _ storedEvent: StoredBreastFeedEvent,
         deletedAt: Date,
         deletedBy: UUID
@@ -663,6 +771,11 @@ public final class SwiftDataEventRepository: EventRepository {
     }
 
     private func markPending(_ storedEvent: StoredBathEvent) {
+        storedEvent.syncStateRawValue = SyncState.pendingSync.rawValue
+        storedEvent.lastSyncErrorCode = nil
+    }
+
+    private func markPending(_ storedEvent: StoredMedicationEvent) {
         storedEvent.syncStateRawValue = SyncState.pendingSync.rawValue
         storedEvent.lastSyncErrorCode = nil
     }

--- a/Packages/BabyTrackerPersistence/Sources/BabyTrackerPersistence/SwiftDataSyncStateRepository.swift
+++ b/Packages/BabyTrackerPersistence/Sources/BabyTrackerPersistence/SwiftDataSyncStateRepository.swift
@@ -29,6 +29,7 @@ public final class SwiftDataSyncStateRepository: SyncStateRepository {
         records.append(contentsOf: try pendingSleepEvents())
         records.append(contentsOf: try pendingNappyEvents())
         records.append(contentsOf: try pendingBathEvents())
+        records.append(contentsOf: try pendingMedicationEvents())
 
         return records
     }
@@ -70,6 +71,10 @@ public final class SwiftDataSyncStateRepository: SyncStateRepository {
             }
         case .bathEvent:
             if let model = try fetchBath(id: record.recordID) {
+                apply(state: state, lastSyncedAt: lastSyncedAt, lastSyncErrorCode: lastSyncErrorCode, to: model)
+            }
+        case .medicationEvent:
+            if let model = try fetchMedication(id: record.recordID) {
                 apply(state: state, lastSyncedAt: lastSyncedAt, lastSyncErrorCode: lastSyncErrorCode, to: model)
             }
         }
@@ -212,6 +217,12 @@ public final class SwiftDataSyncStateRepository: SyncStateRepository {
             .map { SyncRecordReference(recordType: .bathEvent, recordID: $0.id, childID: $0.childID) }
     }
 
+    private func pendingMedicationEvents() throws -> [SyncRecordReference] {
+        try modelContext.fetch(FetchDescriptor<StoredMedicationEvent>())
+            .filter { $0.syncStateRawValue == SyncState.pendingSync.rawValue }
+            .map { SyncRecordReference(recordType: .medicationEvent, recordID: $0.id, childID: $0.childID) }
+    }
+
     private func fetchChild(id: UUID) throws -> StoredChild? {
         try modelContext.fetch(FetchDescriptor<StoredChild>()).first { $0.id == id }
     }
@@ -244,6 +255,10 @@ public final class SwiftDataSyncStateRepository: SyncStateRepository {
         try modelContext.fetch(FetchDescriptor<StoredBathEvent>()).first { $0.id == id }
     }
 
+    private func fetchMedication(id: UUID) throws -> StoredMedicationEvent? {
+        try modelContext.fetch(FetchDescriptor<StoredMedicationEvent>()).first { $0.id == id }
+    }
+
     private func fetchAnchor(
         databaseScope: String,
         zoneName: String?,
@@ -268,6 +283,7 @@ public final class SwiftDataSyncStateRepository: SyncStateRepository {
         rawValues.append(contentsOf: try modelContext.fetch(FetchDescriptor<StoredSleepEvent>()).map(\.syncStateRawValue))
         rawValues.append(contentsOf: try modelContext.fetch(FetchDescriptor<StoredNappyEvent>()).map(\.syncStateRawValue))
         rawValues.append(contentsOf: try modelContext.fetch(FetchDescriptor<StoredBathEvent>()).map(\.syncStateRawValue))
+        rawValues.append(contentsOf: try modelContext.fetch(FetchDescriptor<StoredMedicationEvent>()).map(\.syncStateRawValue))
 
         return rawValues.compactMap(SyncState.init(rawValue:))
     }
@@ -280,7 +296,8 @@ public final class SwiftDataSyncStateRepository: SyncStateRepository {
             modelContext.fetch(FetchDescriptor<StoredBottleFeedEvent>()).map(\.lastSyncedAt) +
             modelContext.fetch(FetchDescriptor<StoredSleepEvent>()).map(\.lastSyncedAt) +
             modelContext.fetch(FetchDescriptor<StoredNappyEvent>()).map(\.lastSyncedAt) +
-            modelContext.fetch(FetchDescriptor<StoredBathEvent>()).map(\.lastSyncedAt)
+            modelContext.fetch(FetchDescriptor<StoredBathEvent>()).map(\.lastSyncedAt) +
+            modelContext.fetch(FetchDescriptor<StoredMedicationEvent>()).map(\.lastSyncedAt)
     }
 
     private func allLastErrorCodes() throws -> [String?] {
@@ -291,7 +308,8 @@ public final class SwiftDataSyncStateRepository: SyncStateRepository {
             modelContext.fetch(FetchDescriptor<StoredBottleFeedEvent>()).map(\.lastSyncErrorCode) +
             modelContext.fetch(FetchDescriptor<StoredSleepEvent>()).map(\.lastSyncErrorCode) +
             modelContext.fetch(FetchDescriptor<StoredNappyEvent>()).map(\.lastSyncErrorCode) +
-            modelContext.fetch(FetchDescriptor<StoredBathEvent>()).map(\.lastSyncErrorCode)
+            modelContext.fetch(FetchDescriptor<StoredBathEvent>()).map(\.lastSyncErrorCode) +
+            modelContext.fetch(FetchDescriptor<StoredMedicationEvent>()).map(\.lastSyncErrorCode)
     }
 
     private func apply(
@@ -376,6 +394,17 @@ public final class SwiftDataSyncStateRepository: SyncStateRepository {
         lastSyncedAt: Date?,
         lastSyncErrorCode: String?,
         to model: StoredBathEvent
+    ) {
+        model.syncStateRawValue = state.rawValue
+        model.lastSyncedAt = lastSyncedAt
+        model.lastSyncErrorCode = lastSyncErrorCode
+    }
+
+    private func apply(
+        state: SyncState,
+        lastSyncedAt: Date?,
+        lastSyncErrorCode: String?,
+        to model: StoredMedicationEvent
     ) {
         model.syncStateRawValue = state.rawValue
         model.lastSyncedAt = lastSyncedAt

--- a/Packages/BabyTrackerPersistence/Sources/BabyTrackerPersistence/SwiftDataUserIdentityRepository.swift
+++ b/Packages/BabyTrackerPersistence/Sources/BabyTrackerPersistence/SwiftDataUserIdentityRepository.swift
@@ -136,6 +136,7 @@ public final class SwiftDataUserIdentityRepository: CloudKitUserIdentityReposito
         try deleteAll(StoredSleepEvent.self)
         try deleteAll(StoredNappyEvent.self)
         try deleteAll(StoredBathEvent.self)
+        try deleteAll(StoredMedicationEvent.self)
         try deleteAll(StoredSyncAnchor.self)
         userDefaults.removeObject(forKey: DefaultsKey.localUserID)
     }
@@ -245,6 +246,14 @@ public final class SwiftDataUserIdentityRepository: CloudKitUserIdentityReposito
                 markPendingSync(event, errorCode: nil)
             }
         }
+
+        for event in try modelContext.fetch(FetchDescriptor<StoredMedicationEvent>()) {
+            if event.createdBy == sourceUserID { event.createdBy = targetUserID }
+            if event.updatedBy == sourceUserID { event.updatedBy = targetUserID }
+            if event.createdBy == targetUserID || event.updatedBy == targetUserID {
+                markPendingSync(event, errorCode: nil)
+            }
+        }
     }
 
     private func markPendingSync(_ storedModel: StoredChild, errorCode: String?) {
@@ -278,6 +287,11 @@ public final class SwiftDataUserIdentityRepository: CloudKitUserIdentityReposito
     }
 
     private func markPendingSync(_ storedModel: StoredBathEvent, errorCode: String?) {
+        storedModel.syncStateRawValue = SyncState.pendingSync.rawValue
+        storedModel.lastSyncErrorCode = errorCode
+    }
+
+    private func markPendingSync(_ storedModel: StoredMedicationEvent, errorCode: String?) {
         storedModel.syncStateRawValue = SyncState.pendingSync.rawValue
         storedModel.lastSyncErrorCode = errorCode
     }

--- a/Packages/BabyTrackerPersistence/Sources/BabyTrackerPersistence/SyncRecordType.swift
+++ b/Packages/BabyTrackerPersistence/Sources/BabyTrackerPersistence/SyncRecordType.swift
@@ -9,4 +9,5 @@ public enum SyncRecordType: String, Equatable, Sendable {
     case sleepEvent
     case nappyEvent
     case bathEvent
+    case medicationEvent
 }

--- a/Packages/BabyTrackerSync/Sources/BabyTrackerSync/CloudKitConfiguration.swift
+++ b/Packages/BabyTrackerSync/Sources/BabyTrackerSync/CloudKitConfiguration.swift
@@ -11,6 +11,7 @@ public enum CloudKitConfiguration {
     public static let sleepRecordType = "SleepEvent"
     public static let nappyRecordType = "NappyEvent"
     public static let bathRecordType = "BathEvent"
+    public static let medicationRecordType = "MedicationEvent"
 
     public static func container() -> CKContainer {
         CKContainer(identifier: containerIdentifier)

--- a/Packages/BabyTrackerSync/Sources/BabyTrackerSync/CloudKitRecordMapper.swift
+++ b/Packages/BabyTrackerSync/Sources/BabyTrackerSync/CloudKitRecordMapper.swift
@@ -21,6 +21,8 @@ public enum CloudKitRecordMapper {
             metadataFieldKeys + ["type", "peeVolume", "pooVolume", "pooColor"]
         case CloudKitConfiguration.bathRecordType:
             metadataFieldKeys + ["shampooUsed", "soapUsed"]
+        case CloudKitConfiguration.medicationRecordType:
+            metadataFieldKeys + ["medicineName", "amount", "unit", "customUnitLabel"]
         default:
             []
         }
@@ -114,6 +116,8 @@ public enum CloudKitRecordMapper {
             return sleepRecord(from: value, zoneID: zoneID)
         case let .nappy(value):
             return nappyRecord(from: value, zoneID: zoneID)
+        case let .medication(value):
+            return medicationRecord(from: value, zoneID: zoneID)
         }
     }
 
@@ -175,6 +179,8 @@ public enum CloudKitRecordMapper {
             return .sleep(try sleep(from: record))
         case CloudKitConfiguration.nappyRecordType:
             return .nappy(try nappy(from: record))
+        case CloudKitConfiguration.medicationRecordType:
+            return .medication(try medication(from: record))
         default:
             throw BabyEventError.invalidDateRange
         }
@@ -276,6 +282,25 @@ public enum CloudKitRecordMapper {
         return record
     }
 
+    private static func medicationRecord(
+        from event: MedicationEvent,
+        zoneID: CKRecordZone.ID
+    ) -> CKRecord {
+        let record = CKRecord(
+            recordType: CloudKitConfiguration.medicationRecordType,
+            recordID: CloudKitRecordNames.medicationRecordID(
+                eventID: event.id,
+                zoneID: zoneID
+            )
+        )
+        applyMetadata(event.metadata, to: record)
+        record["medicineName"] = event.medicineName
+        record["amount"] = event.amount
+        record["unit"] = event.unit.rawValue
+        record["customUnitLabel"] = event.customUnitLabel
+        return record
+    }
+
     private static func breastFeed(from record: CKRecord) throws -> BreastFeedEvent {
         try BreastFeedEvent(
             metadata: metadata(from: record, prefix: "breastFeed."),
@@ -318,6 +343,16 @@ public enum CloudKitRecordMapper {
             metadata: metadata(from: record, prefix: "bath."),
             usedShampoo: record["shampooUsed"] as? Bool ?? false,
             usedSoap: record["soapUsed"] as? Bool ?? false
+        )
+    }
+
+    private static func medication(from record: CKRecord) throws -> MedicationEvent {
+        try MedicationEvent(
+            metadata: metadata(from: record, prefix: "medication."),
+            medicineName: record["medicineName"] as? String ?? "",
+            amount: record["amount"] as? Double ?? 0,
+            unit: MedicationUnit(rawValue: record["unit"] as? String ?? "") ?? .custom,
+            customUnitLabel: record["customUnitLabel"] as? String
         )
     }
 

--- a/Packages/BabyTrackerSync/Sources/BabyTrackerSync/CloudKitRecordNames.swift
+++ b/Packages/BabyTrackerSync/Sources/BabyTrackerSync/CloudKitRecordNames.swift
@@ -106,4 +106,14 @@ public enum CloudKitRecordNames {
             zoneID: zoneID
         )
     }
+
+    static func medicationRecordID(
+        eventID: UUID,
+        zoneID: CKRecordZone.ID
+    ) -> CKRecord.ID {
+        CKRecord.ID(
+            recordName: "medication.\(eventID.uuidString)",
+            zoneID: zoneID
+        )
+    }
 }

--- a/Packages/BabyTrackerSync/Sources/BabyTrackerSync/CloudKitSyncEngine.swift
+++ b/Packages/BabyTrackerSync/Sources/BabyTrackerSync/CloudKitSyncEngine.swift
@@ -1014,7 +1014,8 @@ public final class CloudKitSyncEngine {
              CloudKitConfiguration.bottleFeedRecordType,
              CloudKitConfiguration.sleepRecordType,
              CloudKitConfiguration.nappyRecordType,
-             CloudKitConfiguration.bathRecordType:
+             CloudKitConfiguration.bathRecordType,
+             CloudKitConfiguration.medicationRecordType:
             let event = try CloudKitRecordMapper.event(from: record)
             if let localEvent = try eventRepository.loadEvent(id: event.id),
                LastWriteWinsResolver.prefersLocal(localEvent.metadata, over: event.metadata) {
@@ -1251,6 +1252,8 @@ public final class CloudKitSyncEngine {
             .nappyEvent
         case .bath:
             .bathEvent
+        case .medication:
+            .medicationEvent
         }
     }
 
@@ -1352,7 +1355,7 @@ public final class CloudKitSyncEngine {
                     databaseScope: context.databaseScope
                 )
             )
-        case .breastFeedEvent, .bottleFeedEvent, .sleepEvent, .nappyEvent, .bathEvent:
+        case .breastFeedEvent, .bottleFeedEvent, .sleepEvent, .nappyEvent, .bathEvent, .medicationEvent:
             guard let event = try eventRepository.loadEvent(id: reference.recordID) else {
                 return nil
             }

--- a/cloudkit-schema.txt
+++ b/cloudkit-schema.txt
@@ -1,5 +1,28 @@
 DEFINE SCHEMA
 
+    RECORD TYPE BathEvent (
+        "___createTime" TIMESTAMP,
+        "___createdBy"  REFERENCE,
+        "___etag"       STRING,
+        "___modTime"    TIMESTAMP,
+        "___modifiedBy" REFERENCE,
+        "___recordID"   REFERENCE,
+        childID         STRING QUERYABLE SEARCHABLE SORTABLE,
+        createdAt       TIMESTAMP QUERYABLE SORTABLE,
+        createdBy       STRING QUERYABLE SEARCHABLE SORTABLE,
+        deletedAt       TIMESTAMP QUERYABLE SORTABLE,
+        isDeleted       INT64 QUERYABLE SORTABLE,
+        notes           STRING QUERYABLE SEARCHABLE SORTABLE,
+        occurredAt      TIMESTAMP QUERYABLE SORTABLE,
+        shampooUsed     INT64 QUERYABLE SORTABLE,
+        soapUsed        INT64 QUERYABLE SORTABLE,
+        updatedAt       TIMESTAMP QUERYABLE SORTABLE,
+        updatedBy       STRING QUERYABLE SEARCHABLE SORTABLE,
+        GRANT WRITE TO "_creator",
+        GRANT CREATE TO "_icloud",
+        GRANT READ TO "_world"
+    );
+
     RECORD TYPE BottleFeedEvent (
         "___createTime"   TIMESTAMP,
         "___createdBy"    REFERENCE,
@@ -282,6 +305,31 @@ DEFINE SCHEMA
         role            STRING QUERYABLE SEARCHABLE SORTABLE,
         status          STRING QUERYABLE SEARCHABLE SORTABLE,
         userID          STRING QUERYABLE SEARCHABLE SORTABLE,
+        GRANT WRITE TO "_creator",
+        GRANT CREATE TO "_icloud",
+        GRANT READ TO "_world"
+    );
+
+    RECORD TYPE MedicationEvent (
+        "___createTime" TIMESTAMP,
+        "___createdBy"  REFERENCE,
+        "___etag"       STRING,
+        "___modTime"    TIMESTAMP,
+        "___modifiedBy" REFERENCE,
+        "___recordID"   REFERENCE,
+        amount          DOUBLE QUERYABLE SORTABLE,
+        childID         STRING QUERYABLE SEARCHABLE SORTABLE,
+        createdAt       TIMESTAMP QUERYABLE SORTABLE,
+        createdBy       STRING QUERYABLE SEARCHABLE SORTABLE,
+        customUnitLabel STRING QUERYABLE SEARCHABLE SORTABLE,
+        deletedAt       TIMESTAMP QUERYABLE SORTABLE,
+        isDeleted       INT64 QUERYABLE SORTABLE,
+        medicineName    STRING QUERYABLE SEARCHABLE SORTABLE,
+        notes           STRING QUERYABLE SEARCHABLE SORTABLE,
+        occurredAt      TIMESTAMP QUERYABLE SORTABLE,
+        unit            STRING QUERYABLE SEARCHABLE SORTABLE,
+        updatedAt       TIMESTAMP QUERYABLE SORTABLE,
+        updatedBy       STRING QUERYABLE SEARCHABLE SORTABLE,
         GRANT WRITE TO "_creator",
         GRANT CREATE TO "_icloud",
         GRANT READ TO "_world"

--- a/cloudkit-schema.txt
+++ b/cloudkit-schema.txt
@@ -72,6 +72,33 @@ DEFINE SCHEMA
         GRANT READ TO "_world"
     );
 
+    RECORD TYPE CD_StoredBathEvent (
+        CD_childID           STRING QUERYABLE SEARCHABLE SORTABLE,
+        CD_createdAt         TIMESTAMP QUERYABLE SORTABLE,
+        CD_createdBy         STRING QUERYABLE SEARCHABLE SORTABLE,
+        CD_deletedAt         TIMESTAMP QUERYABLE SORTABLE,
+        CD_entityName        STRING QUERYABLE SEARCHABLE SORTABLE,
+        CD_id                STRING QUERYABLE SEARCHABLE SORTABLE,
+        CD_isDeleted         INT64 QUERYABLE SORTABLE,
+        CD_lastSyncedAt      TIMESTAMP QUERYABLE SORTABLE,
+        CD_notes             STRING QUERYABLE SEARCHABLE SORTABLE,
+        CD_occurredAt        TIMESTAMP QUERYABLE SORTABLE,
+        CD_syncStateRawValue STRING QUERYABLE SEARCHABLE SORTABLE,
+        CD_updatedAt         TIMESTAMP QUERYABLE SORTABLE,
+        CD_updatedBy         STRING QUERYABLE SEARCHABLE SORTABLE,
+        CD_usedShampoo       INT64 QUERYABLE SORTABLE,
+        CD_usedSoap          INT64 QUERYABLE SORTABLE,
+        "___createTime"      TIMESTAMP,
+        "___createdBy"       REFERENCE,
+        "___etag"            STRING,
+        "___modTime"         TIMESTAMP,
+        "___modifiedBy"      REFERENCE,
+        "___recordID"        REFERENCE,
+        GRANT WRITE TO "_creator",
+        GRANT CREATE TO "_icloud",
+        GRANT READ TO "_world"
+    );
+
     RECORD TYPE CD_StoredBottleFeedEvent (
         CD_amountMilliliters INT64 QUERYABLE SORTABLE,
         CD_childID           STRING QUERYABLE SEARCHABLE SORTABLE,
@@ -81,6 +108,7 @@ DEFINE SCHEMA
         CD_entityName        STRING QUERYABLE SEARCHABLE SORTABLE,
         CD_id                STRING QUERYABLE SEARCHABLE SORTABLE,
         CD_isDeleted         INT64 QUERYABLE SORTABLE,
+        CD_lastSyncErrorCode STRING QUERYABLE SEARCHABLE SORTABLE,
         CD_lastSyncedAt      TIMESTAMP QUERYABLE SORTABLE,
         CD_milkTypeRawValue  STRING QUERYABLE SEARCHABLE SORTABLE,
         CD_notes             STRING QUERYABLE SEARCHABLE SORTABLE,
@@ -137,20 +165,42 @@ DEFINE SCHEMA
         CD_cloudKitZoneOwnerName           STRING QUERYABLE SEARCHABLE SORTABLE,
         CD_createdAt                       TIMESTAMP QUERYABLE SORTABLE,
         CD_createdBy                       STRING QUERYABLE SEARCHABLE SORTABLE,
+        CD_customBottleAmountsJSON         STRING QUERYABLE SEARCHABLE SORTABLE,
         CD_entityName                      STRING QUERYABLE SEARCHABLE SORTABLE,
         CD_id                              STRING QUERYABLE SEARCHABLE SORTABLE,
         CD_imageData                       BYTES QUERYABLE SORTABLE,
         CD_isArchived                      INT64 QUERYABLE SORTABLE,
+        CD_lastSyncErrorCode               STRING QUERYABLE SEARCHABLE SORTABLE,
         CD_lastSyncedAt                    TIMESTAMP QUERYABLE SORTABLE,
         CD_name                            STRING QUERYABLE SEARCHABLE SORTABLE,
         CD_preferredFeedVolumeUnitRawValue STRING QUERYABLE SEARCHABLE SORTABLE,
         CD_syncStateRawValue               STRING QUERYABLE SEARCHABLE SORTABLE,
+        CD_updatedAt                       TIMESTAMP QUERYABLE SORTABLE,
         "___createTime"                    TIMESTAMP,
         "___createdBy"                     REFERENCE,
         "___etag"                          STRING,
         "___modTime"                       TIMESTAMP,
         "___modifiedBy"                    REFERENCE,
         "___recordID"                      REFERENCE,
+        GRANT WRITE TO "_creator",
+        GRANT CREATE TO "_icloud",
+        GRANT READ TO "_world"
+    );
+
+    RECORD TYPE CD_StoredCloudKitRecordMetadata (
+        CD_databaseScopeRawValue STRING QUERYABLE SEARCHABLE SORTABLE,
+        CD_entityName            STRING QUERYABLE SEARCHABLE SORTABLE,
+        CD_ownerName             STRING QUERYABLE SEARCHABLE SORTABLE,
+        CD_recordName            STRING QUERYABLE SEARCHABLE SORTABLE,
+        CD_storageKey            STRING QUERYABLE SEARCHABLE SORTABLE,
+        CD_systemFieldsData      BYTES QUERYABLE SORTABLE,
+        CD_zoneName              STRING QUERYABLE SEARCHABLE SORTABLE,
+        "___createTime"          TIMESTAMP,
+        "___createdBy"           REFERENCE,
+        "___etag"                STRING,
+        "___modTime"             TIMESTAMP,
+        "___modifiedBy"          REFERENCE,
+        "___recordID"            REFERENCE,
         GRANT WRITE TO "_creator",
         GRANT CREATE TO "_icloud",
         GRANT READ TO "_world"
@@ -259,6 +309,7 @@ DEFINE SCHEMA
         CD_displayName            STRING QUERYABLE SEARCHABLE SORTABLE,
         CD_entityName             STRING QUERYABLE SEARCHABLE SORTABLE,
         CD_id                     STRING QUERYABLE SEARCHABLE SORTABLE,
+        CD_lastSyncErrorCode      STRING QUERYABLE SEARCHABLE SORTABLE,
         CD_lastSyncedAt           TIMESTAMP QUERYABLE SORTABLE,
         CD_syncStateRawValue      STRING QUERYABLE SEARCHABLE SORTABLE,
         "___createTime"           TIMESTAMP,
@@ -282,29 +333,12 @@ DEFINE SCHEMA
         birthDate               TIMESTAMP QUERYABLE SORTABLE,
         createdAt               TIMESTAMP QUERYABLE SORTABLE,
         createdBy               STRING QUERYABLE SEARCHABLE SORTABLE,
+        customBottleAmounts     STRING QUERYABLE SEARCHABLE SORTABLE,
         imageAsset              ASSET,
         isArchived              INT64 QUERYABLE SORTABLE,
         name                    STRING QUERYABLE SEARCHABLE SORTABLE,
         preferredFeedVolumeUnit STRING QUERYABLE SEARCHABLE SORTABLE,
         updatedAt               TIMESTAMP QUERYABLE SORTABLE,
-        GRANT WRITE TO "_creator",
-        GRANT CREATE TO "_icloud",
-        GRANT READ TO "_world"
-    );
-
-    RECORD TYPE Membership (
-        "___createTime" TIMESTAMP,
-        "___createdBy"  REFERENCE,
-        "___etag"       STRING,
-        "___modTime"    TIMESTAMP,
-        "___modifiedBy" REFERENCE,
-        "___recordID"   REFERENCE,
-        acceptedAt      TIMESTAMP QUERYABLE SORTABLE,
-        childID         STRING QUERYABLE SEARCHABLE SORTABLE,
-        invitedAt       TIMESTAMP QUERYABLE SORTABLE,
-        role            STRING QUERYABLE SEARCHABLE SORTABLE,
-        status          STRING QUERYABLE SEARCHABLE SORTABLE,
-        userID          STRING QUERYABLE SEARCHABLE SORTABLE,
         GRANT WRITE TO "_creator",
         GRANT CREATE TO "_icloud",
         GRANT READ TO "_world"
@@ -330,6 +364,24 @@ DEFINE SCHEMA
         unit            STRING QUERYABLE SEARCHABLE SORTABLE,
         updatedAt       TIMESTAMP QUERYABLE SORTABLE,
         updatedBy       STRING QUERYABLE SEARCHABLE SORTABLE,
+        GRANT WRITE TO "_creator",
+        GRANT CREATE TO "_icloud",
+        GRANT READ TO "_world"
+    );
+
+    RECORD TYPE Membership (
+        "___createTime" TIMESTAMP,
+        "___createdBy"  REFERENCE,
+        "___etag"       STRING,
+        "___modTime"    TIMESTAMP,
+        "___modifiedBy" REFERENCE,
+        "___recordID"   REFERENCE,
+        acceptedAt      TIMESTAMP QUERYABLE SORTABLE,
+        childID         STRING QUERYABLE SEARCHABLE SORTABLE,
+        invitedAt       TIMESTAMP QUERYABLE SORTABLE,
+        role            STRING QUERYABLE SEARCHABLE SORTABLE,
+        status          STRING QUERYABLE SEARCHABLE SORTABLE,
+        userID          STRING QUERYABLE SEARCHABLE SORTABLE,
         GRANT WRITE TO "_creator",
         GRANT CREATE TO "_icloud",
         GRANT READ TO "_world"


### PR DESCRIPTION
## Summary

Adds a new **Medication** tracking type, following the same vertical-slice pattern as the recently-added Bath feature and reusing the Bottle Feed amount/preset/suggestion UX.

Caregivers can now log when a medicine was given, recording:
- **Which medicine** — quick-pick chips from previously-logged medicines, merged with a seeded list of common children's medicines (Paracetamol/Calpol, Ibuprofen/Nurofen, Vitamin D drops, Gripe water, Teething gel), plus free-text entry for a new name.
- **How much** — a decimal dose (e.g. 2.5, 5).
- **In what unit** — `ml`, `mg`, `drops`, `tablet`, or a **custom** free-text unit (e.g. "puff", "sachet").

ml quick-pick amounts adapt to the child's age (`<1yr → 1/2.5/5`, `1–4yr → 2.5/5/7.5/10`, `5yr+ → 5/10/15/20`), with history-based smart suggestions surfaced first.

## Changes by layer

- **Domain** — `MedicationEvent`, `MedicationUnit`, `MedicationCatalog` (seed list + age-based ml defaults); `LogMedicationUseCase`, `UpdateMedicationUseCase`, `FetchRecentMedicineNamesUseCase`; new `.medication` cases in `BabyEvent`, `BabyEventKind`, `TimelineDayGridColumnKind`, and all event switches (filter, timeline datasets, caregiver notifications, restore). Import/export support via `NestMedicationExport` / `MedicationImport`.
- **Persistence** — `StoredMedicationEvent` (SwiftData `@Model`, registered in the schema), with save/load/map/delete and sync-state plumbing across `SwiftDataEventRepository`, `SwiftDataSyncStateRepository`, `SwiftDataChildRepository`, `SwiftDataUserIdentityRepository`, and `SyncRecordType`.
- **Sync** — `MedicationEvent` CloudKit record type, record-name builder, and bidirectional mapping (incl. custom unit) in `CloudKitRecordMapper` / `CloudKitSyncEngine`.
- **Feature (UI)** — new `MedicationEditorSheetView` (medicine chips + name field, unit picker, age-based amount presets, custom unit field, time selector, summary, delete); `logMedication` / `updateMedication` / `recentMedicineNames` / `medicationMillilitreAmounts` on `AppModel`; quick-log entry, edit flow, styling palette, presentation (`pills.fill` icon, detail text), and `.medication` arms across all view-state/calculator/onboarding switches.
- **Live Activity widget** — accent colour and SF Symbol for the new kind.
- **Tests** — domain import/export round-trip (incl. custom unit) and use-case tests (validation, update, recent-name de-duplication); CloudKit mapper round-trip; SwiftData repository round-trip; updated test doubles.

## Notes

- Medication defaults to **visible** for users who haven't customised event visibility (absent preference key → all kinds). Users who previously customised their visible-event list can enable it in settings.
- Custom unit follows the existing `MilkType.other` convention (a sibling `customUnitLabel` field) rather than enum associated values, which the codebase avoids.

## Verification

This is an Apple-only (SwiftUI/SwiftData/CloudKit) project, so it could not be compiled in the cloud environment — it relies on CI / a local Xcode build. Suggested manual checks once built:
1. Home → **Medication** quick-log → seeded chips appear; pick or type a name, pick/enter an amount, switch unit to **Custom** + type e.g. `puff`, save.
2. Verify timeline entry shows the right title/icon/colour and `Name • 2.5 ml` detail.
3. Log a second dose; reopen the editor and confirm the prior medicine appears as a recent chip.
4. Edit/delete the entry; confirm ml presets differ for an under-1yr vs 4yr+ child.
5. Export → re-import a backup containing a medication with a custom unit; confirm fidelity.

🤖 Generated with [Claude Code](https://claude.ai/code)

---
_Generated by [Claude Code](https://claude.ai/code/session_011v4LQhatjZcVXKsZpqDuFM)_