### PR TITLE
Fix Live Activities never starting and add diagnostics

### DIFF
--- a/Baby Tracker/App/BabyTrackerApp.swift
+++ b/Baby Tracker/App/BabyTrackerApp.swift
@@ -14,10 +14,7 @@ struct BabyTrackerApp: App {
         self.container = container
         CloudKitShareAcceptanceBridge.shared.handler = container.shareAcceptanceHandler
         CloudKitRemoteNotificationBridge.shared.handler = {
-            let isAppInBackground = UIApplication.shared.applicationState == .background
-            let summary = await container.appModel.refreshAfterRemoteNotification(
-                isAppInBackground: isAppInBackground
-            )
+            let summary = await container.appModel.refreshAfterRemoteNotification()
             return summary.state == .failed ? .failed : .newData
         }
         try? Tips.configure()

--- a/Baby Tracker/App/FeedLiveActivityManager.swift
+++ b/Baby Tracker/App/FeedLiveActivityManager.swift
@@ -1,4 +1,5 @@
 import ActivityKit
+import BabyTrackerDomain
 import BabyTrackerFeature
 import BabyTrackerLiveActivities
 import Foundation
@@ -24,6 +25,9 @@ final class FeedLiveActivityManager: FeedLiveActivityManaging {
         let activities = Activity<FeedLiveActivityAttributes>.activities
 
         guard let snapshot else {
+            if !activities.isEmpty {
+                Self.log(.info, "reconcile: snapshot is nil — ending \(activities.count) activity(ies)")
+            }
             stateObservationTask?.cancel()
             stateObservationTask = nil
             await Self.endAllActivities()
@@ -62,6 +66,16 @@ final class FeedLiveActivityManager: FeedLiveActivityManaging {
 
         guard !Task.isCancelled else { return }
 
+        let authorizationInfo = ActivityAuthorizationInfo()
+        guard authorizationInfo.areActivitiesEnabled else {
+            Self.log(
+                .error,
+                "Cannot start Live Activity — Live Activities are disabled in system settings (areActivitiesEnabled == false)"
+            )
+            activeActivityID = nil
+            return
+        }
+
         do {
             let activity = try Activity.request(
                 attributes: FeedLiveActivityAttributes(childID: snapshot.childID),
@@ -70,9 +84,17 @@ final class FeedLiveActivityManager: FeedLiveActivityManaging {
             )
             activeActivityID = activity.id
             observeActivityState(activity)
+            Self.log(.info, "Started Live Activity \(activity.id) for child \(snapshot.childID)")
         } catch {
+            // ActivityKit only permits starting a Live Activity while the app is in the
+            // foreground; surfacing the error here is what makes this path observable.
+            Self.log(.error, "Activity.request failed: \(error)")
             activeActivityID = nil
         }
+    }
+
+    private static func log(_ level: LogLevel, _ message: String) {
+        AppLogger.shared.log(level, category: "LiveActivity", message)
     }
 
     private func observeActivityState(_ activity: Activity<FeedLiveActivityAttributes>) {

--- a/Baby TrackerTests/AppModelTests.swift
+++ b/Baby TrackerTests/AppModelTests.swift
@@ -1576,7 +1576,10 @@ struct AppModelTests {
 
         #expect(harness.model.isLiveActivityEnabled == false)
         #expect(liveActivityManager.latestSnapshot == nil)
-        #expect(liveActivityManager.snapshots.count == 1)
+        // The activity is reconciled on every successful refresh (load + background),
+        // but while disabled every reconcile must clear the activity rather than
+        // publish a real snapshot.
+        #expect(liveActivityManager.snapshots.allSatisfy { $0 == nil })
     }
 
     @Test
@@ -1595,7 +1598,8 @@ struct AppModelTests {
         )
         harness.model.load(performLaunchSync: false)
 
-        #expect(liveActivityManager.latestSnapshot == nil)
+        // A successful foreground refresh (load) already starts/reconciles the activity.
+        #expect(liveActivityManager.latestSnapshot?.childID == seed.child.id)
 
         _ = await harness.model.refreshAfterRemoteNotification(isAppInBackground: true)
 
@@ -1603,7 +1607,11 @@ struct AppModelTests {
     }
 
     @Test
-    func remoteNotificationSyncInForegroundDoesNotUpdateLiveActivity() async throws {
+    func remoteNotificationSyncInForegroundKeepsLiveActivityInSync() async throws {
+        // ActivityKit only permits *starting* a Live Activity while the app is in the
+        // foreground, so a foreground refresh must reconcile the activity rather than
+        // skip it. (Previously the app only synced from the background, which meant the
+        // activity could never actually start.)
         let liveActivityManager = LiveActivityManagerSpy()
         let harness = try Harness(liveActivityManager: liveActivityManager)
         defer { harness.cleanUp() }
@@ -1618,12 +1626,11 @@ struct AppModelTests {
         )
         harness.model.load(performLaunchSync: false)
 
-        #expect(liveActivityManager.latestSnapshot == nil)
+        #expect(liveActivityManager.latestSnapshot?.childID == seed.child.id)
 
         _ = await harness.model.refreshAfterRemoteNotification(isAppInBackground: false)
 
-        #expect(liveActivityManager.latestSnapshot == nil)
-        #expect(liveActivityManager.snapshots.isEmpty)
+        #expect(liveActivityManager.latestSnapshot?.childID == seed.child.id)
     }
 
     @Test

--- a/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/AppModel.swift
+++ b/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/AppModel.swift
@@ -299,13 +299,15 @@ public final class AppModel {
         await refreshAfterRemoteNotification(isAppInBackground: false)
     }
 
+    // `isAppInBackground` is retained to satisfy `BackgroundRefreshing`, but the
+    // Live Activity is now reconciled on every successful refresh regardless of
+    // foreground/background state — ActivityKit only lets us *start* an activity
+    // while in the foreground, and updating a running one from the background is
+    // always safe.
     public func refreshAfterRemoteNotification(isAppInBackground: Bool) async -> SyncStatusSummary {
         let summary = await syncEngine.refreshAfterRemoteNotification()
         await scheduleRemoteSyncNotificationIfNeeded()
-        refresh(
-            selecting: childSelectionStore.loadSelectedChildID(),
-            synchronizeLiveActivity: isAppInBackground
-        )
+        refresh(selecting: childSelectionStore.loadSelectedChildID())
         return summary
     }
 
@@ -1284,7 +1286,7 @@ public final class AppModel {
         await scheduleInactivityDriftNotificationIfNeededAsync()
     }
 
-    private func refresh(selecting selectedChildID: UUID?, synchronizeLiveActivity: Bool = false) {
+    private func refresh(selecting selectedChildID: UUID?) {
         do {
             localUser = try userIdentityRepository.loadLocalUser()
 
@@ -1391,9 +1393,10 @@ public final class AppModel {
             pendingShareInvites = builtPendingInvites
 
             route = .childProfile
-            if synchronizeLiveActivity {
-                synchronizeFeedLiveActivity()
-            }
+            // ActivityKit only permits *starting* a Live Activity while the app is in
+            // the foreground, so reconcile on every successful foreground refresh. The
+            // update use case dedups unchanged snapshots, so repeated calls are cheap.
+            synchronizeFeedLiveActivity()
         } catch {
             AppLogger.shared.log(.error, category: "AppModel", "refresh failed: \(error)")
             setErrorMessage(resolveErrorMessage(for: error))

--- a/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/UseCases/ResetFeedLiveActivityUseCase.swift
+++ b/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/UseCases/ResetFeedLiveActivityUseCase.swift
@@ -1,3 +1,5 @@
+import BabyTrackerDomain
+
 /// Ends the live activity and clears the snapshot cache, but only if the
 /// cache contains data (i.e. a live activity is actually running).
 /// Call this to force a full restart — the next UpdateFeedLiveActivityUseCase
@@ -11,6 +13,7 @@ public enum ResetFeedLiveActivityUseCase {
         guard snapshotCache.load() != nil else {
             return
         }
+        AppLogger.shared.log(.info, category: "LiveActivity", "Reset — ending Live Activity and clearing cache")
         liveActivityManager.synchronize(with: nil)
         snapshotCache.save(nil)
     }

--- a/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/UseCases/UpdateFeedLiveActivityUseCase.swift
+++ b/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/UseCases/UpdateFeedLiveActivityUseCase.swift
@@ -13,6 +13,11 @@ public enum UpdateFeedLiveActivityUseCase {
         snapshotCache: any FeedLiveActivitySnapshotCaching
     ) {
         guard isLiveActivityEnabled, let child else {
+            AppLogger.shared.log(
+                .info,
+                category: "LiveActivity",
+                "Update skipped — \(isLiveActivityEnabled ? "no selected child" : "toggle disabled"); ending activity"
+            )
             liveActivityManager.synchronize(with: nil)
             snapshotCache.save(nil)
             return
@@ -24,14 +29,35 @@ public enum UpdateFeedLiveActivityUseCase {
             activeSleep: activeSleep
         )
 
+        guard snapshot != nil else {
+            AppLogger.shared.log(
+                .info,
+                category: "LiveActivity",
+                "Update produced no snapshot — no feed data yet for \(child.name); ending activity"
+            )
+            liveActivityManager.synchronize(with: nil)
+            snapshotCache.save(nil)
+            return
+        }
+
         // Bypass deduplication when no activity is running — the activity may have been
         // ended by the system (8-hour limit, low battery, user dismissal) while the
         // cached snapshot still matches, which would prevent a restart.
         let activityIsDead = !liveActivityManager.hasRunningActivity
         guard snapshot != snapshotCache.load() || activityIsDead else {
+            AppLogger.shared.log(
+                .debug,
+                category: "LiveActivity",
+                "Update deduped — snapshot unchanged and activity already running"
+            )
             return
         }
 
+        AppLogger.shared.log(
+            .info,
+            category: "LiveActivity",
+            "Synchronizing Live Activity (activityIsDead: \(activityIsDead))"
+        )
         liveActivityManager.synchronize(with: snapshot)
         snapshotCache.save(snapshot)
     }

--- a/docs/plans/103-live-activity-background-only-updates.md
+++ b/docs/plans/103-live-activity-background-only-updates.md
@@ -1,12 +1,46 @@
 # 103 Live activity background-only updates
 
-## Goal
+> **⚠️ Superseded — see "Correction" below.**
+> The background-only rule described here shipped in PR #241 but made Live
+> Activities impossible to start. It was reversed in PR #269. Keep this doc as
+> the record of why the original approach didn't work.
+
+## Correction (PR #269)
+
+The goal below restricted **all** live activity synchronization — including the
+initial `Activity.request` — to background triggers. That cannot work:
+
+**ActivityKit only permits *starting* a Live Activity while the app is in the
+foreground.** Routing the first sync through `appDidEnterBackground` /
+background remote notifications meant `Activity.request` was always called from
+the background, threw every time, and the error was silently swallowed. The
+activity therefore never started, and nothing appeared in the logs.
+
+### Corrected design
+
+1. Reconcile the live activity on every **successful foreground `refresh`**
+   (launch, logging an event, switching child, toggling the feature on), so the
+   activity is started while the app is actually allowed to start it.
+2. Keep the background triggers (`appDidEnterBackground`, background remote
+   notification) as **update** points for an already-running activity.
+3. Preserve the original frugality intent through `UpdateFeedLiveActivityUseCase`
+   deduplication: we only write when the snapshot actually changed (or no
+   activity is running), so foreground refreshes with unchanged data are no-ops.
+   Apple's tight update budget applies to *push* updates, not the cheap local
+   `activity.update()` calls used here.
+4. Surface the previously-swallowed failure path with logging under the
+   `LiveActivity` category, plus an explicit
+   `ActivityAuthorizationInfo.areActivitiesEnabled` check.
+
+---
+
+## Original goal (historical — no longer the behavior)
 
 Restrict feed live activity synchronization so the app only pushes updates when:
 1. the app transitions to the background, or
 2. a remote/background notification is handled while the app is already in the background.
 
-## Approach
+## Original approach (historical)
 
 1. Move live activity synchronization control into explicit lifecycle-triggered paths instead of running on every `AppModel.refresh`.
 2. Add an `AppModel` API for background transition updates, and call it from the root view when `scenePhase` becomes `.background`.
@@ -14,4 +48,6 @@ Restrict feed live activity synchronization so the app only pushes updates when:
 4. Add/update tests to verify background-triggered synchronization and to prevent foreground remote-notification synchronization.
 5. Run focused test coverage for `AppModel` and related live activity behavior.
 
-- [x] Complete
+- [x] Complete (later superseded by PR #269)
+</content>
+</invoke>


### PR DESCRIPTION
## Diagnosis

Live Activities never appeared. After tracing every code path that calls `Activity.request`, the root cause is that **the activity was only ever started from a background context**:

- `synchronizeFeedLiveActivity()` (the only thing that reaches `Activity.request`) was invoked from just two places: `appDidEnterBackground()` and a background remote notification.
- **ActivityKit only permits *starting* a Live Activity while the app is in the foreground.** By the time `scenePhase == .background`, `Activity.request` throws every time.
- The throw was caught and **silently discarded** (`FeedLiveActivityManager`), with zero logging anywhere in the Live Activity path — which is why nothing showed up in the logs either.

Secondary bug: toggling Live Activities **on** called `refresh(...)` without ever triggering a sync, so the toggle did nothing in the foreground.

Build/entitlement config was fine (`NSSupportsLiveActivities` is injected for Debug/Release, the extension bundle id is correctly prefixed, the real manager is used in production).

## Fix

- **Reconcile on every successful foreground refresh** (launch, event logging, child switch, toggle-on) so the activity is started while the app is actually allowed to start it. The update use case still dedups unchanged snapshots, so repeated calls are cheap. Background paths remain as update points for an already-running activity.
- **Logging** added under the `LiveActivity` category: start success, the previously-swallowed `Activity.request` failure, an explicit `ActivityAuthorizationInfo.areActivitiesEnabled` check, and the decision branches in the update/reset use cases (disabled / no child / no feed data yet / deduped / synchronizing). These surface in the in-app log so it's clear why an activity did or didn't start.

## Tests

Updated three `AppModelTests` whose assertions encoded the old (broken) background-only contract — a foreground refresh now reconciles the activity instead of skipping it. The remaining content-based Live Activity tests are unaffected.

## Note

This is an iOS target, so it can't be compiled or test-run inside the Linux web session. The change still needs a local **build + full test run on macOS/Xcode** before merging. Worth a quick on-device sanity check that the activity now appears on the lock screen after logging a feed and locking the phone.

https://claude.ai/code/session_01Jzdq5BaxoQinzfWgZM6kB7

---
_Generated by [Claude Code](https://claude.ai/code/session_01Jzdq5BaxoQinzfWgZM6kB7)_