### PR TITLE
Medication reminder notifications

### DIFF
--- a/Baby Tracker/App/AppContainer.swift
+++ b/Baby Tracker/App/AppContainer.swift
@@ -25,6 +25,7 @@ struct AppContainer {
         let recordMetadataRepository = SwiftDataCloudKitRecordMetadataRepository(store: store)
         let liveActivityPreferenceStore = UserDefaultsLiveActivityPreferenceStore(userDefaults: userDefaults)
         let reminderNotificationPreferenceStore = UserDefaultsReminderNotificationPreferenceStore(userDefaults: userDefaults)
+        let medicationReminderPreferenceStore = UserDefaultsMedicationReminderPreferenceStore(userDefaults: userDefaults)
         let eventVisibilityPreferenceStore = UserDefaultsEventVisibilityPreferenceStore(userDefaults: userDefaults)
         let appReviewPromptStateStore = UserDefaultsAppReviewPromptStateStore(userDefaults: userDefaults)
 
@@ -76,6 +77,7 @@ struct AppContainer {
             liveActivitySnapshotCache: liveActivitySnapshotCache,
             liveActivityPreferenceStore: liveActivityPreferenceStore,
             reminderNotificationPreferenceStore: reminderNotificationPreferenceStore,
+            medicationReminderPreferenceStore: medicationReminderPreferenceStore,
             eventVisibilityPreferenceStore: eventVisibilityPreferenceStore,
             localNotificationManager: localNotificationManager,
             hapticFeedbackProvider: hapticFeedbackProvider,

--- a/Baby Tracker/App/SystemLocalNotificationManager.swift
+++ b/Baby Tracker/App/SystemLocalNotificationManager.swift
@@ -124,6 +124,68 @@ final class SystemLocalNotificationManager: NSObject, LocalNotificationManaging 
         .sorted { $0.fireDate < $1.fireDate }
     }
 
+    func scheduleMedicationReminderNotification(
+        childID: UUID,
+        childName: String,
+        medicineName: String,
+        mode: ReminderMode,
+        intervalHours: Int,
+        fireAt: Date
+    ) async {
+        guard await isAuthorized() else { return }
+
+        let content = UNMutableNotificationContent()
+        switch mode {
+        case .safeToGive:
+            content.title = "\(medicineName) – Safe to give again"
+            content.body = "It's been \(intervalHours)h since \(childName)'s last dose."
+        case .nextDueDose:
+            content.title = "\(medicineName) – Next dose due"
+            content.body = "\(childName)'s next \(medicineName) dose is due now."
+        }
+        content.sound = .default
+        content.userInfo = ["childID": childID.uuidString, "medicineName": medicineName]
+
+        let id = medicationReminderIdentifier(childID: childID, medicineName: medicineName)
+        notificationCenter.removePendingNotificationRequests(withIdentifiers: [id])
+
+        // Calendar trigger survives device restarts; time-interval trigger does not.
+        let components = Calendar.current.dateComponents(
+            [.year, .month, .day, .hour, .minute, .second],
+            from: fireAt
+        )
+        let trigger = UNCalendarNotificationTrigger(dateMatching: components, repeats: false)
+        let request = UNNotificationRequest(identifier: id, content: content, trigger: trigger)
+        try? await notificationCenter.add(request)
+    }
+
+    func cancelMedicationReminderNotification(childID: UUID, medicineName: String) async {
+        notificationCenter.removePendingNotificationRequests(
+            withIdentifiers: [medicationReminderIdentifier(childID: childID, medicineName: medicineName)]
+        )
+    }
+
+    func pendingMedicationReminderNotifications() async -> [PendingMedicationReminder] {
+        let requests = await notificationCenter.pendingNotificationRequests()
+        return requests.compactMap { request -> PendingMedicationReminder? in
+            guard request.identifier.hasPrefix("medication."),
+                  let trigger = request.trigger as? UNCalendarNotificationTrigger,
+                  let fireDate = trigger.nextTriggerDate(),
+                  let childIDString = request.content.userInfo["childID"] as? String,
+                  let childID = UUID(uuidString: childIDString),
+                  let medicineName = request.content.userInfo["medicineName"] as? String
+            else { return nil }
+
+            return PendingMedicationReminder(
+                id: request.identifier,
+                childID: childID,
+                medicineName: medicineName,
+                fireDate: fireDate
+            )
+        }
+        .sorted { $0.fireDate < $1.fireDate }
+    }
+
     // MARK: - Private helpers
 
     private func isAuthorized() async -> Bool {
@@ -137,6 +199,10 @@ final class SystemLocalNotificationManager: NSObject, LocalNotificationManaging 
 
     private func inactivityDriftIdentifier(childID: UUID) -> String {
         "drift.inactivity.\(childID.uuidString)"
+    }
+
+    private func medicationReminderIdentifier(childID: UUID, medicineName: String) -> String {
+        "medication.\(childID.uuidString).\(medicineName.lowercased())"
     }
 }
 

--- a/Baby Tracker/App/UserDefaultsMedicationReminderPreferenceStore.swift
+++ b/Baby Tracker/App/UserDefaultsMedicationReminderPreferenceStore.swift
@@ -1,0 +1,30 @@
+import BabyTrackerDomain
+import BabyTrackerFeature
+import Foundation
+
+@MainActor
+final class UserDefaultsMedicationReminderPreferenceStore: MedicationReminderPreferenceStore {
+    private let userDefaults: UserDefaults
+    private let decoder = JSONDecoder()
+    private let encoder = JSONEncoder()
+
+    init(userDefaults: UserDefaults = .standard) {
+        self.userDefaults = userDefaults
+    }
+
+    func preference(for medicineName: String, childID: UUID) -> MedicationReminderPreference? {
+        let key = defaultsKey(medicineName: medicineName, childID: childID)
+        guard let data = userDefaults.data(forKey: key) else { return nil }
+        return try? decoder.decode(MedicationReminderPreference.self, from: data)
+    }
+
+    func savePreference(_ preference: MedicationReminderPreference, for medicineName: String, childID: UUID) {
+        let key = defaultsKey(medicineName: medicineName, childID: childID)
+        guard let data = try? encoder.encode(preference) else { return }
+        userDefaults.set(data, forKey: key)
+    }
+
+    private func defaultsKey(medicineName: String, childID: UUID) -> String {
+        "medicationReminder.\(childID.uuidString).\(medicineName.lowercased())"
+    }
+}

--- a/Baby TrackerTests/AppModelTests.swift
+++ b/Baby TrackerTests/AppModelTests.swift
@@ -2249,6 +2249,10 @@ extension AppModelTests {
         }
 
         func pendingDriftNotifications() async -> [PendingDriftNotification] { [] }
+
+        func scheduleMedicationReminderNotification(childID: UUID, childName: String, medicineName: String, mode: ReminderMode, intervalHours: Int, fireAt: Date) async {}
+        func cancelMedicationReminderNotification(childID: UUID, medicineName: String) async {}
+        func pendingMedicationReminderNotifications() async -> [PendingMedicationReminder] { [] }
     }
 }
 

