### PR TITLE
Fix background-refresh crash from MainActor-isolated launch handler

### DIFF
--- a/Baby Tracker/App/SystemBackgroundRefreshScheduler.swift
+++ b/Baby Tracker/App/SystemBackgroundRefreshScheduler.swift
@@ -32,19 +32,23 @@ final class SystemBackgroundRefreshScheduler: BackgroundRefreshScheduling {
         guard !didRegisterLaunchHandler else { return }
         didRegisterLaunchHandler = true
 
+        // The launch handler MUST be `@Sendable`. Without it, the closure
+        // inherits this method's `@MainActor` isolation, and the Swift runtime
+        // emits an executor-isolation check at the closure's entry point.
+        // BGTaskScheduler invokes the handler on a private *background* queue,
+        // so that check (`dispatch_assert_queue` for the main queue) fails and
+        // traps with EXC_BREAKPOINT before any of our code runs. Marking the
+        // closure `@Sendable` keeps it non-isolated; we then hop to the main
+        // actor explicitly via `Task { @MainActor in }` to touch @MainActor
+        // state safely.
         BGTaskScheduler.shared.register(
             forTaskWithIdentifier: Self.taskIdentifier,
             using: nil
-        ) { [weak self] task in
+        ) { @Sendable [weak self] task in
             guard let appRefreshTask = task as? BGAppRefreshTask else {
                 task.setTaskCompleted(success: false)
                 return
             }
-            // BGTaskScheduler invokes this launch handler on a private
-            // background queue, so we must hop to the main actor before
-            // touching @MainActor state. `MainActor.assumeIsolated` would
-            // trap here because the runtime asserts we are already on the
-            // main queue.
             Task { @MainActor in
                 self?.handle(task: appRefreshTask)
             }

--- a/Baby Tracker/App/SystemBackgroundRefreshScheduler.swift
+++ b/Baby Tracker/App/SystemBackgroundRefreshScheduler.swift
@@ -32,31 +32,26 @@ final class SystemBackgroundRefreshScheduler: BackgroundRefreshScheduling {
         guard !didRegisterLaunchHandler else { return }
         didRegisterLaunchHandler = true
 
-        // The launch handler MUST be `@Sendable`. Without it, the closure
-        // inherits this method's `@MainActor` isolation, and the Swift runtime
-        // emits an executor-isolation check at the closure's entry point.
-        // BGTaskScheduler invokes the handler on a private *background* queue,
-        // so that check (`dispatch_assert_queue` for the main queue) fails and
-        // traps with EXC_BREAKPOINT before any of our code runs. Marking the
-        // closure `@Sendable` keeps it non-isolated; we then hop to the main
-        // actor explicitly via `Task { @MainActor in }` to touch @MainActor
-        // state safely.
+        // Run the launch handler on the main queue (`using: .main`).
+        //
+        // The app target builds with `SWIFT_DEFAULT_ACTOR_ISOLATION = MainActor`,
+        // so this closure is implicitly `@MainActor`-isolated and the Swift
+        // runtime inserts an executor-isolation check at its entry point. With
+        // the default queue (`using: nil`), BGTaskScheduler invokes the handler
+        // on a private *background* queue, so that check (`dispatch_assert_queue`
+        // for the main queue) fails and traps with EXC_BREAKPOINT before any of
+        // our code runs. Dispatching on the main queue satisfies the MainActor
+        // executor, so the check passes. The handler is trivial — it just kicks
+        // off the actual async refresh work on the main actor.
         BGTaskScheduler.shared.register(
             forTaskWithIdentifier: Self.taskIdentifier,
-            using: nil
-        ) { @Sendable [weak self] task in
+            using: .main
+        ) { [weak self] task in
             guard let appRefreshTask = task as? BGAppRefreshTask else {
                 task.setTaskCompleted(success: false)
                 return
             }
-            // `task` is a non-Sendable value handed to this non-isolated
-            // closure, so it can't be sent across the actor hop directly.
-            // The system hands us exactly one task and we only ever touch it
-            // serially on the main actor, so an unchecked box is safe here.
-            let boxedTask = UncheckedSendableBox(appRefreshTask)
-            Task { @MainActor in
-                self?.handle(task: boxedTask.value)
-            }
+            self?.handle(task: appRefreshTask)
         }
     }
 
@@ -100,17 +95,5 @@ final class SystemBackgroundRefreshScheduler: BackgroundRefreshScheduling {
         task.expirationHandler = {
             work.cancel()
         }
-    }
-}
-
-/// Bridges a non-`Sendable` value across a concurrency boundary. Used to carry
-/// the `BGTask` from the non-isolated launch handler onto the main actor. Safe
-/// because the boxed task is owned solely by this scheduler and accessed
-/// serially on the main actor.
-private struct UncheckedSendableBox<Value>: @unchecked Sendable {
-    let value: Value
-
-    init(_ value: Value) {
-        self.value = value
     }
 }

--- a/Baby Tracker/App/SystemBackgroundRefreshScheduler.swift
+++ b/Baby Tracker/App/SystemBackgroundRefreshScheduler.swift
@@ -49,8 +49,13 @@ final class SystemBackgroundRefreshScheduler: BackgroundRefreshScheduling {
                 task.setTaskCompleted(success: false)
                 return
             }
+            // `task` is a non-Sendable value handed to this non-isolated
+            // closure, so it can't be sent across the actor hop directly.
+            // The system hands us exactly one task and we only ever touch it
+            // serially on the main actor, so an unchecked box is safe here.
+            let boxedTask = UncheckedSendableBox(appRefreshTask)
             Task { @MainActor in
-                self?.handle(task: appRefreshTask)
+                self?.handle(task: boxedTask.value)
             }
         }
     }
