### PR TITLE
Phase 0: performance instrumentation (no behavior change)

### DIFF
--- a/Baby Tracker/App/AppContainer.swift
+++ b/Baby Tracker/App/AppContainer.swift
@@ -11,11 +11,21 @@ struct AppContainer {
     let backgroundRefreshScheduler: any BackgroundRefreshScheduling
 
     init(processInfo: ProcessInfo = .processInfo) {
+        // PHASE 0 INSTRUMENTATION — the whole synchronous launch composition root,
+        // including ModelContainer creation and the blocking `appModel.load` below.
+        PerfLog.event("AppContainer.init started")
+        let launchStart = PerfLog.now()
+        defer {
+            let ms = PerfLog.elapsedMs(since: launchStart)
+            PerfLog.event("AppContainer.init finished in \(String(format: "%.2f", ms)) ms")
+        }
         let launchConfiguration = LaunchConfiguration(processInfo: processInfo)
         let userDefaults = launchConfiguration.makeUserDefaults()
-        let store = try! BabyTrackerModelStore(
-            isStoredInMemoryOnly: launchConfiguration.usesInMemoryStore
-        )
+        let store = try! PerfLog.measure("AppContainer.BabyTrackerModelStore.init") {
+            try BabyTrackerModelStore(
+                isStoredInMemoryOnly: launchConfiguration.usesInMemoryStore
+            )
+        }
         let childRepository = SwiftDataChildRepository(store: store)
         let userIdentityRepository = SwiftDataUserIdentityRepository(store: store, userDefaults: userDefaults)
         let membershipRepository = SwiftDataMembershipRepository(store: store)

--- a/Packages/BabyTrackerDomain/Sources/BabyTrackerDomain/PerfLog.swift
+++ b/Packages/BabyTrackerDomain/Sources/BabyTrackerDomain/PerfLog.swift
@@ -1,0 +1,99 @@
+import Dispatch
+import Foundation
+import os
+
+/// Lightweight, dependency-free performance instrumentation used to measure the
+/// app's launch / refresh / data-loading hot paths.
+///
+/// Everything funnels through a single `os.Logger` category ("Performance") and a
+/// matching `OSSignposter`, so the output is:
+///   - filterable in Console.app / `log stream` via
+///     `subsystem == "com.adappt.BabyTracker" && category == "Performance"`
+///   - visible as intervals in Instruments (os_signpost)
+///
+/// The log lines are intentionally **stable** (fixed prefixes + labels) so that a
+/// "before" capture and an "after" capture can be diffed mechanically. When the
+/// data-loading refactor lands, the same lines keep emitting and the numbers move.
+///
+/// To pull a capture from a device build:
+///   log stream --predicate 'subsystem == "com.adappt.BabyTracker" && category == "Performance"' --info
+/// or in Xcode, filter the console on `[Perf]`.
+public enum PerfLog {
+    public static let subsystem = "com.adappt.BabyTracker"
+
+    public static let logger = Logger(subsystem: subsystem, category: "Performance")
+    public static let signposter = OSSignposter(subsystem: subsystem, category: "Performance")
+
+    /// Process-lifetime call counters keyed by label. A fresh launch resets them,
+    /// which is what we want: the delta across a single `refresh` reveals how many
+    /// times a method (e.g. `loadTimeline`) was invoked during that refresh.
+    private static let counters = OSAllocatedUnfairLock(initialState: [String: Int]())
+
+    /// Increments and returns the running total for `label`.
+    @discardableResult
+    public static func increment(_ label: String) -> Int {
+        counters.withLock { store in
+            let next = (store[label] ?? 0) + 1
+            store[label] = next
+            return next
+        }
+    }
+
+    /// Current running total for `label` without mutating it. Read it before and
+    /// after a span to log how many calls happened inside that span.
+    public static func total(_ label: String) -> Int {
+        counters.withLock { $0[label] ?? 0 }
+    }
+
+    /// Emit a one-off, stable, public log line (no timing).
+    public static func event(_ message: String) {
+        logger.info("[Perf] \(message, privacy: .public)")
+    }
+
+    /// Monotonic timestamp token (nanoseconds) for manual `defer`-based timing,
+    /// so call sites don't need to import Dispatch.
+    public static func now() -> UInt64 {
+        DispatchTime.now().uptimeNanoseconds
+    }
+
+    /// Milliseconds elapsed since a token returned by `now()`.
+    public static func elapsedMs(since start: UInt64) -> Double {
+        Double(DispatchTime.now().uptimeNanoseconds - start) / 1_000_000
+    }
+
+    /// Time a synchronous block, emit a signpost interval and a `[Perf]` line with
+    /// elapsed milliseconds. Returns the block's value.
+    @discardableResult
+    public static func measure<T>(_ label: String, _ body: () throws -> T) rethrows -> T {
+        let id = signposter.makeSignpostID()
+        let state = signposter.beginInterval("span", id: id, "\(label)")
+        let start = DispatchTime.now().uptimeNanoseconds
+        defer {
+            let elapsedMs = Double(DispatchTime.now().uptimeNanoseconds - start) / 1_000_000
+            signposter.endInterval("span", state)
+            logger.info("[Perf] \(label, privacy: .public) took \(elapsedMs, format: .fixed(precision: 2), privacy: .public) ms")
+        }
+        return try body()
+    }
+
+    /// Async variant of `measure`.
+    @discardableResult
+    public static func measureAsync<T>(_ label: String, _ body: () async throws -> T) async rethrows -> T {
+        let id = signposter.makeSignpostID()
+        let state = signposter.beginInterval("span", id: id, "\(label)")
+        let start = DispatchTime.now().uptimeNanoseconds
+        defer {
+            let elapsedMs = Double(DispatchTime.now().uptimeNanoseconds - start) / 1_000_000
+            signposter.endInterval("span", state)
+            logger.info("[Perf] \(label, privacy: .public) took \(elapsedMs, format: .fixed(precision: 2), privacy: .public) ms")
+        }
+        return try await body()
+    }
+
+    /// Convenience for the very common "this method was called; here's its running
+    /// total" marker. Use a stable `label` so before/after diffs line up.
+    public static func tick(_ label: String) {
+        let count = increment(label)
+        logger.info("[Perf] call \(label, privacy: .public) #\(count, privacy: .public)")
+    }
+}

--- a/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/AdvancedSummaryMetricsCalculator.swift
+++ b/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/AdvancedSummaryMetricsCalculator.swift
@@ -8,6 +8,13 @@ public enum AdvancedSummaryMetricsCalculator {
         now: Date = .now,
         calendar: Calendar = .autoupdatingCurrent
     ) -> AdvancedSummaryViewState {
+        // PHASE 0 INSTRUMENTATION — sorts + filters the full array; recomputed per
+        // render / selection change.
+        let perfStart = PerfLog.now()
+        defer {
+            let ms = PerfLog.elapsedMs(since: perfStart)
+            PerfLog.event("AdvancedSummaryMetricsCalculator.makeViewState took \(String(format: "%.2f", ms)) ms (events=\(events.count))")
+        }
         let filteredEvents = filter(
             events: events.sorted { $0.metadata.occurredAt < $1.metadata.occurredAt },
             selection: selection,

--- a/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/AppModel.swift
+++ b/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/AppModel.swift
@@ -135,8 +135,14 @@ public final class AppModel {
     }
 
     public func load(performLaunchSync: Bool = true) {
-        refresh(selecting: nil)
-        rescheduleAllDriftNotifications()
+        // PHASE 0 INSTRUMENTATION — `load` is the synchronous launch-critical path
+        // (called from AppContainer at startup). The measured span covers the
+        // blocking work done before the first frame settles.
+        PerfLog.tick("AppModel.load")
+        PerfLog.measure("AppModel.load (sync portion)") {
+            refresh(selecting: nil)
+            rescheduleAllDriftNotifications()
+        }
         Task { @MainActor in
             await refreshReminderNotificationAuthorization()
             await refreshPendingMedicationReminders()
@@ -147,7 +153,9 @@ public final class AppModel {
         }
 
         Task { @MainActor in
+            let syncStart = PerfLog.now()
             await runSyncRefresh { await self.syncEngine.prepareForLaunch() }
+            PerfLog.event("AppModel.syncEngine.prepareForLaunch took \(String(format: "%.2f", PerfLog.elapsedMs(since: syncStart))) ms")
         }
     }
 
@@ -1296,6 +1304,10 @@ public final class AppModel {
     private func scheduleInactivityDriftNotificationIfNeededAsync() async {
         guard isReminderNotificationsEnabled else { return }
         guard let child = currentChild else { return }
+        // PHASE 0 INSTRUMENTATION — full O(n) scan to find the latest event, and the
+        // entire `events` array is handed to the use case though only the latest is used.
+        PerfLog.tick("AppModel.scheduleInactivityDriftNotification")
+        PerfLog.event("AppModel.scheduleInactivityDriftNotification passing allEvents=\(events.count)")
         guard let lastEvent = events.max(by: { $0.metadata.occurredAt < $1.metadata.occurredAt }) else { return }
         await ScheduleInactivityDriftNotificationUseCase.execute(
             input: .init(
@@ -1358,6 +1370,20 @@ public final class AppModel {
     }
 
     private func refresh(selecting selectedChildID: UUID?) {
+        // PHASE 0 INSTRUMENTATION — `refresh` runs on launch, child switch, and
+        // after every sync. The defer logs total wall-clock plus how many times
+        // the repository was hit *during this single refresh* (the ~8× re-load),
+        // regardless of which return path is taken.
+        PerfLog.tick("AppModel.refresh")
+        let timelineCallsBefore = PerfLog.total("EventRepository.loadTimeline")
+        let dayCallsBefore = PerfLog.total("EventRepository.loadEvents(on:)")
+        let refreshStart = PerfLog.now()
+        defer {
+            let elapsedMs = PerfLog.elapsedMs(since: refreshStart)
+            let timelineCalls = PerfLog.total("EventRepository.loadTimeline") - timelineCallsBefore
+            let dayCalls = PerfLog.total("EventRepository.loadEvents(on:)") - dayCallsBefore
+            PerfLog.event("AppModel.refresh finished in \(String(format: "%.2f", elapsedMs)) ms — loadTimeline×\(timelineCalls), loadEvents(on:)×\(dayCalls), events=\(events.count)")
+        }
         do {
             localUser = try userIdentityRepository.loadLocalUser()
 
@@ -1407,12 +1433,16 @@ public final class AppModel {
             childSelectionStore.saveSelectedChildID(currentSummary.child.id)
             synchronizeTimelineSelection(for: currentSummary.child.id)
 
-            let visibleEvents = try loadVisibleEvents(for: currentSummary.child.id)
-            let builtTimelinePages = try loadTimelinePages(
-                child: currentSummary.child,
-                for: currentSummary.child.id,
-                days: timelineVisibleDays(for: timelineSelectedDay)
-            )
+            let visibleEvents = try PerfLog.measure("AppModel.loadVisibleEvents") {
+                try loadVisibleEvents(for: currentSummary.child.id)
+            }
+            let builtTimelinePages = try PerfLog.measure("AppModel.loadTimelinePages") {
+                try loadTimelinePages(
+                    child: currentSummary.child,
+                    for: currentSummary.child.id,
+                    days: timelineVisibleDays(for: timelineSelectedDay)
+                )
+            }
             let currentActiveSleep = try eventRepository.loadActiveSleepEvent(for: currentSummary.child.id)
             let childMemberships = try membershipRepository.loadMemberships(for: currentSummary.child.id)
             let userIDs = childMemberships.map(\.userID)
@@ -1445,10 +1475,12 @@ public final class AppModel {
                     statusLabel: invite.acceptanceStatus == .pending ? "Pending invitation" : "Invited"
                 )
             }
-            let stripDataset = buildTimelineStripDatasetUseCase.execute(
-                events: visibleEvents,
-                calendar: calendar
-            )
+            let stripDataset = PerfLog.measure("AppModel.buildTimelineStripDataset") {
+                buildTimelineStripDatasetUseCase.execute(
+                    events: visibleEvents,
+                    calendar: calendar
+                )
+            }
 
             // Set flat observable properties — triggers ViewModel recomputation
             events = visibleEvents
@@ -1488,6 +1520,10 @@ public final class AppModel {
     }
 
     private func synchronizeFeedLiveActivity() {
+        // PHASE 0 INSTRUMENTATION — feeds the full event array into Feed/Sleep/Nappy
+        // summary calculators, each of which does its own O(n) scan.
+        PerfLog.tick("AppModel.synchronizeFeedLiveActivity")
+        PerfLog.measure("AppModel.synchronizeFeedLiveActivity") {
         UpdateFeedLiveActivityUseCase.execute(
             events: events,
             child: currentChild,
@@ -1495,6 +1531,7 @@ public final class AppModel {
             isLiveActivityEnabled: isLiveActivityEnabled,
             liveActivityManager: liveActivityManager
         )
+        }
     }
 
     private func clearProfileData() {

--- a/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/TodaySummaryCalculator.swift
+++ b/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/TodaySummaryCalculator.swift
@@ -21,6 +21,13 @@ public enum TodaySummaryCalculator {
         referenceNow: Date = .now,
         calendar: Calendar = .autoupdatingCurrent
     ) -> TodaySummaryData {
+        // PHASE 0 INSTRUMENTATION — scans the full event array ~8× (today + 7 days)
+        // plus per-hour cumulative series; recomputed per render / date change.
+        let perfStart = PerfLog.now()
+        defer {
+            let ms = PerfLog.elapsedMs(since: perfStart)
+            PerfLog.event("TodaySummaryCalculator.makeData took \(String(format: "%.2f", ms)) ms (events=\(allEvents.count))")
+        }
         let selectedDay = calendar.startOfDay(for: day)
         let isSelectedDayToday = calendar.isDate(selectedDay, inSameDayAs: referenceNow)
         let effectiveNow = if isSelectedDayToday {

--- a/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/TrendsSummaryCalculator.swift
+++ b/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/TrendsSummaryCalculator.swift
@@ -8,6 +8,13 @@ public enum TrendsSummaryCalculator {
         now: Date = .now,
         calendar: Calendar = .autoupdatingCurrent
     ) -> TrendsSummaryData {
+        // PHASE 0 INSTRUMENTATION — sorts + groups the full array and maps across
+        // every day in the range; recomputed per render / range change.
+        let perfStart = PerfLog.now()
+        defer {
+            let ms = PerfLog.elapsedMs(since: perfStart)
+            PerfLog.event("TrendsSummaryCalculator.makeData took \(String(format: "%.2f", ms)) ms (events=\(events.count))")
+        }
         let sortedEvents = events.sorted { $0.metadata.occurredAt < $1.metadata.occurredAt }
         let rangeEvents = filter(events: sortedEvents, range: range, now: now, calendar: calendar)
         let dates = makeDates(range: range, events: rangeEvents, now: now, calendar: calendar)

--- a/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/ViewModels/EventHistoryViewModel.swift
+++ b/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/ViewModels/EventHistoryViewModel.swift
@@ -22,26 +22,30 @@ public final class EventHistoryViewModel {
 
     public var sections: [EventHistorySectionViewState] {
         guard let child = appModel.currentChild else { return [] }
-        let filter = appModel.activeEventFilter
-        let filtered = filter.isEmpty
-            ? appModel.events
-            : appModel.events.filter { filter.matches($0) }
+        // PHASE 0 INSTRUMENTATION — filter O(n) + group O(n) + per-day card build +
+        // sort O(n log n), recomputed on every body access with no memoization.
+        return PerfLog.measure("EventHistoryViewModel.sections") {
+            let filter = appModel.activeEventFilter
+            let filtered = filter.isEmpty
+                ? appModel.events
+                : appModel.events.filter { filter.matches($0) }
 
-        let grouped = Dictionary(grouping: filtered) { event in
-            calendar.startOfDay(for: event.metadata.occurredAt)
-        }
-
-        return grouped
-            .map { day, events in
-                EventHistorySectionViewState(
-                    date: day,
-                    events: BuildEventCardsUseCase.execute(
-                        events: events,
-                        preferredFeedVolumeUnit: child.preferredFeedVolumeUnit
-                    )
-                )
+            let grouped = Dictionary(grouping: filtered) { event in
+                calendar.startOfDay(for: event.metadata.occurredAt)
             }
-            .sorted { $0.date > $1.date }
+
+            return grouped
+                .map { day, events in
+                    EventHistorySectionViewState(
+                        date: day,
+                        events: BuildEventCardsUseCase.execute(
+                            events: events,
+                            preferredFeedVolumeUnit: child.preferredFeedVolumeUnit
+                        )
+                    )
+                }
+                .sorted { $0.date > $1.date }
+        }
     }
 
     public var activeFilter: EventFilter {

--- a/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/ViewModels/HomeViewModel.swift
+++ b/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/ViewModels/HomeViewModel.swift
@@ -27,22 +27,29 @@ public final class HomeViewModel {
                 lastSleep: nil
             )
         }
-        return BuildCurrentStatusViewStateUseCase.execute(
-            events: appModel.events,
-            child: child,
-            enabledEventKinds: appModel.enabledEventKinds,
-            activeSleep: appModel.activeSleep
-        )
+        // PHASE 0 INSTRUMENTATION — recomputed on every body access over the full
+        // event array with no memoization (one [Perf] line per render).
+        return PerfLog.measure("HomeViewModel.currentStatus") {
+            BuildCurrentStatusViewStateUseCase.execute(
+                events: appModel.events,
+                child: child,
+                enabledEventKinds: appModel.enabledEventKinds,
+                activeSleep: appModel.activeSleep
+            )
+        }
     }
 
     public var recentEvents: [EventCardViewState] {
         guard let child = appModel.currentChild else { return [] }
-        return Array(
-            BuildEventCardsUseCase.execute(
-                events: appModel.events,
-                preferredFeedVolumeUnit: child.preferredFeedVolumeUnit
-            ).prefix(6)
-        )
+        // PHASE 0 INSTRUMENTATION — builds cards from the full array just to show 6.
+        return PerfLog.measure("HomeViewModel.recentEvents") {
+            Array(
+                BuildEventCardsUseCase.execute(
+                    events: appModel.events,
+                    preferredFeedVolumeUnit: child.preferredFeedVolumeUnit
+                ).prefix(6)
+            )
+        }
     }
 
     public var syncStatus: CloudKitStatusViewState {
@@ -79,6 +86,8 @@ public final class HomeViewModel {
         let preferredUnit = child.preferredFeedVolumeUnit
         let activeSleepID = appModel.activeSleep?.id
 
+        // PHASE 0 INSTRUMENTATION — per-render transform + date formatting.
+        return PerfLog.measure("HomeViewModel.todayTimelineEvents") {
         return Array(appModel.events.prefix(6)).compactMap { event -> HomeTimelineEventViewState? in
             let id: UUID
             let kind: BabyEventKind
@@ -119,6 +128,7 @@ public final class HomeViewModel {
                 timeText: occurredAt.formatted(.dateTime.hour().minute()),
                 isOngoing: activeSleepID.map { $0 == id } ?? false
             )
+        }
         }
     }
 }

--- a/Packages/BabyTrackerPersistence/Sources/BabyTrackerPersistence/SwiftDataEventRepository.swift
+++ b/Packages/BabyTrackerPersistence/Sources/BabyTrackerPersistence/SwiftDataEventRepository.swift
@@ -68,83 +68,77 @@ public final class SwiftDataEventRepository: EventRepository {
         for childID: UUID,
         includingDeleted: Bool = false
     ) throws -> [BabyEvent] {
-        var timeline: [BabyEvent] = []
+        // PHASE 0 INSTRUMENTATION — measures the full-table-scan cost. `fetched`
+        // counts rows materialised from the store across all six event types;
+        // `surviving` counts rows that pass the childID + soft-delete filter. A
+        // large fetched/surviving gap is the fetch-then-discard waste the refactor
+        // removes, and the call counter exposes the repeated re-loads per refresh.
+        // Behaviour below is identical to the original implementation.
+        PerfLog.tick("EventRepository.loadTimeline")
+        return try PerfLog.measure("EventRepository.loadTimeline") {
+            var timeline: [BabyEvent] = []
+            var fetched = 0
+            var surviving = 0
 
-        timeline.append(contentsOf: try modelContext.fetch(FetchDescriptor<StoredBathEvent>())
-            .filter { storedEvent in
+            let baths = try modelContext.fetch(FetchDescriptor<StoredBathEvent>())
+            fetched += baths.count
+            let visibleBaths = baths.filter { storedEvent in
                 storedEvent.childID == childID &&
-                (
-                    includingDeleted ||
-                    !isSoftDeleted(
-                        isDeleted: storedEvent.isDeleted,
-                        deletedAt: storedEvent.deletedAt
-                    )
-                )
+                (includingDeleted || !isSoftDeleted(isDeleted: storedEvent.isDeleted, deletedAt: storedEvent.deletedAt))
             }
-            .map { .bath(mapBath($0)) })
-        timeline.append(contentsOf: try modelContext.fetch(FetchDescriptor<StoredBreastFeedEvent>())
-            .filter { storedEvent in
-                storedEvent.childID == childID &&
-                (
-                    includingDeleted ||
-                    !isSoftDeleted(
-                        isDeleted: storedEvent.isDeleted,
-                        deletedAt: storedEvent.deletedAt
-                    )
-                )
-            }
-            .map { .breastFeed(try mapBreastFeed($0)) })
-        timeline.append(contentsOf: try modelContext.fetch(FetchDescriptor<StoredBottleFeedEvent>())
-            .filter { storedEvent in
-                storedEvent.childID == childID &&
-                (
-                    includingDeleted ||
-                    !isSoftDeleted(
-                        isDeleted: storedEvent.isDeleted,
-                        deletedAt: storedEvent.deletedAt
-                    )
-                )
-            }
-            .map { .bottleFeed(try mapBottleFeed($0)) })
-        timeline.append(contentsOf: try modelContext.fetch(FetchDescriptor<StoredSleepEvent>())
-            .filter { storedEvent in
-                storedEvent.childID == childID &&
-                (
-                    includingDeleted ||
-                    !isSoftDeleted(
-                        isDeleted: storedEvent.isDeleted,
-                        deletedAt: storedEvent.deletedAt
-                    )
-                )
-            }
-            .map { .sleep(try mapSleep($0)) })
-        timeline.append(contentsOf: try modelContext.fetch(FetchDescriptor<StoredNappyEvent>())
-            .filter { storedEvent in
-                storedEvent.childID == childID &&
-                (
-                    includingDeleted ||
-                    !isSoftDeleted(
-                        isDeleted: storedEvent.isDeleted,
-                        deletedAt: storedEvent.deletedAt
-                    )
-                )
-            }
-            .map { .nappy(try mapNappy($0)) })
-        timeline.append(contentsOf: try modelContext.fetch(FetchDescriptor<StoredMedicationEvent>())
-            .filter { storedEvent in
-                storedEvent.childID == childID &&
-                (
-                    includingDeleted ||
-                    !isSoftDeleted(
-                        isDeleted: storedEvent.isDeleted,
-                        deletedAt: storedEvent.deletedAt
-                    )
-                )
-            }
-            .map { .medication(try mapMedication($0)) })
+            surviving += visibleBaths.count
+            timeline.append(contentsOf: visibleBaths.map { .bath(mapBath($0)) })
 
-        return timeline.sorted { left, right in
-            left.metadata.occurredAt > right.metadata.occurredAt
+            let breastFeeds = try modelContext.fetch(FetchDescriptor<StoredBreastFeedEvent>())
+            fetched += breastFeeds.count
+            let visibleBreastFeeds = breastFeeds.filter { storedEvent in
+                storedEvent.childID == childID &&
+                (includingDeleted || !isSoftDeleted(isDeleted: storedEvent.isDeleted, deletedAt: storedEvent.deletedAt))
+            }
+            surviving += visibleBreastFeeds.count
+            timeline.append(contentsOf: try visibleBreastFeeds.map { .breastFeed(try mapBreastFeed($0)) })
+
+            let bottleFeeds = try modelContext.fetch(FetchDescriptor<StoredBottleFeedEvent>())
+            fetched += bottleFeeds.count
+            let visibleBottleFeeds = bottleFeeds.filter { storedEvent in
+                storedEvent.childID == childID &&
+                (includingDeleted || !isSoftDeleted(isDeleted: storedEvent.isDeleted, deletedAt: storedEvent.deletedAt))
+            }
+            surviving += visibleBottleFeeds.count
+            timeline.append(contentsOf: try visibleBottleFeeds.map { .bottleFeed(try mapBottleFeed($0)) })
+
+            let sleeps = try modelContext.fetch(FetchDescriptor<StoredSleepEvent>())
+            fetched += sleeps.count
+            let visibleSleeps = sleeps.filter { storedEvent in
+                storedEvent.childID == childID &&
+                (includingDeleted || !isSoftDeleted(isDeleted: storedEvent.isDeleted, deletedAt: storedEvent.deletedAt))
+            }
+            surviving += visibleSleeps.count
+            timeline.append(contentsOf: try visibleSleeps.map { .sleep(try mapSleep($0)) })
+
+            let nappies = try modelContext.fetch(FetchDescriptor<StoredNappyEvent>())
+            fetched += nappies.count
+            let visibleNappies = nappies.filter { storedEvent in
+                storedEvent.childID == childID &&
+                (includingDeleted || !isSoftDeleted(isDeleted: storedEvent.isDeleted, deletedAt: storedEvent.deletedAt))
+            }
+            surviving += visibleNappies.count
+            timeline.append(contentsOf: try visibleNappies.map { .nappy(try mapNappy($0)) })
+
+            let medications = try modelContext.fetch(FetchDescriptor<StoredMedicationEvent>())
+            fetched += medications.count
+            let visibleMedications = medications.filter { storedEvent in
+                storedEvent.childID == childID &&
+                (includingDeleted || !isSoftDeleted(isDeleted: storedEvent.isDeleted, deletedAt: storedEvent.deletedAt))
+            }
+            surviving += visibleMedications.count
+            timeline.append(contentsOf: try visibleMedications.map { .medication(try mapMedication($0)) })
+
+            PerfLog.event("EventRepository.loadTimeline fetched=\(fetched) surviving=\(surviving)")
+
+            return timeline.sorted { left, right in
+                left.metadata.occurredAt > right.metadata.occurredAt
+            }
         }
     }
 
@@ -154,15 +148,21 @@ public final class SwiftDataEventRepository: EventRepository {
         calendar: Calendar = .current,
         includingDeleted: Bool = false
     ) throws -> [BabyEvent] {
-        let startOfDay = calendar.startOfDay(for: day)
-        guard let endOfDay = calendar.date(byAdding: .day, value: 1, to: startOfDay) else {
-            return []
-        }
-
-        return try loadTimeline(for: childID, includingDeleted: includingDeleted)
-            .filter { event in
-                eventOverlapsDay(event, startOfDay: startOfDay, endOfDay: endOfDay)
+        // PHASE 0 INSTRUMENTATION — each call re-runs the full `loadTimeline`
+        // above and then discards everything outside `day`; the call counter shows
+        // how many times this happens per refresh (one per visible timeline day).
+        PerfLog.tick("EventRepository.loadEvents(on:)")
+        return try PerfLog.measure("EventRepository.loadEvents(on:)") {
+            let startOfDay = calendar.startOfDay(for: day)
+            guard let endOfDay = calendar.date(byAdding: .day, value: 1, to: startOfDay) else {
+                return []
             }
+
+            return try loadTimeline(for: childID, includingDeleted: includingDeleted)
+                .filter { event in
+                    eventOverlapsDay(event, startOfDay: startOfDay, endOfDay: endOfDay)
+                }
+        }
     }
 
     private func eventOverlapsDay(
@@ -189,18 +189,22 @@ public final class SwiftDataEventRepository: EventRepository {
     }
 
     public func loadActiveSleepEvent(for childID: UUID) throws -> SleepEvent? {
-        try modelContext.fetch(FetchDescriptor<StoredSleepEvent>())
-            .filter { storedEvent in
-                storedEvent.childID == childID &&
-                !isSoftDeleted(
-                    isDeleted: storedEvent.isDeleted,
-                    deletedAt: storedEvent.deletedAt
-                ) &&
-                storedEvent.endedAt == nil
-            }
-            .map(mapSleep)
-            .sorted { left, right in left.startedAt > right.startedAt }
-            .first
+        // PHASE 0 INSTRUMENTATION — another full StoredSleepEvent table scan per refresh.
+        PerfLog.tick("EventRepository.loadActiveSleepEvent")
+        return try PerfLog.measure("EventRepository.loadActiveSleepEvent") {
+            try modelContext.fetch(FetchDescriptor<StoredSleepEvent>())
+                .filter { storedEvent in
+                    storedEvent.childID == childID &&
+                    !isSoftDeleted(
+                        isDeleted: storedEvent.isDeleted,
+                        deletedAt: storedEvent.deletedAt
+                    ) &&
+                    storedEvent.endedAt == nil
+                }
+                .map(mapSleep)
+                .sorted { left, right in left.startedAt > right.startedAt }
+                .first
+        }
     }
 
     public func softDeleteEvent(


### PR DESCRIPTION
## Phase 0 — Measurement only (no behavior change)

First of a stacked pair fixing the post-launch slowdown with 2500+ events. This PR adds instrumentation **only** — no logic changes — so we can build it, capture a **"before"** baseline on device, and compare against Phase 1 using identical, stable log lines.

**Phase 1 is stacked on top of this:** #276.

### What it adds
A small `PerfLog` utility (`BabyTrackerDomain`) routing everything through one `os.Logger` / `OSSignposter` category `"Performance"`:
- timing spans (ms) + Instruments signpost intervals
- process-lifetime **call counters** (the delta across one `refresh` exposes the repeated full-table re-loads)
- stable `[Perf]`-prefixed lines for mechanical before/after diffing

### Instrumented hot paths
- `AppContainer.init` — synchronous launch composition root + `ModelContainer` creation
- `AppModel.load` / `refresh` — sub-spans (`loadVisibleEvents`, `loadTimelinePages`, `loadActiveSleepEvent`, `buildTimelineStripDataset`, `synchronizeFeedLiveActivity`) + per-refresh repository call deltas
- `SwiftDataEventRepository.loadTimeline` / `loadEvents` / `loadActiveSleepEvent` — elapsed ms, **fetched vs surviving** rows, call counters
- `HomeViewModel` / `EventHistoryViewModel` computed properties and the Today/Trends/Advanced calculators — per-render cost
- inactivity drift scheduling — logs the full-array hand-off

### Capture a baseline
```
log stream --predicate 'subsystem == "com.adappt.BabyTracker" && category == "Performance"' --info
```
or filter the Xcode console on `[Perf]`. (Already tagged as `TestFlight-44`.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01D1BQw2PzSQwUE28NoTHHBB)_