--- a/Baby TrackerTests/MedicationReminderTests.swift
+++ b/Baby TrackerTests/MedicationReminderTests.swift
@@ -1,0 +1,228 @@
+import BabyTrackerDomain
+import BabyTrackerFeature
+import Foundation
+import Testing
+
+struct MedicationReminderPreferenceTests {
+    @Test
+    func encodesAndDecodesRoundTrip() throws {
+        let preference = MedicationReminderPreference(
+            intervalHours: 4,
+            mode: .safeToGive,
+            referencePoint: .doseTime
+        )
+        let data = try JSONEncoder().encode(preference)
+        let decoded = try JSONDecoder().decode(MedicationReminderPreference.self, from: data)
+        #expect(decoded == preference)
+    }
+
+    @Test
+    func encodesAndDecodesAllModes() throws {
+        for mode in ReminderMode.allCases {
+            let preference = MedicationReminderPreference(
+                intervalHours: 6,
+                mode: mode,
+                referencePoint: .now
+            )
+            let data = try JSONEncoder().encode(preference)
+            let decoded = try JSONDecoder().decode(MedicationReminderPreference.self, from: data)
+            #expect(decoded.mode == mode)
+        }
+    }
+
+    @Test
+    func encodesAndDecodesAllReferencePoints() throws {
+        for point in ReminderReferencePoint.allCases {
+            let preference = MedicationReminderPreference(
+                intervalHours: 2,
+                mode: .nextDueDose,
+                referencePoint: point
+            )
+            let data = try JSONEncoder().encode(preference)
+            let decoded = try JSONDecoder().decode(MedicationReminderPreference.self, from: data)
+            #expect(decoded.referencePoint == point)
+        }
+    }
+}
+
+@MainActor
+struct ScheduleMedicationReminderUseCaseTests {
+    @Test
+    func schedulesNotificationWhenFireDateIsInFuture() async {
+        let spy = NotificationManagerSpy()
+        let store = InMemoryMedicationReminderPreferenceStore()
+        let childID = UUID()
+        let now = Date(timeIntervalSince1970: 1_000)
+        let occurredAt = Date(timeIntervalSince1970: 900)
+        let preference = MedicationReminderPreference(
+            intervalHours: 4,
+            mode: .safeToGive,
+            referencePoint: .doseTime
+        )
+
+        await ScheduleMedicationReminderUseCase.execute(
+            input: .init(
+                childID: childID,
+                childName: "Poppy",
+                medicineName: "Calpol",
+                preference: preference,
+                occurredAt: occurredAt,
+                now: now
+            ),
+            notificationManager: spy,
+            preferenceStore: store
+        )
+
+        // occurredAt (900) + 4h (14_400) = 15_300, which is > now (1_000)
+        #expect(spy.scheduledCount == 1)
+    }
+
+    @Test
+    func skipsSchedulingWhenFireDateIsInPast() async {
+        let spy = NotificationManagerSpy()
+        let store = InMemoryMedicationReminderPreferenceStore()
+        let childID = UUID()
+        let now = Date(timeIntervalSince1970: 100_000)
+        let occurredAt = Date(timeIntervalSince1970: 1_000)
+        let preference = MedicationReminderPreference(
+            intervalHours: 4,
+            mode: .safeToGive,
+            referencePoint: .doseTime
+        )
+
+        await ScheduleMedicationReminderUseCase.execute(
+            input: .init(
+                childID: childID,
+                childName: "Poppy",
+                medicineName: "Calpol",
+                preference: preference,
+                occurredAt: occurredAt,
+                now: now
+            ),
+            notificationManager: spy,
+            preferenceStore: store
+        )
+
+        // occurredAt (1_000) + 4h (14_400) = 15_400, which is < now (100_000)
+        #expect(spy.scheduledCount == 0)
+    }
+
+    @Test
+    func savesPreferenceToStoreOnSuccess() async {
+        let spy = NotificationManagerSpy()
+        let store = InMemoryCapturingPreferenceStore()
+        let childID = UUID()
+        let now = Date(timeIntervalSince1970: 1_000)
+        let occurredAt = Date(timeIntervalSince1970: 900)
+        let preference = MedicationReminderPreference(
+            intervalHours: 6,
+            mode: .nextDueDose,
+            referencePoint: .now
+        )
+
+        await ScheduleMedicationReminderUseCase.execute(
+            input: .init(
+                childID: childID,
+                childName: "Poppy",
+                medicineName: "Calpol",
+                preference: preference,
+                occurredAt: occurredAt,
+                now: now
+            ),
+            notificationManager: spy,
+            preferenceStore: store
+        )
+
+        let saved = store.preference(for: "Calpol", childID: childID)
+        #expect(saved == preference)
+    }
+
+    @Test
+    func usesNowAsReferenceWhenReferencePointIsNow() async {
+        let spy = NotificationManagerSpy()
+        let store = InMemoryMedicationReminderPreferenceStore()
+        let childID = UUID()
+        let now = Date(timeIntervalSince1970: 1_000)
+        // occurredAt is far in the past; with doseTime reference this would be in the past
+        let occurredAt = Date(timeIntervalSince1970: 100)
+        let preference = MedicationReminderPreference(
+            intervalHours: 4,
+            mode: .safeToGive,
+            referencePoint: .now
+        )
+
+        await ScheduleMedicationReminderUseCase.execute(
+            input: .init(
+                childID: childID,
+                childName: "Poppy",
+                medicineName: "Calpol",
+                preference: preference,
+                occurredAt: occurredAt,
+                now: now
+            ),
+            notificationManager: spy,
+            preferenceStore: store
+        )
+
+        // now (1_000) + 4h (14_400) = 15_400 > now — should schedule
+        #expect(spy.scheduledCount == 1)
+    }
+
+    @Test
+    func cancelUseCaseCancelsNotification() async {
+        let spy = NotificationManagerSpy()
+        let childID = UUID()
+
+        await CancelMedicationReminderUseCase.execute(
+            childID: childID,
+            medicineName: "Calpol",
+            notificationManager: spy
+        )
+
+        #expect(spy.cancelledCount == 1)
+    }
+}
+
+// MARK: - Test doubles
+
+@MainActor
+private final class NotificationManagerSpy: LocalNotificationManaging {
+    private(set) var scheduledCount = 0
+    private(set) var cancelledCount = 0
+
+    func isAuthorizedForNotifications() async -> Bool { true }
+    func requestAuthorizationIfNeeded() async -> Bool { true }
+    func scheduleRemoteSyncNotification(_ content: RemoteCaregiverNotificationContent) async {}
+    func scheduleSleepDriftNotification(childID: UUID, childName: String, fireAfter: TimeInterval) async {}
+    func cancelSleepDriftNotification(childID: UUID) async {}
+    func scheduleInactivityDriftNotification(childID: UUID, childName: String, fireAfter: TimeInterval) async {}
+    func cancelInactivityDriftNotification(childID: UUID) async {}
+    func pendingDriftNotifications() async -> [PendingDriftNotification] { [] }
+
+    func scheduleMedicationReminderNotification(childID: UUID, childName: String, medicineName: String, mode: ReminderMode, intervalHours: Int, fireAt: Date) async {
+        scheduledCount += 1
+    }
+
+    func cancelMedicationReminderNotification(childID: UUID, medicineName: String) async {
+        cancelledCount += 1
+    }
+
+    func pendingMedicationReminderNotifications() async -> [PendingMedicationReminder] { [] }
+}
+
+@MainActor
+private final class InMemoryCapturingPreferenceStore: MedicationReminderPreferenceStore {
+    private var storage: [String: MedicationReminderPreference] = [:]
+
+    func preference(for medicineName: String, childID: UUID) -> MedicationReminderPreference? {
+        storage[key(medicineName: medicineName, childID: childID)]
+    }
+
+    func savePreference(_ preference: MedicationReminderPreference, for medicineName: String, childID: UUID) {
+        storage[key(medicineName: medicineName, childID: childID)] = preference
+    }
+
+    private func key(medicineName: String, childID: UUID) -> String {
+        "\(childID.uuidString).\(medicineName.lowercased())"
+    }
+}

--- a/Packages/BabyTrackerDomain/Sources/BabyTrackerDomain/MedicationReminderPreference.swift
+++ b/Packages/BabyTrackerDomain/Sources/BabyTrackerDomain/MedicationReminderPreference.swift
@@ -1,0 +1,23 @@
+import Foundation
+
+public enum ReminderMode: String, Codable, Equatable, Sendable, CaseIterable {
+    case safeToGive
+    case nextDueDose
+}
+
+public enum ReminderReferencePoint: String, Codable, Equatable, Sendable, CaseIterable {
+    case doseTime
+    case now
+}
+
+public struct MedicationReminderPreference: Codable, Equatable, Sendable {
+    public var intervalHours: Int
+    public var mode: ReminderMode
+    public var referencePoint: ReminderReferencePoint
+
+    public init(intervalHours: Int, mode: ReminderMode, referencePoint: ReminderReferencePoint) {
+        self.intervalHours = intervalHours
+        self.mode = mode
+        self.referencePoint = referencePoint
+    }
+}

--- a/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/AppModel.swift
+++ b/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/AppModel.swift
@@ -259,6 +259,12 @@ public final class AppModel {
         return isReminderNotificationsEnabled == isEnabled
     }
 