@@ -95,5 +100,17 @@ final class SystemBackgroundRefreshScheduler: BackgroundRefreshScheduling {
         task.expirationHandler = {
             work.cancel()
         }
+    }
+}
+
+/// Bridges a non-`Sendable` value across a concurrency boundary. Used to carry
+/// the `BGTask` from the non-isolated launch handler onto the main actor. Safe
+/// because the boxed task is owned solely by this scheduler and accessed
+/// serially on the main actor.
+private struct UncheckedSendableBox<Value>: @unchecked Sendable {
+    let value: Value
+
+    init(_ value: Value) {
+        self.value = value
     }
 }


### PR DESCRIPTION
## Problem

TestFlight crash (1.0.2 / build 134) on iOS 26.5, happening **in the background**:

```
Exception Type:  EXC_BREAKPOINT (SIGTRAP)
Thread 11 Crashed:
0  libdispatch.dylib            _dispatch_assert_queue_fail
2  libdispatch.dylib            dispatch_assert_queue
3  libswift_Concurrency.dylib   _swift_task_checkIsolatedSwift
4  libswift_Concurrency.dylib   swift_task_isCurrentExecutorWithFlagsImpl
5  Baby Tracker                 closure #1 in SystemBackgroundRefreshScheduler.registerLaunchHandler(_:)
6  Baby Tracker                 thunk for @escaping @callee_guaranteed (@guaranteed BGTask) -> ()
7  BackgroundTasks              -[BGTaskScheduler _runTask:registration:]_block_invoke_5
```

## Root cause

The app target builds with `SWIFT_DEFAULT_ACTOR_ISOLATION = MainActor` (Swift 6 mode — see `Config/App.xcconfig`). Under that setting the `BGTaskScheduler` launch-handler closure is implicitly `@MainActor`-isolated, so the Swift runtime inserts an executor-isolation check at the closure's entry point (the `swift_task_isCurrentExecutor` → `dispatch_assert_queue` frames above).

`BGTaskScheduler.register(..., using: nil, ...)` invokes that handler on its **private background queue**. The main-queue assertion therefore fails and traps with `EXC_BREAKPOINT` — *before* any of our code runs, which is why the original `Task { @MainActor in … }` hop inside the handler never got a chance to help.

## Fix

Register with `using: .main` so the trivial launch handler runs on the **main queue**, which satisfies the MainActor executor check instead of tripping it. The closure stays `@MainActor`-isolated (compiles exactly like the shipped code), and the actual async refresh work already runs on the main actor, so behavior is unchanged apart from where the thin handler is dispatched.

## Verification

This target imports `BackgroundTasks` (Apple-only) and can't be compiled on the Linux CI container — relying on the `unit-tests` GitHub Actions job (Xcode 26.3) to confirm the build.

https://claude.ai/code/session_013ro4sfGzvVT1X4AqgxVgyi