### PR TITLE
[codex] Add tag request comment reactions

### DIFF
--- a/.github/workflows/pr-comment-tags.yml
+++ b/.github/workflows/pr-comment-tags.yml
@@ -40,6 +40,23 @@ jobs:
               return;
             }
 
+            const addReaction = async (content) => {
+              try {
+                await github.rest.reactions.createForIssueComment({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  comment_id: context.payload.comment.id,
+                  content,
+                });
+              } catch (error) {
+                if (error.status !== 422) {
+                  throw error;
+                }
+              }
+            };
+
+            await addReaction('eyes');
+
             const allowedAssociations = new Set(['OWNER', 'MEMBER', 'COLLABORATOR']);
             const authorAssociation = context.payload.comment.author_association;
 
@@ -81,6 +98,8 @@ jobs:
               core.setFailed('Fork pull requests are not supported for release tag creation.');
               return;
             }
+
+            await addReaction(testFlightMatch ? 'hooray' : 'rocket');
 
             core.setOutput('request_type', testFlightMatch ? 'testflight' : 'release');
             core.setOutput('release_bump', releaseMatch ? releaseMatch[1] : '');
@@ -321,6 +340,24 @@ jobs:
               issue_number: context.issue.number,
               body,
             });
+
+      - name: React to completed request
+        if: ${{ success() && steps.request.outcome == 'success' }}
+        uses: actions/github-script@v7
+        with:
+          script: |
+            try {
+              await github.rest.reactions.createForIssueComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: context.payload.comment.id,
+                content: '+1',
+              });
+            } catch (error) {
+              if (error.status !== 422) {
+                throw error;
+              }
+            }
 
       - name: Comment with failure details
         if: ${{ failure() && steps.request.outcome == 'success' }}


### PR DESCRIPTION
## Summary
- Add reactions to the original tag command comment as the workflow progresses.
- React with `eyes` when a valid tag command is accepted for processing.
- React with `rocket` for release requests and `hooray` for TestFlight requests.
- React with `+1` when the request completes successfully.

## Why
This gives immediate feedback on the original PR comment without requiring maintainers to wait for the final status comment.

GitHub only supports a fixed set of issue comment reactions. Custom builder emoji and checkmark reactions are not available through the reactions API, so this uses the closest supported reactions for TestFlight and completion.

## Validation
- Reviewed the workflow diff to confirm the PR only changes `.github/workflows/pr-comment-tags.yml`.
- Ran `git diff --check origin/main...HEAD`.

No plan document or issue was added because this is a small workflow feedback tweak.