+    /// Requests notification permission if not yet determined. Returns `true` if
+    /// notifications are authorized, `false` if the user has denied permission.
+    public func requestMedicationReminderPermission() async -> Bool {
+        await localNotificationManager.requestAuthorizationIfNeeded()
+    }
+
     public func refreshReminderNotificationAuthorization() async {
         let isAuthorized = await localNotificationManager.isAuthorizedForNotifications()
         let previousValue = isReminderNotificationsEnabled

--- a/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/AppModel.swift
+++ b/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/AppModel.swift
@@ -62,6 +62,8 @@ public final class AppModel {
     public private(set) var timelineDisplayMode: TimelineDisplayMode = .day
     /// The active event filter for the event history screen.
     public private(set) var activeEventFilter: EventFilter = .empty
+    /// Pending medication reminder notifications for the current child.
+    public private(set) var pendingMedicationReminders: [PendingMedicationReminder] = []
 
     private let logger = Logger(subsystem: "com.adappt.BabyTracker", category: "AppModel")
     private let childRepository: any ChildRepository
@@ -74,6 +76,7 @@ public final class AppModel {
     private let liveActivitySnapshotCache: any FeedLiveActivitySnapshotCaching
     private let liveActivityPreferenceStore: any LiveActivityPreferenceStore
     private let reminderNotificationPreferenceStore: any ReminderNotificationPreferenceStore
+    private let medicationReminderPreferenceStore: any MedicationReminderPreferenceStore
     private let eventVisibilityPreferenceStore: any EventVisibilityPreferenceStore
     private let localNotificationManager: any LocalNotificationManaging
     private let hapticFeedbackProvider: any HapticFeedbackProviding
@@ -102,6 +105,7 @@ public final class AppModel {
         liveActivitySnapshotCache: any FeedLiveActivitySnapshotCaching = InMemoryFeedLiveActivitySnapshotCache(),
         liveActivityPreferenceStore: any LiveActivityPreferenceStore = InMemoryLiveActivityPreferenceStore(),
         reminderNotificationPreferenceStore: any ReminderNotificationPreferenceStore = InMemoryReminderNotificationPreferenceStore(),
+        medicationReminderPreferenceStore: any MedicationReminderPreferenceStore = InMemoryMedicationReminderPreferenceStore(),
         eventVisibilityPreferenceStore: any EventVisibilityPreferenceStore = InMemoryEventVisibilityPreferenceStore(),
         localNotificationManager: any LocalNotificationManaging = NoOpLocalNotificationManager(),
         hapticFeedbackProvider: any HapticFeedbackProviding = NoOpHapticFeedbackProvider(),
@@ -118,6 +122,7 @@ public final class AppModel {
         self.liveActivitySnapshotCache = liveActivitySnapshotCache
         self.liveActivityPreferenceStore = liveActivityPreferenceStore
         self.reminderNotificationPreferenceStore = reminderNotificationPreferenceStore
+        self.medicationReminderPreferenceStore = medicationReminderPreferenceStore
         self.eventVisibilityPreferenceStore = eventVisibilityPreferenceStore
         self.localNotificationManager = localNotificationManager
         self.hapticFeedbackProvider = hapticFeedbackProvider
@@ -137,6 +142,7 @@ public final class AppModel {
         rescheduleAllDriftNotifications()
         Task { @MainActor in
             await refreshReminderNotificationAuthorization()
+            await refreshPendingMedicationReminders()
         }
 
         guard performLaunchSync else {
@@ -744,17 +750,21 @@ public final class AppModel {
         medicineName: String,
         amount: Double,
         unit: MedicationUnit,
-        customUnitLabel: String?
+        customUnitLabel: String?,
+        reminder: MedicationReminderPreference? = nil
     ) -> Bool {
-        perform(onSuccess: handleSuccessfulEventLog) {
-            guard let currentChild, let currentMembership else { throw ChildProfileValidationError.insufficientPermissions }
+        guard let currentChild else { return false }
+        let childID = currentChild.id
+        let childName = currentChild.name
+        let succeeded = perform(onSuccess: handleSuccessfulEventLog) {
+            guard let currentMembership else { throw ChildProfileValidationError.insufficientPermissions }
             guard let localUser else { throw ChildProfileValidationError.insufficientPermissions }
             _ = try LogMedicationUseCase(
                 eventRepository: eventRepository,
                 hapticFeedbackProvider: hapticFeedbackProvider
             )
                 .execute(.init(
-                    childID: currentChild.id,
+                    childID: childID,
                     localUserID: localUser.id,
                     occurredAt: occurredAt,
                     medicineName: medicineName,
@@ -764,6 +774,52 @@ public final class AppModel {
                     membership: currentMembership
                 ))
         }
+        if succeeded {
+            Task { @MainActor in
+                if let reminder {
+                    await ScheduleMedicationReminderUseCase.execute(
+                        input: .init(
+                            childID: childID,
+                            childName: childName,
+                            medicineName: medicineName,
+                            preference: reminder,
+                            occurredAt: occurredAt
+                        ),
+                        notificationManager: localNotificationManager,
+                        preferenceStore: medicationReminderPreferenceStore
+                    )
+                } else {
+                    await CancelMedicationReminderUseCase.execute(
+                        childID: childID,
+                        medicineName: medicineName,
+                        notificationManager: localNotificationManager
+                    )
+                }
+                await refreshPendingMedicationReminders()
+            }
+        }
+        return succeeded
+    }
+
+    public func medicationReminderPreference(for medicineName: String) -> MedicationReminderPreference? {
+        guard let childID = currentChild?.id else { return nil }
+        return medicationReminderPreferenceStore.preference(for: medicineName, childID: childID)
+    }
+
+    public func cancelMedicationReminder(medicineName: String) {
+        guard let childID = currentChild?.id else { return }
+        Task { @MainActor in
+            await CancelMedicationReminderUseCase.execute(
+                childID: childID,
+                medicineName: medicineName,
+                notificationManager: localNotificationManager
+            )
+            await refreshPendingMedicationReminders()
+        }
+    }
+
+    private func refreshPendingMedicationReminders() async {
+        pendingMedicationReminders = await localNotificationManager.pendingMedicationReminderNotifications()
     }
 
     @discardableResult
@@ -1120,7 +1176,8 @@ public final class AppModel {
 
     @discardableResult
     public func deleteEvent(id: UUID) -> Bool {
-        perform {
+        guard let childID = currentChild?.id else { return false }
+        let succeeded = perform {
             guard let currentMembership else { throw ChildProfileValidationError.insufficientPermissions }
             guard let localUser else { throw ChildProfileValidationError.insufficientPermissions }
             clearUndoDeleteState()
@@ -1136,8 +1193,19 @@ public final class AppModel {
                 pendingUndoDeletedEvent = event
                 undoDeleteMessage = "\(eventTitle(for: event)) deleted"
                 startUndoDeleteExpiryTask()
+                if case let .medication(medication) = event {
+                    Task { @MainActor in
+                        await CancelMedicationReminderUseCase.execute(
+                            childID: childID,
+                            medicineName: medication.medicineName,
+                            notificationManager: localNotificationManager
+                        )
+                        await refreshPendingMedicationReminders()
+                    }
+                }
             }
         }
+        return succeeded
     }
 
     public func undoLastDeletedEvent() {

--- a/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/LocalNotificationManaging.swift
+++ b/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/LocalNotificationManaging.swift
@@ -11,4 +11,7 @@ public protocol LocalNotificationManaging: AnyObject {
     func scheduleInactivityDriftNotification(childID: UUID, childName: String, fireAfter: TimeInterval) async
     func cancelInactivityDriftNotification(childID: UUID) async
     func pendingDriftNotifications() async -> [PendingDriftNotification]
+    func scheduleMedicationReminderNotification(childID: UUID, childName: String, medicineName: String, mode: ReminderMode, intervalHours: Int, fireAt: Date) async
+    func cancelMedicationReminderNotification(childID: UUID, medicineName: String) async
+    func pendingMedicationReminderNotifications() async -> [PendingMedicationReminder]
 }

--- a/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/MedicationReminderPreferenceStore.swift
+++ b/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/MedicationReminderPreferenceStore.swift
@@ -1,0 +1,15 @@
+import BabyTrackerDomain
+import Foundation
+
+@MainActor
+public protocol MedicationReminderPreferenceStore: AnyObject {
+    func preference(for medicineName: String, childID: UUID) -> MedicationReminderPreference?
+    func savePreference(_ preference: MedicationReminderPreference, for medicineName: String, childID: UUID)
+}
+
+@MainActor
+public final class InMemoryMedicationReminderPreferenceStore: MedicationReminderPreferenceStore {
+    public init() {}
+    public func preference(for medicineName: String, childID: UUID) -> MedicationReminderPreference? { nil }
+    public func savePreference(_ preference: MedicationReminderPreference, for medicineName: String, childID: UUID) {}
+}

--- a/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/NoOpLocalNotificationManager.swift
+++ b/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/NoOpLocalNotificationManager.swift
@@ -17,4 +17,7 @@ public final class NoOpLocalNotificationManager: LocalNotificationManaging {
     public func scheduleInactivityDriftNotification(childID: UUID, childName: String, fireAfter: TimeInterval) async {}
     public func cancelInactivityDriftNotification(childID: UUID) async {}
     public func pendingDriftNotifications() async -> [PendingDriftNotification] { [] }
+    public func scheduleMedicationReminderNotification(childID: UUID, childName: String, medicineName: String, mode: ReminderMode, intervalHours: Int, fireAt: Date) async {}
+    public func cancelMedicationReminderNotification(childID: UUID, medicineName: String) async {}
+    public func pendingMedicationReminderNotifications() async -> [PendingMedicationReminder] { [] }
 }

--- a/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/PendingMedicationReminder.swift
+++ b/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/PendingMedicationReminder.swift
@@ -1,0 +1,15 @@
+import Foundation
+
+public struct PendingMedicationReminder: Equatable, Sendable {
+    public let id: String
+    public let childID: UUID
+    public let medicineName: String
+    public let fireDate: Date
+
+    public init(id: String, childID: UUID, medicineName: String, fireDate: Date) {
+        self.id = id
+        self.childID = childID
+        self.medicineName = medicineName
+        self.fireDate = fireDate
+    }
+}

--- a/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/UseCases/CancelMedicationReminderUseCase.swift
+++ b/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/UseCases/CancelMedicationReminderUseCase.swift
@@ -1,0 +1,13 @@
+import BabyTrackerDomain
+import Foundation
+
+public enum CancelMedicationReminderUseCase {
+    @MainActor
+    public static func execute(
+        childID: UUID,
+        medicineName: String,
+        notificationManager: any LocalNotificationManaging
+    ) async {
+        await notificationManager.cancelMedicationReminderNotification(childID: childID, medicineName: medicineName)
+    }
+}

--- a/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/UseCases/ScheduleMedicationReminderUseCase.swift
+++ b/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/UseCases/ScheduleMedicationReminderUseCase.swift
@@ -1,0 +1,51 @@
+import BabyTrackerDomain
+import Foundation
+
+public enum ScheduleMedicationReminderUseCase {
+    public struct Input {
+        public let childID: UUID
+        public let childName: String
+        public let medicineName: String
+        public let preference: MedicationReminderPreference
+        public let occurredAt: Date
+        public let now: Date
+
+        public init(
+            childID: UUID,
+            childName: String,
+            medicineName: String,
+            preference: MedicationReminderPreference,
+            occurredAt: Date,
+            now: Date = .now
+        ) {
+            self.childID = childID
+            self.childName = childName
+            self.medicineName = medicineName
+            self.preference = preference
+            self.occurredAt = occurredAt
+            self.now = now
+        }
+    }
+
+    @MainActor
+    public static func execute(
+        input: Input,
+        notificationManager: any LocalNotificationManaging,
+        preferenceStore: any MedicationReminderPreferenceStore
+    ) async {
+        let referenceDate = input.preference.referencePoint == .doseTime ? input.occurredAt : input.now
+        let fireAt = referenceDate.addingTimeInterval(TimeInterval(input.preference.intervalHours) * 3_600)
+        guard fireAt > input.now else { return }
+
+        preferenceStore.savePreference(input.preference, for: input.medicineName, childID: input.childID)
+
+        await notificationManager.scheduleMedicationReminderNotification(
+            childID: input.childID,
+            childName: input.childName,
+            medicineName: input.medicineName,
+            mode: input.preference.mode,
+            intervalHours: input.preference.intervalHours,
+            fireAt: fireAt
+        )
+    }
+}

--- a/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/ChildWorkspaceTabView.swift
+++ b/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/ChildWorkspaceTabView.swift
@@ -311,6 +311,9 @@ public struct ChildWorkspaceTabView: View {
                 initialOccurredAt: Date(),
                 reminderPreferenceLoader: { medicineName in
                     model.medicationReminderPreference(for: medicineName)
+                },
+                requestNotificationPermission: {
+                    await model.requestMedicationReminderPermission()
                 }
             ) { occurredAt, medicineName, amount, unit, customUnitLabel, reminder in
                 let didSave = model.logMedication(

--- a/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/ChildWorkspaceTabView.swift
+++ b/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/ChildWorkspaceTabView.swift
@@ -608,6 +608,10 @@ public struct ChildWorkspaceTabView: View {
                 return didSave
             }
         case let .editMedication(id, occurredAt, medicineName, amount, unit, customUnitLabel):
+            let pendingReminder = model.pendingMedicationReminders.first(where: {
+                $0.childID == model.currentChild?.id &&
+                $0.medicineName.lowercased() == medicineName.lowercased()
+            })
             MedicationEditorSheetView(
                 navigationTitle: "Edit Medication",
                 primaryActionTitle: "Update",
@@ -620,6 +624,10 @@ public struct ChildWorkspaceTabView: View {
                 initialUnit: unit,
                 initialCustomUnitLabel: customUnitLabel,
                 initialTimePreset: .custom,
+                pendingReminder: pendingReminder,
+                cancelReminderAction: {
+                    model.cancelMedicationReminder(medicineName: medicineName)
+                },
                 deleteAction: childProfileViewModel.canManageEvents ? {
                     if model.deleteEvent(id: id) {
                         activeEventSheet = nil

--- a/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/ChildWorkspaceTabView.swift
+++ b/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/ChildWorkspaceTabView.swift
@@ -64,7 +64,18 @@ public struct ChildWorkspaceTabView: View {
                 pendingDeleteEvent: deleteCandidate,
                 confirmDelete: performDelete,
                 cancelDelete: cancelDelete,
-                onRefresh: model.forceFullSyncRefresh
+                onRefresh: model.forceFullSyncRefresh,
+                pendingReminderDate: { event in
+                    guard case let .editMedication(_, medicineName, _, _, _) = event.actionPayload else { return nil }
+                    return model.pendingMedicationReminders.first(where: {
+                        $0.childID == model.currentChild?.id &&
+                        $0.medicineName.lowercased() == medicineName.lowercased()
+                    })?.fireDate
+                },
+                cancelReminder: { event in
+                    guard case let .editMedication(_, medicineName, _, _, _) = event.actionPayload else { return }
+                    model.cancelMedicationReminder(medicineName: medicineName)
+                }
             )
             .tag(ChildWorkspaceTab.events)
             .tabItem {
@@ -297,14 +308,18 @@ public struct ChildWorkspaceTabView: View {
                 childName: childProfileViewModel.childName,
                 recentMedicineNames: recentNames,
                 millilitreAmounts: millilitreAmounts,
-                initialOccurredAt: Date()
-            ) { occurredAt, medicineName, amount, unit, customUnitLabel in
+                initialOccurredAt: Date(),
+                reminderPreferenceLoader: { medicineName in
+                    model.medicationReminderPreference(for: medicineName)
+                }
+            ) { occurredAt, medicineName, amount, unit, customUnitLabel, reminder in
                 let didSave = model.logMedication(
                     occurredAt: occurredAt,
                     medicineName: medicineName,
                     amount: amount,
                     unit: unit,
-                    customUnitLabel: customUnitLabel
+                    customUnitLabel: customUnitLabel,
+                    reminder: reminder
                 )
                 if didSave {
                     activeEventSheet = nil
@@ -607,7 +622,7 @@ public struct ChildWorkspaceTabView: View {
                         activeEventSheet = nil
                     }
                 } : nil
-            ) { updatedOccurredAt, updatedName, updatedAmount, updatedUnit, updatedCustomUnitLabel in
+            ) { updatedOccurredAt, updatedName, updatedAmount, updatedUnit, updatedCustomUnitLabel, _ in
                 let didSave = model.updateMedication(
                     id: id,
                     occurredAt: updatedOccurredAt,

--- a/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/EventCardView.swift
+++ b/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/EventCardView.swift
@@ -3,39 +3,75 @@ import SwiftUI
 
 public struct EventCardView: View {
     let event: EventCardViewState
+    let pendingReminderDate: Date?
+    let onCancelReminder: (() -> Void)?
 
-    public init(event: EventCardViewState) {
+    public init(
+        event: EventCardViewState,
+        pendingReminderDate: Date? = nil,
+        onCancelReminder: (() -> Void)? = nil
+    ) {
         self.event = event
+        self.pendingReminderDate = pendingReminderDate
+        self.onCancelReminder = onCancelReminder
     }
 
     public var body: some View {
-        HStack(alignment: .top, spacing: 12) {
-            ZStack {
-                Circle()
-                    .fill(BabyEventStyle.backgroundColor(for: event.kind))
-                    .frame(width: 36, height: 36)
+        VStack(alignment: .leading, spacing: 0) {
+            HStack(alignment: .top, spacing: 12) {
+                ZStack {
+                    Circle()
+                        .fill(BabyEventStyle.backgroundColor(for: event.kind))
+                        .frame(width: 36, height: 36)
 
-                Image(systemName: BabyEventStyle.systemImage(for: event.kind))
-                    .font(.headline)
-                    .foregroundStyle(BabyEventStyle.accentColor(for: event.kind))
-            }
+                    Image(systemName: BabyEventStyle.systemImage(for: event.kind))
+                        .font(.headline)
+                        .foregroundStyle(BabyEventStyle.accentColor(for: event.kind))
+                }
 
-            VStack(alignment: .leading, spacing: 6) {
-                Text(event.title)
-                    .font(.headline)
-                    .foregroundStyle(BabyEventStyle.cardForegroundColor(for: event.kind))
+                VStack(alignment: .leading, spacing: 6) {
+                    Text(event.title)
+                        .font(.headline)
+                        .foregroundStyle(BabyEventStyle.cardForegroundColor(for: event.kind))
 
-                Text(event.detailText)
-                    .font(.subheadline)
+                    Text(event.detailText)
+                        .font(.subheadline)
+                        .foregroundStyle(BabyEventStyle.cardSecondaryForegroundColor(for: event.kind))
+                }
+
+                Spacer(minLength: 12)
+
+                Text(event.timestampText)
+                    .font(.footnote)
                     .foregroundStyle(BabyEventStyle.cardSecondaryForegroundColor(for: event.kind))
+                    .multilineTextAlignment(.trailing)
             }
 
-            Spacer(minLength: 12)
-
-            Text(event.timestampText)
-                .font(.footnote)
-                .foregroundStyle(BabyEventStyle.cardSecondaryForegroundColor(for: event.kind))
-                .multilineTextAlignment(.trailing)
+            if let fireDate = pendingReminderDate {
+                Divider()
+                    .padding(.top, 10)
+                HStack(spacing: 6) {
+                    Image(systemName: "bell.fill")
+                        .font(.caption)
+                        .foregroundStyle(BabyEventStyle.accentColor(for: event.kind))
+                    Text("Reminder: \(fireDate.formatted(date: .omitted, time: .shortened))")
+                        .font(.caption)
+                        .foregroundStyle(BabyEventStyle.cardSecondaryForegroundColor(for: event.kind))
+                    Spacer()
+                    if let onCancel = onCancelReminder {
+                        Button {
+                            onCancel()
+                        } label: {
+                            Image(systemName: "xmark.circle.fill")
+                                .font(.caption)
+                                .foregroundStyle(.secondary)
+                        }
+                        .buttonStyle(.plain)
+                        .accessibilityLabel("Cancel reminder")
+                    }
+                }
+                .padding(.top, 8)
+            }
         }
         .padding(16)
         .frame(maxWidth: .infinity, alignment: .leading)

--- a/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/EventCardView.swift
+++ b/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/EventCardView.swift
@@ -6,6 +6,8 @@ public struct EventCardView: View {
     let pendingReminderDate: Date?
     let onCancelReminder: (() -> Void)?
 
+    @State private var showCancelReminderAlert = false
+
     public init(
         event: EventCardViewState,
         pendingReminderDate: Date? = nil,
@@ -58,9 +60,9 @@ public struct EventCardView: View {
                         .font(.caption)
                         .foregroundStyle(BabyEventStyle.cardSecondaryForegroundColor(for: event.kind))
                     Spacer()
-                    if let onCancel = onCancelReminder {
+                    if onCancelReminder != nil {
                         Button {
-                            onCancel()
+                            showCancelReminderAlert = true
                         } label: {
                             Image(systemName: "xmark.circle.fill")
                                 .font(.caption)
@@ -83,5 +85,13 @@ public struct EventCardView: View {
             RoundedRectangle(cornerRadius: 18, style: .continuous)
                 .stroke(BabyEventStyle.timelineBorderColor(for: event.kind), lineWidth: 1)
         )
+        .alert("Cancel Reminder?", isPresented: $showCancelReminderAlert) {
+            Button("Cancel Reminder", role: .destructive) {
+                onCancelReminder?()
+            }
+            Button("Keep It", role: .cancel) {}
+        } message: {
+            Text("The reminder will be removed and you won't be notified.")
+        }
     }
 }

--- a/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/EventHistoryView.swift
+++ b/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/EventHistoryView.swift
@@ -10,6 +10,8 @@ public struct EventHistoryView: View {
     let confirmDelete: () -> Void
     let cancelDelete: () -> Void
     let onRefresh: () async -> Void
+    let pendingReminderDate: ((EventCardViewState) -> Date?)?
+    let cancelReminder: ((EventCardViewState) -> Void)?
 
     public init(
         viewModel: EventHistoryViewModel,
@@ -19,7 +21,9 @@ public struct EventHistoryView: View {
         pendingDeleteEvent: EventDeleteCandidate?,
         confirmDelete: @escaping () -> Void,
         cancelDelete: @escaping () -> Void,
-        onRefresh: @escaping () async -> Void
+        onRefresh: @escaping () async -> Void,
+        pendingReminderDate: ((EventCardViewState) -> Date?)? = nil,
+        cancelReminder: ((EventCardViewState) -> Void)? = nil
     ) {
         self.viewModel = viewModel
         self.canManageEvents = canManageEvents
@@ -29,6 +33,8 @@ public struct EventHistoryView: View {
         self.confirmDelete = confirmDelete
         self.cancelDelete = cancelDelete
         self.onRefresh = onRefresh
+        self.pendingReminderDate = pendingReminderDate
+        self.cancelReminder = cancelReminder
     }
 
     public var body: some View {
@@ -109,13 +115,19 @@ public struct EventHistoryView: View {
     @ViewBuilder
     private func eventRow(for event: EventCardViewState) -> some View {
         let isPendingDelete = pendingDeleteEvent?.id == event.id
+        let fireDate = pendingReminderDate?(event)
+        let card = EventCardView(
+            event: event,
+            pendingReminderDate: fireDate,
+            onCancelReminder: fireDate != nil ? { cancelReminder?(event) } : nil
+        )
 
         if canManageEvents {
             VStack(alignment: .leading, spacing: 8) {
                 Button {
                     openEvent(event)
                 } label: {
-                    EventCardView(event: event)
+                    card
                 }
                 .buttonStyle(.plain)
                 .accessibilityIdentifier("event-history-event-\(event.id.uuidString)")
@@ -149,7 +161,7 @@ public struct EventHistoryView: View {
                 }
             }
         } else {
-            EventCardView(event: event)
+            card
                 .accessibilityIdentifier("event-history-event-\(event.id.uuidString)")
         }
     }

--- a/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/MedicationEditorSheetView.swift
+++ b/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/MedicationEditorSheetView.swift
@@ -9,7 +9,8 @@ public struct MedicationEditorSheetView: View {
     let childName: String
     let recentMedicineNames: [String]
     let millilitreAmounts: [Double]
-    let saveAction: (_ occurredAt: Date, _ medicineName: String, _ amount: Double, _ unit: MedicationUnit, _ customUnitLabel: String?) -> Bool
+    let reminderPreferenceLoader: ((_ medicineName: String) -> MedicationReminderPreference?)?
+    let saveAction: (_ occurredAt: Date, _ medicineName: String, _ amount: Double, _ unit: MedicationUnit, _ customUnitLabel: String?, _ reminder: MedicationReminderPreference?) -> Bool
     let deleteAction: (() -> Void)?
 
     @Environment(\.dismiss) private var dismiss
@@ -21,7 +22,14 @@ public struct MedicationEditorSheetView: View {
     @State private var unit: MedicationUnit
     @State private var customUnitLabel: String
     @State private var showDeleteConfirmation = false
+    @State private var isReminderEnabled = false
+    @State private var reminderIntervalHours: Int = 4
+    @State private var reminderMode: ReminderMode = .safeToGive
+    @State private var reminderReferencePoint: ReminderReferencePoint = .doseTime
+    @State private var isCustomInterval = false
     private let initialTimePreset: QuickTimeSelectorView.TimePreset
+
+    private static let quickIntervalOptions: [Int] = [2, 4, 6, 8]
 
     private let amountColumns = [
         GridItem(.flexible(), spacing: 8),
@@ -42,14 +50,16 @@ public struct MedicationEditorSheetView: View {
         initialUnit: MedicationUnit = .ml,
         initialCustomUnitLabel: String? = nil,
         initialTimePreset: QuickTimeSelectorView.TimePreset = .now,
+        reminderPreferenceLoader: ((_ medicineName: String) -> MedicationReminderPreference?)? = nil,
         deleteAction: (() -> Void)? = nil,
-        saveAction: @escaping (_ occurredAt: Date, _ medicineName: String, _ amount: Double, _ unit: MedicationUnit, _ customUnitLabel: String?) -> Bool
+        saveAction: @escaping (_ occurredAt: Date, _ medicineName: String, _ amount: Double, _ unit: MedicationUnit, _ customUnitLabel: String?, _ reminder: MedicationReminderPreference?) -> Bool
     ) {
         self.navigationTitle = navigationTitle
         self.primaryActionTitle = primaryActionTitle
         self.childName = childName
         self.recentMedicineNames = recentMedicineNames
         self.millilitreAmounts = millilitreAmounts
+        self.reminderPreferenceLoader = reminderPreferenceLoader
         self.deleteAction = deleteAction
         self.saveAction = saveAction
         let allKnownNames = Set(
@@ -74,6 +84,7 @@ public struct MedicationEditorSheetView: View {
                 amountSection
                 validationSection
                 whenSection
+                reminderSection
                 deleteSection
             }
             .alert("Delete Medication?", isPresented: $showDeleteConfirmation) {
@@ -115,6 +126,7 @@ public struct MedicationEditorSheetView: View {
                     Button {
                         medicineName = name
                         isCustomMedicine = false
+                        prefillReminderIfAvailable(for: name)
                     } label: {
                         chipLabel(name, isSelected: !isCustomMedicine && isSelectedName(name), shape: Capsule())
                     }
@@ -211,6 +223,93 @@ public struct MedicationEditorSheetView: View {
     }
 
     @ViewBuilder
+    private var reminderSection: some View {
+        Section {
+            Toggle("Set a reminder", isOn: $isReminderEnabled)
+                .accessibilityIdentifier("medication-reminder-toggle")
+                .onChange(of: isReminderEnabled) { _, newValue in
+                    if newValue {
+                        prefillReminderIfAvailable(for: effectiveMedicineName)
+                    }
+                }
+
+            if isReminderEnabled {
+                reminderIntervalRow
+                reminderModeRow
+                reminderReferencePointRow
+                if let fireDate = calculatedFireDate {
+                    HStack {
+                        Text("Reminder will fire at")
+                            .foregroundStyle(.secondary)
+                        Spacer()
+                        Text(fireDate, style: .time)
+                            .foregroundStyle(Self.eventColor)
+                            .fontWeight(.semibold)
+                    }
+                    .accessibilityIdentifier("medication-reminder-fire-time")
+                }
+            }
+        } header: {
+            Text("Reminder")
+        }
+    }
+
+    private var reminderIntervalRow: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            Text("How long after the dose?")
+                .font(.subheadline)
+                .foregroundStyle(.secondary)
+            ScrollView(.horizontal, showsIndicators: false) {
+                HStack(spacing: 8) {
+                    ForEach(Self.quickIntervalOptions, id: \.self) { hours in
+                        Button {
+                            reminderIntervalHours = hours
+                            isCustomInterval = false
+                        } label: {
+                            chipLabel(
+                                "\(hours)h",
+                                isSelected: !isCustomInterval && reminderIntervalHours == hours,
+                                shape: Capsule()
+                            )
+                        }
+                        .buttonStyle(.plain)
+                        .accessibilityIdentifier("medication-reminder-interval-\(hours)h")
+                    }
+                    Button {
+                        isCustomInterval = true
+                    } label: {
+                        chipLabel("Custom", isSelected: isCustomInterval, shape: Capsule())
+                    }
+                    .buttonStyle(.plain)
+                    .accessibilityIdentifier("medication-reminder-interval-custom")
+                }
+                .padding(.vertical, 2)
+            }
+            if isCustomInterval {
+                Stepper("\(reminderIntervalHours) hour\(reminderIntervalHours == 1 ? "" : "s")", value: $reminderIntervalHours, in: 1...24)
+                    .accessibilityIdentifier("medication-reminder-custom-stepper")
+            }
+        }
+        .listRowInsets(EdgeInsets(top: 10, leading: 16, bottom: 10, trailing: 16))
+    }
+
+    private var reminderModeRow: some View {
+        Picker("Notification type", selection: $reminderMode) {
+            Text("Safe to give again").tag(ReminderMode.safeToGive)
+            Text("Next dose due").tag(ReminderMode.nextDueDose)
+        }
+        .accessibilityIdentifier("medication-reminder-mode-picker")
+    }
+
+    private var reminderReferencePointRow: some View {
+        Picker("Count from", selection: $reminderReferencePoint) {
+            Text("Dose time").tag(ReminderReferencePoint.doseTime)
+            Text("Now").tag(ReminderReferencePoint.now)
+        }
+        .accessibilityIdentifier("medication-reminder-reference-picker")
+    }
+
+    @ViewBuilder
     private var deleteSection: some View {
         if deleteAction != nil {
             Section {
@@ -233,12 +332,18 @@ public struct MedicationEditorSheetView: View {
         ToolbarItem(placement: .confirmationAction) {
             Button(primaryActionTitle) {
                 guard let amount = parsedAmount, isValid else { return }
+                let reminder = isReminderEnabled ? MedicationReminderPreference(
+                    intervalHours: reminderIntervalHours,
+                    mode: reminderMode,
+                    referencePoint: reminderReferencePoint
+                ) : nil
                 let didSave = saveAction(
                     occurredAt,
                     effectiveMedicineName.trimmingCharacters(in: .whitespacesAndNewlines),
                     amount,
                     unit,
-                    unit == .custom ? customUnitLabel.trimmingCharacters(in: .whitespacesAndNewlines) : nil
+                    unit == .custom ? customUnitLabel.trimmingCharacters(in: .whitespacesAndNewlines) : nil,
+                    reminder
                 )
                 if didSave {
                     dismiss()
@@ -275,6 +380,22 @@ public struct MedicationEditorSheetView: View {
             return trimmed.isEmpty ? "unit" : trimmed
         }
         return unit.shortTitle
+    }
+
+    private var calculatedFireDate: Date? {
+        guard isReminderEnabled else { return nil }
+        let reference = reminderReferencePoint == .doseTime ? occurredAt : Date.now
+        let fireDate = reference.addingTimeInterval(TimeInterval(reminderIntervalHours) * 3_600)
+        return fireDate > Date.now ? fireDate : nil
+    }
+
+    private func prefillReminderIfAvailable(for name: String) {
+        let trimmed = name.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty, let preference = reminderPreferenceLoader?(trimmed) else { return }
+        reminderIntervalHours = preference.intervalHours
+        reminderMode = preference.mode
+        reminderReferencePoint = preference.referencePoint
+        isCustomInterval = !Self.quickIntervalOptions.contains(preference.intervalHours)
     }
 
     /// Quick-pick names: previously logged medicines first, then seeded catalog entries
@@ -370,6 +491,21 @@ public struct MedicationEditorSheetView: View {
         recentMedicineNames: ["Paracetamol (Calpol)"],
         millilitreAmounts: [2.5, 5, 7.5, 10],
         initialOccurredAt: .now,
-        saveAction: { _, _, _, _, _ in true }
+        saveAction: { _, _, _, _, _, _ in true }
+    )
+}
+
+#Preview("Reminder Pre-filled") {
+    MedicationEditorSheetView(
+        navigationTitle: "Medication",
+        primaryActionTitle: "Save",
+        childName: "Poppy",
+        recentMedicineNames: ["Paracetamol (Calpol)"],
+        millilitreAmounts: [2.5, 5, 7.5, 10],
+        initialOccurredAt: .now,
+        reminderPreferenceLoader: { _ in
+            MedicationReminderPreference(intervalHours: 4, mode: .safeToGive, referencePoint: .doseTime)
+        },
+        saveAction: { _, _, _, _, _, _ in true }
     )
 }

--- a/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/MedicationEditorSheetView.swift
+++ b/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/MedicationEditorSheetView.swift
@@ -1,5 +1,6 @@
 import BabyTrackerDomain
 import SwiftUI
+import UIKit
 
 public struct MedicationEditorSheetView: View {
     private static let eventColor = BabyEventStyle.accentColor(for: .medication)
@@ -10,10 +11,12 @@ public struct MedicationEditorSheetView: View {
     let recentMedicineNames: [String]
     let millilitreAmounts: [Double]
     let reminderPreferenceLoader: ((_ medicineName: String) -> MedicationReminderPreference?)?
+    let requestNotificationPermission: (() async -> Bool)?
     let saveAction: (_ occurredAt: Date, _ medicineName: String, _ amount: Double, _ unit: MedicationUnit, _ customUnitLabel: String?, _ reminder: MedicationReminderPreference?) -> Bool
     let deleteAction: (() -> Void)?
 
     @Environment(\.dismiss) private var dismiss
+    @Environment(\.openURL) private var openURL
     @State private var occurredAt: Date
     @State private var medicineName: String
     @State private var isCustomMedicine: Bool
@@ -22,6 +25,7 @@ public struct MedicationEditorSheetView: View {
     @State private var unit: MedicationUnit
     @State private var customUnitLabel: String
     @State private var showDeleteConfirmation = false
+    @State private var showNotificationDeniedAlert = false
     @State private var isReminderEnabled = false
     @State private var reminderIntervalHours: Int = 4
     @State private var reminderMode: ReminderMode = .safeToGive
@@ -51,6 +55,7 @@ public struct MedicationEditorSheetView: View {
         initialCustomUnitLabel: String? = nil,
         initialTimePreset: QuickTimeSelectorView.TimePreset = .now,
         reminderPreferenceLoader: ((_ medicineName: String) -> MedicationReminderPreference?)? = nil,
+        requestNotificationPermission: (() async -> Bool)? = nil,
         deleteAction: (() -> Void)? = nil,
         saveAction: @escaping (_ occurredAt: Date, _ medicineName: String, _ amount: Double, _ unit: MedicationUnit, _ customUnitLabel: String?, _ reminder: MedicationReminderPreference?) -> Bool
     ) {
@@ -60,6 +65,7 @@ public struct MedicationEditorSheetView: View {
         self.recentMedicineNames = recentMedicineNames
         self.millilitreAmounts = millilitreAmounts
         self.reminderPreferenceLoader = reminderPreferenceLoader
+        self.requestNotificationPermission = requestNotificationPermission
         self.deleteAction = deleteAction
         self.saveAction = saveAction
         let allKnownNames = Set(
@@ -95,6 +101,16 @@ public struct MedicationEditorSheetView: View {
                 Button("Cancel", role: .cancel) {}
             } message: {
                 Text("This event will be permanently removed.")
+            }
+            .alert("Notifications Disabled", isPresented: $showNotificationDeniedAlert) {
+                Button("Open Settings") {
+                    if let url = URL(string: UIApplication.openSettingsURLString) {
+                        openURL(url)
+                    }
+                }
+                Button("Not Now", role: .cancel) {}
+            } message: {
+                Text("Allow notifications in Settings to use medication reminders.")
             }
             .scrollContentBackground(.hidden)
             .background(Self.eventColor.opacity(0.08))
@@ -228,8 +244,19 @@ public struct MedicationEditorSheetView: View {
             Toggle("Set a reminder", isOn: $isReminderEnabled)
                 .accessibilityIdentifier("medication-reminder-toggle")
                 .onChange(of: isReminderEnabled) { _, newValue in
-                    if newValue {
+                    guard newValue else { return }
+                    guard let requestPermission = requestNotificationPermission else {
                         prefillReminderIfAvailable(for: effectiveMedicineName)
+                        return
+                    }
+                    Task {
+                        let granted = await requestPermission()
+                        if granted {
+                            prefillReminderIfAvailable(for: effectiveMedicineName)
+                        } else {
+                            isReminderEnabled = false
+                            showNotificationDeniedAlert = true
+                        }
                     }
                 }
 

--- a/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/MedicationEditorSheetView.swift
+++ b/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/MedicationEditorSheetView.swift
@@ -12,6 +12,10 @@ public struct MedicationEditorSheetView: View {
     let millilitreAmounts: [Double]
     let reminderPreferenceLoader: ((_ medicineName: String) -> MedicationReminderPreference?)?
     let requestNotificationPermission: (() async -> Bool)?
+    /// In edit mode, provide the currently pending reminder (if any) and a cancel action.
+    /// When non-nil, the sheet shows a read-only reminder display instead of the toggle setup.
+    let pendingReminder: PendingMedicationReminder?
+    let cancelReminderAction: (() -> Void)?
     let saveAction: (_ occurredAt: Date, _ medicineName: String, _ amount: Double, _ unit: MedicationUnit, _ customUnitLabel: String?, _ reminder: MedicationReminderPreference?) -> Bool
     let deleteAction: (() -> Void)?
 
@@ -26,6 +30,7 @@ public struct MedicationEditorSheetView: View {
     @State private var customUnitLabel: String
     @State private var showDeleteConfirmation = false
     @State private var showNotificationDeniedAlert = false
+    @State private var showCancelReminderAlert = false
     @State private var isReminderEnabled = false
     @State private var reminderIntervalHours: Int = 4
     @State private var reminderMode: ReminderMode = .safeToGive
@@ -56,6 +61,8 @@ public struct MedicationEditorSheetView: View {
         initialTimePreset: QuickTimeSelectorView.TimePreset = .now,
         reminderPreferenceLoader: ((_ medicineName: String) -> MedicationReminderPreference?)? = nil,
         requestNotificationPermission: (() async -> Bool)? = nil,
+        pendingReminder: PendingMedicationReminder? = nil,
+        cancelReminderAction: (() -> Void)? = nil,
         deleteAction: (() -> Void)? = nil,
         saveAction: @escaping (_ occurredAt: Date, _ medicineName: String, _ amount: Double, _ unit: MedicationUnit, _ customUnitLabel: String?, _ reminder: MedicationReminderPreference?) -> Bool
     ) {
@@ -66,6 +73,8 @@ public struct MedicationEditorSheetView: View {
         self.millilitreAmounts = millilitreAmounts
         self.reminderPreferenceLoader = reminderPreferenceLoader
         self.requestNotificationPermission = requestNotificationPermission
+        self.pendingReminder = pendingReminder
+        self.cancelReminderAction = cancelReminderAction
         self.deleteAction = deleteAction
         self.saveAction = saveAction
         let allKnownNames = Set(
@@ -111,6 +120,14 @@ public struct MedicationEditorSheetView: View {
                 Button("Not Now", role: .cancel) {}
             } message: {
                 Text("Allow notifications in Settings to use medication reminders.")
+            }
+            .alert("Cancel Reminder?", isPresented: $showCancelReminderAlert) {
+                Button("Cancel Reminder", role: .destructive) {
+                    cancelReminderAction?()
+                }
+                Button("Keep It", role: .cancel) {}
+            } message: {
+                Text("The reminder will be removed and you won't be notified.")
             }
             .scrollContentBackground(.hidden)
             .background(Self.eventColor.opacity(0.08))
@@ -240,44 +257,73 @@ public struct MedicationEditorSheetView: View {
 
     @ViewBuilder
     private var reminderSection: some View {
-        Section {
-            Toggle("Set a reminder", isOn: $isReminderEnabled)
-                .accessibilityIdentifier("medication-reminder-toggle")
-                .onChange(of: isReminderEnabled) { _, newValue in
-                    guard newValue else { return }
-                    guard let requestPermission = requestNotificationPermission else {
-                        prefillReminderIfAvailable(for: effectiveMedicineName)
-                        return
-                    }
-                    Task {
-                        let granted = await requestPermission()
-                        if granted {
-                            prefillReminderIfAvailable(for: effectiveMedicineName)
-                        } else {
-                            isReminderEnabled = false
-                            showNotificationDeniedAlert = true
-                        }
-                    }
-                }
-
-            if isReminderEnabled {
-                reminderIntervalRow
-                reminderModeRow
-                reminderReferencePointRow
-                if let fireDate = calculatedFireDate {
+        if cancelReminderAction != nil {
+            // Edit mode: show a read-only overview of the existing reminder, or nothing.
+            if let reminder = pendingReminder {
+                Section {
                     HStack {
-                        Text("Reminder will fire at")
-                            .foregroundStyle(.secondary)
-                        Spacer()
-                        Text(fireDate, style: .time)
+                        Image(systemName: "bell.fill")
                             .foregroundStyle(Self.eventColor)
-                            .fontWeight(.semibold)
+                        VStack(alignment: .leading, spacing: 2) {
+                            Text("Reminder set")
+                                .font(.subheadline.weight(.medium))
+                            Text(reminder.fireDate, style: .time)
+                                .font(.subheadline)
+                                .foregroundStyle(.secondary)
+                        }
+                        Spacer()
+                        Button("Cancel", role: .destructive) {
+                            showCancelReminderAlert = true
+                        }
+                        .font(.subheadline)
+                        .accessibilityIdentifier("medication-cancel-reminder-button")
                     }
-                    .accessibilityIdentifier("medication-reminder-fire-time")
+                } header: {
+                    Text("Reminder")
                 }
             }
-        } header: {
-            Text("Reminder")
+            // No reminder set in edit mode → show nothing.
+        } else {
+            // Log mode: full toggle and setup UI.
+            Section {
+                Toggle("Set a reminder", isOn: $isReminderEnabled)
+                    .accessibilityIdentifier("medication-reminder-toggle")
+                    .onChange(of: isReminderEnabled) { _, newValue in
+                        guard newValue else { return }
+                        guard let requestPermission = requestNotificationPermission else {
+                            prefillReminderIfAvailable(for: effectiveMedicineName)
+                            return
+                        }
+                        Task {
+                            let granted = await requestPermission()
+                            if granted {
+                                prefillReminderIfAvailable(for: effectiveMedicineName)
+                            } else {
+                                isReminderEnabled = false
+                                showNotificationDeniedAlert = true
+                            }
+                        }
+                    }
+
+                if isReminderEnabled {
+                    reminderIntervalRow
+                    reminderModeRow
+                    reminderReferencePointRow
+                    if let fireDate = calculatedFireDate {
+                        HStack {
+                            Text("Reminder will fire at")
+                                .foregroundStyle(.secondary)
+                            Spacer()
+                            Text(fireDate, style: .time)
+                                .foregroundStyle(Self.eventColor)
+                                .fontWeight(.semibold)
+                        }
+                        .accessibilityIdentifier("medication-reminder-fire-time")
+                    }
+                }
+            } header: {
+                Text("Reminder")
+            }
         }
     }
 
@@ -533,6 +579,49 @@ public struct MedicationEditorSheetView: View {
         reminderPreferenceLoader: { _ in
             MedicationReminderPreference(intervalHours: 4, mode: .safeToGive, referencePoint: .doseTime)
         },
+        saveAction: { _, _, _, _, _, _ in true }
+    )
+}
+
+#Preview("Edit — Reminder Active") {
+    MedicationEditorSheetView(
+        navigationTitle: "Edit Medication",
+        primaryActionTitle: "Update",
+        childName: "Poppy",
+        recentMedicineNames: ["Paracetamol (Calpol)"],
+        millilitreAmounts: [2.5, 5, 7.5, 10],
+        initialOccurredAt: .now.addingTimeInterval(-3_600),
+        initialMedicineName: "Paracetamol (Calpol)",
+        initialAmount: 5,
+        initialUnit: .ml,
+        initialTimePreset: .custom,
+        pendingReminder: PendingMedicationReminder(
+            id: "medication.child.calpol",
+            childID: UUID(),
+            medicineName: "Paracetamol (Calpol)",
+            fireDate: .now.addingTimeInterval(3 * 3_600)
+        ),
+        cancelReminderAction: {},
+        deleteAction: {},
+        saveAction: { _, _, _, _, _, _ in true }
+    )
+}
+
+#Preview("Edit — No Reminder") {
+    MedicationEditorSheetView(
+        navigationTitle: "Edit Medication",
+        primaryActionTitle: "Update",
+        childName: "Poppy",
+        recentMedicineNames: ["Paracetamol (Calpol)"],
+        millilitreAmounts: [2.5, 5, 7.5, 10],
+        initialOccurredAt: .now.addingTimeInterval(-3_600),
+        initialMedicineName: "Paracetamol (Calpol)",
+        initialAmount: 5,
+        initialUnit: .ml,
+        initialTimePreset: .custom,
+        pendingReminder: nil,
+        cancelReminderAction: {},
+        deleteAction: {},
         saveAction: { _, _, _, _, _, _ in true }
     )
 }

--- a/docs/plans/110-medication-reminder-notifications.md
+++ b/docs/plans/110-medication-reminder-notifications.md
@@ -1,0 +1,192 @@
+# 110 — Medication Reminder Notifications
+
+GitHub issue: https://github.com/murphb52/BabyTracker/issues/267
+
+## Goal
+
+Allow caregivers to opt in to a local notification when logging a medication event. The notification fires after a chosen interval and reminds the caregiver either that it is safe to give the next dose, or that the next dose is due. The app remembers the last used interval, mode, and reference point per medicine per child, and suggests them the next time the same medicine is logged.
+
+---
+
+## Design decisions
+
+### Two notification modes
+
+The user picks their framing when logging:
+
+- **Safe to give**: "Calpol – Safe to give again" / "It's been 4 hours since {childName}'s last dose."
+- **Next dose due**: "Calpol – Next dose due" / "{childName}'s next Calpol dose is due now."
+
+### Reference point
+
+The user chooses whether the interval is measured from:
+
+- **Dose time** (`occurredAt`) — medically precise
+- **Now** — useful when logging in real time
+
+The calculated fire time is shown inline in the sheet ("Your reminder will fire at 10:00 PM") so the user can verify before saving.
+
+### Interval picker
+
+- Quick chips: 2h, 4h, 6h, 8h
+- Custom stepper: 1–24 hours
+- Hours granularity only for v1
+
+### Preference storage
+
+`MedicationReminderPreference` — a `Codable` struct stored in `UserDefaults` keyed by `"medicationReminder.\(childID).\(medicineName)"`.
+
+Fields:
+- `intervalHours: Int`
+- `mode: ReminderMode` (`.safeToGive` | `.nextDueDose`)
+- `referencePoint: ReminderReferencePoint` (`.doseTime` | `.now`)
+
+When the reminder toggle is turned on and a saved preference exists for this medicine+child, all three values pre-fill.
+
+### Notification identifier
+
+`"medication.\(childID.uuidString).\(medicineName)"` — one active reminder per medicine+child at a time.
+
+### Replacement and cancellation
+
+- **New dose logged with reminder on**: cancel existing identifier, schedule new one.
+- **New dose logged with reminder off**: cancel existing identifier, do not schedule.
+- **Event deleted**: cancel existing identifier.
+- **Event edited**: no change to reminder for v1.
+
+### Timeline indicator
+
+The medication event card in the timeline shows a pending reminder chip ("Reminder: 10:00 PM ✕"). Tapping ✕ cancels the notification. This uses the same `pendingNotifications()` query pattern as drift notifications.
+
+### Architecture
+
+- `MedicationReminderPreference` — domain-layer value type (`Codable` struct)
+- `MedicationReminderPreferenceStore` — protocol in Feature layer (read/write by medicine+child key)
+- `UserDefaultsMedicationReminderPreferenceStore` — concrete implementation in the App target
+- `ScheduleMedicationReminderUseCase` — Feature layer; computes fire date, builds notification content, saves preference, calls `LocalNotificationManaging`
+- `CancelMedicationReminderUseCase` — Feature layer; cancels by identifier
+- `LocalNotificationManaging` — extend with `scheduleMedicationReminderNotification(...)` and `cancelMedicationReminderNotification(childID:medicineName:)`
+- `NoOpLocalNotificationManager` — add no-op implementations
+- View model for `MedicationEditorSheetView` — calls log use case, then on success calls schedule or cancel use case; reads saved preference to pre-fill UI
+
+---
+
+## Implementation steps
+
+### 1. Domain — `MedicationReminderPreference`
+
+- [ ] Add `MedicationReminderPreference.swift` to `BabyTrackerDomain`
+  - `ReminderMode` enum: `.safeToGive`, `.nextDueDose`
+  - `ReminderReferencePoint` enum: `.doseTime`, `.now`
+  - `MedicationReminderPreference` struct: `intervalHours: Int`, `mode: ReminderMode`, `referencePoint: ReminderReferencePoint`
+  - All types `Codable`, `Equatable`, `Sendable`
+
+### 2. Feature — preference store protocol and implementation
+
+- [ ] Add `MedicationReminderPreferenceStore.swift` to `BabyTrackerFeature`
+  - Protocol: `func preference(for medicineName: String, childID: UUID) -> MedicationReminderPreference?`
+  - Protocol: `func savePreference(_ preference: MedicationReminderPreference, for medicineName: String, childID: UUID)`
+- [ ] Add `UserDefaultsMedicationReminderPreferenceStore.swift` to the App target
+  - Key: `"medicationReminder.\(childID.uuidString).\(medicineName)"`
+  - Encode/decode with `JSONEncoder`/`JSONDecoder`
+- [ ] Add `NoOpMedicationReminderPreferenceStore` for tests/previews
+
+### 3. Feature — extend `LocalNotificationManaging`
+
+- [ ] Add to `LocalNotificationManaging` protocol:
+  - `scheduleMedicationReminderNotification(childID: UUID, childName: String, medicineName: String, mode: ReminderMode, fireAt: Date) async`
+  - `cancelMedicationReminderNotification(childID: UUID, medicineName: String) async`
+- [ ] Implement in `SystemLocalNotificationManager`:
+  - Identifier: `"medication.\(childID.uuidString).\(medicineName)"`
+  - Safe mode title: `"\(medicineName) – Safe to give again"`
+  - Safe mode body: `"It's been \(intervalHours)h since \(childName)'s last dose."`
+  - Due mode title: `"\(medicineName) – Next dose due"`
+  - Due mode body: `"\(childName)'s next \(medicineName) dose is due now."`
+  - Trigger: `UNCalendarNotificationTrigger` from fire date (not time-interval, so it survives device restart)
+  - Cancel existing identifier before scheduling
+- [ ] Add no-op stubs to `NoOpLocalNotificationManager`
+
+### 4. Feature — `ScheduleMedicationReminderUseCase`
+
+- [ ] Add `ScheduleMedicationReminderUseCase.swift` to `BabyTrackerFeature`
+  - Input: `childID`, `childName`, `medicineName`, `preference: MedicationReminderPreference`, `occurredAt: Date`, `now: Date`
+  - Computes `fireAt`: `referencePoint == .doseTime ? occurredAt + interval : now + interval`
+  - Guards: if `fireAt <= now`, return without scheduling
+  - Saves preference via `MedicationReminderPreferenceStore`
+  - Calls `localNotificationManager.scheduleMedicationReminderNotification(...)`
+
+### 5. Feature — `CancelMedicationReminderUseCase`
+
+- [ ] Add `CancelMedicationReminderUseCase.swift` to `BabyTrackerFeature`
+  - Input: `childID`, `medicineName`
+  - Calls `localNotificationManager.cancelMedicationReminderNotification(childID:medicineName:)`
+
+### 6. Feature — extend `pendingNotifications` query
+
+- [ ] Add `pendingMedicationReminderNotifications() async -> [PendingMedicationReminder]` to `LocalNotificationManaging`
+  - `PendingMedicationReminder`: `id: String`, `childID: UUID`, `medicineName: String`, `fireDate: Date`
+  - Filter pending requests with prefix `"medication."`
+  - Implement in `SystemLocalNotificationManager` and `NoOpLocalNotificationManager`
+
+### 7. Presentation — `MedicationEditorSheetView` reminder section
+
+- [ ] Extend the medication editor view model to expose:
+  - `savedPreference: MedicationReminderPreference?` (loaded on init for current medicine+child)
+  - `isReminderEnabled: Bool`
+  - `selectedIntervalHours: Int`
+  - `reminderMode: ReminderMode`
+  - `referencePoint: ReminderReferencePoint`
+  - `calculatedFireDate: Date?` (derived, for display)
+- [ ] Add reminder section to `MedicationEditorSheetView`:
+  - Toggle: "Set a reminder"
+  - When on: quick chips (2h, 4h, 6h, 8h), custom stepper (1–24h)
+  - Mode picker: "Safe to give" / "Next dose due"
+  - Reference point picker: "From dose time" / "From now"
+  - Calculated fire time label: "Your reminder will fire at 10:00 PM"
+  - Pre-fill all fields from `savedPreference` when toggled on if preference exists
+- [ ] After successful log: call `ScheduleMedicationReminderUseCase` if reminder enabled, else call `CancelMedicationReminderUseCase`
+- [ ] Add `#Preview` states: reminder off, reminder on with saved preference, reminder on with no preference, fire date in past (disabled state)
+
+### 8. Presentation — delete flow cancels reminder
+
+- [ ] After a medication event is deleted, call `CancelMedicationReminderUseCase` for that event's `childID` and `medicineName`
+- [ ] Find the delete path for medication events and wire in the cancel call
+
+### 9. Presentation — timeline card indicator
+
+- [ ] Extend the medication event card to query `pendingMedicationReminderNotifications()` and show a chip if a reminder exists for this event's `childID` + `medicineName`
+- [ ] Chip format: "Reminder: 10:00 PM ✕"
+- [ ] Tapping ✕ calls `CancelMedicationReminderUseCase` and refreshes the card
+
+### 10. Dependency injection
+
+- [ ] Add `MedicationReminderPreferenceStore` and `ScheduleMedicationReminderUseCase` / `CancelMedicationReminderUseCase` to `AppContainer`
+- [ ] Inject into the medication editor view model
+
+### 11. Notification permission
+
+- [ ] When the reminder toggle is turned on and notification permission has not been granted, call `requestAuthorizationIfNeeded()` before showing the reminder options
+- [ ] If permission is denied, show a brief inline message and leave the toggle off
+
+### 12. Tests
+
+- [ ] `MedicationReminderPreference` encode/decode round-trip
+- [ ] `ScheduleMedicationReminderUseCase`: fire date calculated correctly for both reference points
+- [ ] `ScheduleMedicationReminderUseCase`: skips scheduling when fire date is in the past
+- [ ] `ScheduleMedicationReminderUseCase`: saves preference to store
+- [ ] `CancelMedicationReminderUseCase`: calls cancel on notification manager
+- [ ] `UserDefaultsMedicationReminderPreferenceStore`: read/write/overwrite
+
+---
+
+## Out of scope for v1
+
+- Deep-link from notification tap into the child's timeline
+- Edit event shifts the reminder
+- Cross-caregiver CloudKit sync of reminder preferences
+- Minutes granularity in interval picker
+- Rich notification actions ("Mark as given" from lock screen)
+
+---
+
+- [x] Complete


### PR DESCRIPTION
## Summary

- Caregivers can opt in to a local notification when logging a medication, choosing how long after the dose (2h, 4h, 6h, 8h or custom) and whether to be reminded that it is safe to give the next dose or that the next dose is due
- The app remembers the last-used interval, mode (safe to give / next dose due), and reference point (from dose time / from now) per medicine per child, and pre-fills all three on the next log of the same medicine
- The calculated fire time is shown inline so the caregiver can confirm before saving
- Notification permission is requested when the toggle is turned on; if denied, an alert offers a direct link to the app's Settings page
- Opening a past medication event shows the active reminder (if any) as a read-only section with a cancel button; if no reminder is set, the section is hidden
- A pending reminder chip appears on medication event cards in the event list with a cancel button; both the card chip and the edit-sheet cancel button show a confirmation alert before removing the reminder
- Logging a new dose silently replaces any existing reminder for that medicine and child; deleting an event cancels its reminder

## Architecture

- `MedicationReminderPreference` (Domain) — `Codable` struct: `intervalHours`, `mode`, `referencePoint`
- `MedicationReminderPreferenceStore` (Feature) — protocol; `UserDefaultsMedicationReminderPreferenceStore` keyed by `"medicationReminder.\(childID).\(medicineName)"`
- `ScheduleMedicationReminderUseCase` + `CancelMedicationReminderUseCase` (Feature)
- `LocalNotificationManaging` extended with schedule / cancel / pending-query methods; uses `UNCalendarNotificationTrigger` so reminders survive device restarts
- Notification identifier: `"medication.\(childID.uuidString).\(medicineName.lowercased())"`
- `AppModel` gains `pendingMedicationReminders`, `logMedication(reminder:)`, `deleteEvent` cancel wiring, `medicationReminderPreference(for:)`, `cancelMedicationReminder(medicineName:)`, `requestMedicationReminderPermission()`

## Test plan

- [ ] Log a medication, enable the reminder toggle — confirm permission prompt appears on first use
- [ ] With permission denied, toggle on — confirm "Notifications Disabled" alert appears with Open Settings link
- [ ] Set a 4h reminder from dose time — confirm fire time shown matches `occurredAt + 4h`
- [ ] Set a 4h reminder from now — confirm fire time shown matches `now + 4h`
- [ ] Log Calpol with a 4h safe-to-give reminder, then log Calpol again — confirm old reminder is replaced, new fire time reflects new dose
- [ ] Log Calpol with reminder off — confirm any existing reminder is cancelled
- [ ] Log Calpol with a reminder, then open the edit sheet — confirm reminder is shown read-only with correct time
- [ ] Tap Cancel in the edit sheet — confirm confirmation alert appears; confirm reminder is removed after confirming
- [ ] Open a past medication with no reminder — confirm no reminder section shown in edit sheet
- [ ] Delete a medication event that has a reminder — confirm reminder is cancelled
- [ ] Tap ✕ on the reminder chip in the event list — confirm confirmation alert appears before cancelling
- [ ] Log Calpol with 4h, close app, reopen — confirm reminder chip still shows (calendar trigger survives restart)
- [ ] Log Calpol twice with different intervals — confirm the second interval is suggested next time
- [ ] Run the unit test suite — all tests pass

## Related

Closes #267 — plan: `docs/plans/110-medication-reminder-notifications.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)