### PR TITLE
[codex] Fix TestFlight tag numbering

### DIFF
--- a/.github/workflows/pr-comment-tags.yml
+++ b/.github/workflows/pr-comment-tags.yml
@@ -113,7 +113,7 @@ jobs:
           if [[ -z "${latest_number}" ]]; then
             next_number=1
           else
-            next_number=$((latest_number + 1))
+            next_number=$((10#${latest_number} + 1))
           fi
 
           tag_name="TestFlight-${next_number}"


### PR DESCRIPTION
## Summary
- Force existing TestFlight tag numbers with leading zeroes to parse as base 10.
- Create future TestFlight tags with the simpler non-padded format, such as `TestFlight-36`.
- React to the original command comment as the workflow progresses.

## Why
Bash arithmetic treats numbers with leading zeroes as octal, so `035 + 1` became decimal `30` and created `TestFlight-30` instead of the next logical tag.

Moving forward with non-padded tags avoids that class of bug and keeps numbering straightforward beyond `999`.

GitHub only supports a fixed set of issue comment reactions, so the workflow uses supported reactions:
- `eyes` when a valid tag command is seen.
- `rocket` for release requests.
- `hooray` for TestFlight requests, because custom builder emoji reactions are not supported.
- `+1` when the request completes successfully, because checkmark reactions are not supported.

## Validation
- Ran the workflow shell snippet against the current remote tags and confirmed it resolves `latest_number=035`, `next_number=36`, and `tag_name=TestFlight-36`.
- Ran `git diff --check`.

No plan document or issue was added because this PR intentionally keeps the fix to the small workflow bug and related workflow feedback only.
