### PR TITLE
Fix app-wide lag at ~2500 events via predicate-based queries and view-layer caching

### DIFF
--- a/Baby TrackerTests/EventRepositoryTests.swift
+++ b/Baby TrackerTests/EventRepositoryTests.swift
@@ -461,6 +461,148 @@ struct EventRepositoryTests {
         #expect(firstDayEvents.map(\.id) == [sleep.id])
         #expect(secondDayEvents.map(\.id) == [sleep.id])
     }
+
+    @Test
+    func loadEventsIncludesBreastFeedOnBothDaysWhenItSpansMidnight() throws {
+        let harness = try RepositoryHarness()
+        defer { harness.cleanUp() }
+
+        let childID = UUID()
+        let userID = UUID()
+        let calendar = Calendar(identifier: .gregorian)
+        let dayOne = Date(timeIntervalSince1970: 1_728_000_000)
+        let startOfDayOne = calendar.startOfDay(for: dayOne)
+        let startOfDayTwo = try #require(
+            calendar.date(byAdding: .day, value: 1, to: startOfDayOne)
+        )
+        let feedStart = try #require(
+            calendar.date(byAdding: .hour, value: 23, to: startOfDayOne)
+        )
+        let feedEnd = try #require(
+            calendar.date(byAdding: .hour, value: 1, to: startOfDayTwo)
+        )
+
+        let feed = try BreastFeedEvent(
+            metadata: EventMetadata(
+                childID: childID,
+                occurredAt: feedEnd,
+                createdAt: feedEnd,
+                createdBy: userID
+            ),
+            side: nil,
+            startedAt: feedStart,
+            endedAt: feedEnd
+        )
+
+        try harness.repository.saveEvent(.breastFeed(feed))
+
+        let firstDayEvents = try harness.repository.loadEvents(
+            for: childID,
+            on: startOfDayOne,
+            calendar: calendar,
+            includingDeleted: false
+        )
+        let secondDayEvents = try harness.repository.loadEvents(
+            for: childID,
+            on: startOfDayTwo,
+            calendar: calendar,
+            includingDeleted: false
+        )
+
+        #expect(firstDayEvents.map(\.id) == [feed.id])
+        #expect(secondDayEvents.map(\.id) == [feed.id])
+    }
+
+    @Test
+    func loadEventsExcludesSoftDeletedEventsUnlessIncludingDeleted() throws {
+        let harness = try RepositoryHarness()
+        defer { harness.cleanUp() }
+
+        let childID = UUID()
+        let userID = UUID()
+        let calendar = Calendar(identifier: .gregorian)
+        let occurredAt = Date(timeIntervalSince1970: 20_000)
+        let day = calendar.startOfDay(for: occurredAt)
+
+        let bottle = try BottleFeedEvent(
+            metadata: EventMetadata(
+                childID: childID,
+                occurredAt: occurredAt,
+                createdAt: occurredAt,
+                createdBy: userID
+            ),
+            amountMilliliters: 90
+        )
+
+        try harness.repository.saveEvent(.bottleFeed(bottle))
+        try harness.repository.softDeleteEvent(
+            id: bottle.id,
+            deletedAt: occurredAt.addingTimeInterval(60),
+            deletedBy: userID
+        )
+
+        let visibleDayEvents = try harness.repository.loadEvents(
+            for: childID,
+            on: day,
+            calendar: calendar,
+            includingDeleted: false
+        )
+        let allDayEvents = try harness.repository.loadEvents(
+            for: childID,
+            on: day,
+            calendar: calendar,
+            includingDeleted: true
+        )
+
+        #expect(visibleDayEvents.isEmpty)
+        #expect(allDayEvents.map(\.id) == [bottle.id])
+    }
+
+    @Test
+    func loadTimelineAndLoadEventsDoNotLeakEventsAcrossChildren() throws {
+        let harness = try RepositoryHarness()
+        defer { harness.cleanUp() }
+
+        let childOneID = UUID()
+        let childTwoID = UUID()
+        let userID = UUID()
+        let calendar = Calendar(identifier: .gregorian)
+        let occurredAt = Date(timeIntervalSince1970: 30_000)
+        let day = calendar.startOfDay(for: occurredAt)
+
+        let childOneNappy = try NappyEvent(
+            metadata: EventMetadata(
+                childID: childOneID,
+                occurredAt: occurredAt,
+                createdAt: occurredAt,
+                createdBy: userID
+            ),
+            type: .dry
+        )
+        let childTwoNappy = try NappyEvent(
+            metadata: EventMetadata(
+                childID: childTwoID,
+                occurredAt: occurredAt,
+                createdAt: occurredAt,
+                createdBy: userID
+            ),
+            type: .dry
+        )
+
+        try harness.repository.saveEvent(.nappy(childOneNappy))
+        try harness.repository.saveEvent(.nappy(childTwoNappy))
+
+        let childOneTimeline = try harness.repository.loadTimeline(for: childOneID, includingDeleted: false)
+        let childOneDayEvents = try harness.repository.loadEvents(
+            for: childOneID,
+            on: day,
+            calendar: calendar,
+            includingDeleted: false
+        )
+
+        #expect(childOneTimeline.map(\.id) == [childOneNappy.id])
+        #expect(childOneDayEvents.map(\.id) == [childOneNappy.id])
+    }
 }
 
 extension EventRepositoryTests {

--- a/Baby TrackerTests/TestDoubles/InMemoryEventRepository.swift
+++ b/Baby TrackerTests/TestDoubles/InMemoryEventRepository.swift
@@ -40,11 +40,16 @@ final class InMemoryEventRepository: EventRepository {
         calendar: Calendar,
         includingDeleted: Bool
     ) throws -> [BabyEvent] {
-        store.events.values
+        let startOfDay = calendar.startOfDay(for: day)
+        guard let endOfDay = calendar.date(byAdding: .day, value: 1, to: startOfDay) else {
+            return []
+        }
+
+        return store.events.values
             .filter { event in
                 event.metadata.childID == childID &&
                 (includingDeleted || !event.metadata.isDeleted) &&
-                calendar.isDate(event.metadata.occurredAt, inSameDayAs: day)
+                event.overlaps(startOfDay: startOfDay, endOfDay: endOfDay)
             }
             .sorted { $0.metadata.occurredAt > $1.metadata.occurredAt }
     }

--- a/Packages/BabyTrackerDomain/Sources/BabyTrackerDomain/BabyEvent.swift
+++ b/Packages/BabyTrackerDomain/Sources/BabyTrackerDomain/BabyEvent.swift
@@ -45,4 +45,23 @@ public enum BabyEvent: Equatable, Identifiable, Sendable {
             .medication
         }
     }
+
+    /// Whether this event should be considered part of the given day.
+    ///
+    /// Instant events (bath/bottle feed/nappy/medication) use `occurredAt`.
+    /// Sessions with a duration (sleep, breast feed) overlap a day if any
+    /// part of the session falls within it, so a session spanning midnight
+    /// counts on both days. An active sleep session (nil `endedAt`) is
+    /// treated as still ongoing.
+    public func overlaps(startOfDay: Date, endOfDay: Date) -> Bool {
+        switch self {
+        case let .sleep(sleep):
+            let end = sleep.endedAt ?? Date.distantFuture
+            return sleep.startedAt < endOfDay && end > startOfDay
+        case let .breastFeed(feed):
+            return feed.startedAt < endOfDay && feed.endedAt > startOfDay
+        case .bath, .bottleFeed, .nappy, .medication:
+            return metadata.occurredAt >= startOfDay && metadata.occurredAt < endOfDay
+        }
+    }
 }

--- a/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/AppModel.swift
+++ b/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/AppModel.swift
@@ -1408,9 +1408,9 @@ public final class AppModel {
             synchronizeTimelineSelection(for: currentSummary.child.id)
 
             let visibleEvents = try loadVisibleEvents(for: currentSummary.child.id)
-            let builtTimelinePages = try loadTimelinePages(
+            let builtTimelinePages = loadTimelinePages(
                 child: currentSummary.child,
-                for: currentSummary.child.id,
+                from: visibleEvents,
                 days: timelineVisibleDays(for: timelineSelectedDay)
             )
             let currentActiveSleep = try eventRepository.loadActiveSleepEvent(for: currentSummary.child.id)
@@ -1551,25 +1551,21 @@ public final class AppModel {
 
     private func loadTimelinePages(
         child: Child,
-        for childID: UUID,
+        from events: [BabyEvent],
         days: [Date]
-    ) throws -> [TimelineDayGridPageState] {
-        try days.map { day in
+    ) -> [TimelineDayGridPageState] {
+        days.map { day in
             let dayStart = calendar.startOfDay(for: day)
-            let events = try eventRepository.loadEvents(
-                for: childID,
-                on: day,
-                calendar: calendar,
-                includingDeleted: false
-            ).filter { enabledEventKinds.contains($0.kind) }
+            let dayEnd = calendar.date(byAdding: .day, value: 1, to: dayStart) ?? dayStart
+            let dayEvents = events.filter { $0.overlaps(startOfDay: dayStart, endOfDay: dayEnd) }
             let gridDataset = buildTimelineDayGridDatasetUseCase.execute(
-                events: events,
+                events: dayEvents,
                 day: dayStart,
                 calendar: calendar
             )
             let grid = buildTimelineDayGridViewState(
                 from: gridDataset,
-                events: events,
+                events: dayEvents,
                 child: child,
                 day: dayStart
             )

--- a/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/ViewModels/EventHistoryViewModel.swift
+++ b/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/ViewModels/EventHistoryViewModel.swift
@@ -10,6 +10,17 @@ public final class EventHistoryViewModel {
     private let appModel: AppModel
     private let calendar = Calendar.current
 
+    // `sections` does a sort/filter/group-by-day pass plus per-event card
+    // building over the full event history. Cache it, keyed on the exact
+    // inputs that produced it, so unrelated `AppModel` mutations (or repeat
+    // SwiftUI body evaluations) don't force a full recompute.
+    @ObservationIgnored private var cachedSections: (
+        events: [BabyEvent],
+        filter: EventFilter,
+        preferredFeedVolumeUnit: FeedVolumeUnit,
+        value: [EventHistorySectionViewState]
+    )?
+
     public init(appModel: AppModel) {
         self.appModel = appModel
     }
@@ -22,26 +33,39 @@ public final class EventHistoryViewModel {
 
     public var sections: [EventHistorySectionViewState] {
         guard let child = appModel.currentChild else { return [] }
+        let currentEvents = appModel.events
         let filter = appModel.activeEventFilter
+        let preferredFeedVolumeUnit = child.preferredFeedVolumeUnit
+
+        if let cached = cachedSections,
+           cached.filter == filter,
+           cached.preferredFeedVolumeUnit == preferredFeedVolumeUnit,
+           cached.events == currentEvents {
+            return cached.value
+        }
+
         let filtered = filter.isEmpty
-            ? appModel.events
-            : appModel.events.filter { filter.matches($0) }
+            ? currentEvents
+            : currentEvents.filter { filter.matches($0) }
 
         let grouped = Dictionary(grouping: filtered) { event in
             calendar.startOfDay(for: event.metadata.occurredAt)
         }
 
-        return grouped
+        let value = grouped
             .map { day, events in
                 EventHistorySectionViewState(
                     date: day,
                     events: BuildEventCardsUseCase.execute(
                         events: events,
-                        preferredFeedVolumeUnit: child.preferredFeedVolumeUnit
+                        preferredFeedVolumeUnit: preferredFeedVolumeUnit
                     )
                 )
             }
             .sorted { $0.date > $1.date }
+
+        cachedSections = (currentEvents, filter, preferredFeedVolumeUnit, value)
+        return value
     }
 
     public var activeFilter: EventFilter {

--- a/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/ViewModels/HomeViewModel.swift
+++ b/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/ViewModels/HomeViewModel.swift
@@ -37,11 +37,9 @@ public final class HomeViewModel {
 
     public var recentEvents: [EventCardViewState] {
         guard let child = appModel.currentChild else { return [] }
-        return Array(
-            BuildEventCardsUseCase.execute(
-                events: appModel.events,
-                preferredFeedVolumeUnit: child.preferredFeedVolumeUnit
-            ).prefix(6)
+        return BuildEventCardsUseCase.execute(
+            events: Array(appModel.events.prefix(6)),
+            preferredFeedVolumeUnit: child.preferredFeedVolumeUnit
         )
     }
 

--- a/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/ViewModels/SummaryViewModel.swift
+++ b/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/ViewModels/SummaryViewModel.swift
@@ -12,6 +12,16 @@ public final class SummaryViewModel {
     private let fixedEvents: [BabyEvent]?
     private let fixedPreferredFeedVolumeUnit: FeedVolumeUnit?
 
+    // Caches below are keyed on the exact inputs that produced them. Each of
+    // the calculators they front does multiple O(n) passes over the full
+    // event history, so re-running them on every SwiftUI body evaluation
+    // (including ones triggered by unrelated `AppModel` state) is wasteful.
+    // These are `@ObservationIgnored` so writing to them from a computed
+    // property getter doesn't itself register as an observed mutation.
+    @ObservationIgnored private var cachedTodaySummary: (events: [BabyEvent], day: Date, value: TodaySummaryData)?
+    @ObservationIgnored private var cachedTrendsSummary: (events: [BabyEvent], range: TrendsTimeRange, value: TrendsSummaryData)?
+    @ObservationIgnored private var cachedAdvancedSummary: (events: [BabyEvent], selection: AdvancedSummarySelection, value: AdvancedSummaryViewState)?
+
     /// Production initialiser — events are sourced reactively from `appModel`.
     public init(appModel: AppModel) {
         self.appModel = appModel
@@ -45,4 +55,34 @@ public final class SummaryViewModel {
 
     public var emptyStateTitle: String { "No summary data yet" }
     public var emptyStateMessage: String { "Add events and your key trends will appear here." }
+
+    public func todaySummaryData(for day: Date) -> TodaySummaryData {
+        let currentEvents = events
+        if let cached = cachedTodaySummary, cached.day == day, cached.events == currentEvents {
+            return cached.value
+        }
+        let value = TodaySummaryCalculator.makeData(from: currentEvents, day: day)
+        cachedTodaySummary = (currentEvents, day, value)
+        return value
+    }
+
+    public func trendsSummaryData(for range: TrendsTimeRange) -> TrendsSummaryData {
+        let currentEvents = events
+        if let cached = cachedTrendsSummary, cached.range == range, cached.events == currentEvents {
+            return cached.value
+        }
+        let value = TrendsSummaryCalculator.makeData(from: currentEvents, range: range)
+        cachedTrendsSummary = (currentEvents, range, value)
+        return value
+    }
+
+    public func advancedSummaryViewState(for selection: AdvancedSummarySelection) -> AdvancedSummaryViewState {
+        let currentEvents = events
+        if let cached = cachedAdvancedSummary, cached.selection == selection, cached.events == currentEvents {
+            return cached.value
+        }
+        let value = AdvancedSummaryMetricsCalculator.makeViewState(from: currentEvents, selection: selection)
+        cachedAdvancedSummary = (currentEvents, selection, value)
+        return value
+    }
 }

--- a/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/AdvancedSummaryView.swift
+++ b/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/AdvancedSummaryView.swift
@@ -15,10 +15,7 @@ public struct AdvancedSummaryView: View {
     }
 
     public var body: some View {
-        let viewState = AdvancedSummaryMetricsCalculator.makeViewState(
-            from: viewModel.events,
-            selection: selection
-        )
+        let viewState = viewModel.advancedSummaryViewState(for: selection)
 
         ScrollView {
             VStack(alignment: .leading, spacing: 18) {

--- a/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/SummaryScreenView.swift
+++ b/Packages/BabyTrackerFeature/Sources/BabyTrackerFeature/Views/SummaryScreenView.swift
@@ -291,10 +291,7 @@ public struct SummaryScreenView: View {
     // MARK: - Today Tab
 
     private var todayTabContent: some View {
-        let data = TodaySummaryCalculator.makeData(
-            from: viewModel.events,
-            day: selectedDate
-        )
+        let data = viewModel.todaySummaryData(for: selectedDate)
 
         return Group {
             if viewModel.events.isEmpty {
@@ -684,7 +681,7 @@ public struct SummaryScreenView: View {
     // MARK: - Trends Tab
 
     private var trendsTabContent: some View {
-        let data = TrendsSummaryCalculator.makeData(from: viewModel.events, range: selectedTrendsRange)
+        let data = viewModel.trendsSummaryData(for: selectedTrendsRange)
         let hasData = data.dailyBottle.contains { $0.count > 0 }
             || data.dailyBreastFeed.contains { $0.sessionCount > 0 }
             || data.dailySleep.contains { $0.totalMinutes > 0 }

--- a/Packages/BabyTrackerPersistence/Sources/BabyTrackerPersistence/Models/StoredBathEvent.swift
+++ b/Packages/BabyTrackerPersistence/Sources/BabyTrackerPersistence/Models/StoredBathEvent.swift
@@ -3,6 +3,8 @@ import SwiftData
 
 @Model
 final class StoredBathEvent {
+    #Index<StoredBathEvent>([\.childID], [\.childID, \.occurredAt])
+
     var id: UUID = UUID()
     var childID: UUID = UUID()
     var occurredAt: Date = Date()

--- a/Packages/BabyTrackerPersistence/Sources/BabyTrackerPersistence/Models/StoredBottleFeedEvent.swift
+++ b/Packages/BabyTrackerPersistence/Sources/BabyTrackerPersistence/Models/StoredBottleFeedEvent.swift
@@ -3,6 +3,8 @@ import SwiftData
 
 @Model
 final class StoredBottleFeedEvent {
+    #Index<StoredBottleFeedEvent>([\.childID], [\.childID, \.occurredAt])
+
     var id: UUID = UUID()
     var childID: UUID = UUID()
     var occurredAt: Date = Date()

--- a/Packages/BabyTrackerPersistence/Sources/BabyTrackerPersistence/Models/StoredBreastFeedEvent.swift
+++ b/Packages/BabyTrackerPersistence/Sources/BabyTrackerPersistence/Models/StoredBreastFeedEvent.swift
@@ -3,6 +3,8 @@ import SwiftData
 
 @Model
 final class StoredBreastFeedEvent {
+    #Index<StoredBreastFeedEvent>([\.childID], [\.childID, \.startedAt])
+
     var id: UUID = UUID()
     var childID: UUID = UUID()
     var occurredAt: Date = Date()

--- a/Packages/BabyTrackerPersistence/Sources/BabyTrackerPersistence/Models/StoredMedicationEvent.swift
+++ b/Packages/BabyTrackerPersistence/Sources/BabyTrackerPersistence/Models/StoredMedicationEvent.swift
@@ -3,6 +3,8 @@ import SwiftData
 
 @Model
 final class StoredMedicationEvent {
+    #Index<StoredMedicationEvent>([\.childID], [\.childID, \.occurredAt])
+
     var id: UUID = UUID()
     var childID: UUID = UUID()
     var occurredAt: Date = Date()

--- a/Packages/BabyTrackerPersistence/Sources/BabyTrackerPersistence/Models/StoredNappyEvent.swift
+++ b/Packages/BabyTrackerPersistence/Sources/BabyTrackerPersistence/Models/StoredNappyEvent.swift
@@ -3,6 +3,8 @@ import SwiftData
 
 @Model
 final class StoredNappyEvent {
+    #Index<StoredNappyEvent>([\.childID], [\.childID, \.occurredAt])
+
     var id: UUID = UUID()
     var childID: UUID = UUID()
     var occurredAt: Date = Date()

--- a/Packages/BabyTrackerPersistence/Sources/BabyTrackerPersistence/Models/StoredSleepEvent.swift
+++ b/Packages/BabyTrackerPersistence/Sources/BabyTrackerPersistence/Models/StoredSleepEvent.swift
@@ -3,6 +3,8 @@ import SwiftData
 
 @Model
 final class StoredSleepEvent {
+    #Index<StoredSleepEvent>([\.childID], [\.childID, \.startedAt], [\.childID, \.occurredAt])
+
     var id: UUID = UUID()
     var childID: UUID = UUID()
     var occurredAt: Date = Date()

--- a/Packages/BabyTrackerPersistence/Sources/BabyTrackerPersistence/SwiftDataEventRepository.swift
+++ b/Packages/BabyTrackerPersistence/Sources/BabyTrackerPersistence/SwiftDataEventRepository.swift
@@ -70,77 +70,17 @@ public final class SwiftDataEventRepository: EventRepository {
     ) throws -> [BabyEvent] {
         var timeline: [BabyEvent] = []
 
-        timeline.append(contentsOf: try modelContext.fetch(FetchDescriptor<StoredBathEvent>())
-            .filter { storedEvent in
-                storedEvent.childID == childID &&
-                (
-                    includingDeleted ||
-                    !isSoftDeleted(
-                        isDeleted: storedEvent.isDeleted,
-                        deletedAt: storedEvent.deletedAt
-                    )
-                )
-            }
+        timeline.append(contentsOf: try fetchBathEvents(childID: childID, includingDeleted: includingDeleted)
             .map { .bath(mapBath($0)) })
-        timeline.append(contentsOf: try modelContext.fetch(FetchDescriptor<StoredBreastFeedEvent>())
-            .filter { storedEvent in
-                storedEvent.childID == childID &&
-                (
-                    includingDeleted ||
-                    !isSoftDeleted(
-                        isDeleted: storedEvent.isDeleted,
-                        deletedAt: storedEvent.deletedAt
-                    )
-                )
-            }
+        timeline.append(contentsOf: try fetchBreastFeedEvents(childID: childID, includingDeleted: includingDeleted)
             .map { .breastFeed(try mapBreastFeed($0)) })
-        timeline.append(contentsOf: try modelContext.fetch(FetchDescriptor<StoredBottleFeedEvent>())
-            .filter { storedEvent in
-                storedEvent.childID == childID &&
-                (
-                    includingDeleted ||
-                    !isSoftDeleted(
-                        isDeleted: storedEvent.isDeleted,
-                        deletedAt: storedEvent.deletedAt
-                    )
-                )
-            }
+        timeline.append(contentsOf: try fetchBottleFeedEvents(childID: childID, includingDeleted: includingDeleted)
             .map { .bottleFeed(try mapBottleFeed($0)) })
-        timeline.append(contentsOf: try modelContext.fetch(FetchDescriptor<StoredSleepEvent>())
-            .filter { storedEvent in
-                storedEvent.childID == childID &&
-                (
-                    includingDeleted ||
-                    !isSoftDeleted(
-                        isDeleted: storedEvent.isDeleted,
-                        deletedAt: storedEvent.deletedAt
-                    )
-                )
-            }
+        timeline.append(contentsOf: try fetchSleepEvents(childID: childID, includingDeleted: includingDeleted)
             .map { .sleep(try mapSleep($0)) })
-        timeline.append(contentsOf: try modelContext.fetch(FetchDescriptor<StoredNappyEvent>())
-            .filter { storedEvent in
-                storedEvent.childID == childID &&
-                (
-                    includingDeleted ||
-                    !isSoftDeleted(
-                        isDeleted: storedEvent.isDeleted,
-                        deletedAt: storedEvent.deletedAt
-                    )
-                )
-            }
+        timeline.append(contentsOf: try fetchNappyEvents(childID: childID, includingDeleted: includingDeleted)
             .map { .nappy(try mapNappy($0)) })
-        timeline.append(contentsOf: try modelContext.fetch(FetchDescriptor<StoredMedicationEvent>())
-            .filter { storedEvent in
-                storedEvent.childID == childID &&
-                (
-                    includingDeleted ||
-                    !isSoftDeleted(
-                        isDeleted: storedEvent.isDeleted,
-                        deletedAt: storedEvent.deletedAt
-                    )
-                )
-            }
+        timeline.append(contentsOf: try fetchMedicationEvents(childID: childID, includingDeleted: includingDeleted)
             .map { .medication(try mapMedication($0)) })
 
         return timeline.sorted { left, right in
@@ -159,48 +99,64 @@ public final class SwiftDataEventRepository: EventRepository {
             return []
         }
 
-        return try loadTimeline(for: childID, includingDeleted: includingDeleted)
-            .filter { event in
-                eventOverlapsDay(event, startOfDay: startOfDay, endOfDay: endOfDay)
-            }
-    }
+        var dayEvents: [BabyEvent] = []
 
-    private func eventOverlapsDay(
-        _ event: BabyEvent,
-        startOfDay: Date,
-        endOfDay: Date
-    ) -> Bool {
-        switch event {
-        case let .sleep(sleep):
-            // Active sleep (nil endedAt) is treated as still ongoing
-            let end = sleep.endedAt ?? Date.distantFuture
-            return sleep.startedAt < endOfDay && end > startOfDay
-        case let .breastFeed(feed):
-            return feed.startedAt < endOfDay && feed.endedAt > startOfDay
-        case let .bath(bath):
-            return bath.metadata.occurredAt >= startOfDay && bath.metadata.occurredAt < endOfDay
-        case let .bottleFeed(feed):
-            return feed.metadata.occurredAt >= startOfDay && feed.metadata.occurredAt < endOfDay
-        case let .nappy(nappy):
-            return nappy.metadata.occurredAt >= startOfDay && nappy.metadata.occurredAt < endOfDay
-        case let .medication(medication):
-            return medication.metadata.occurredAt >= startOfDay && medication.metadata.occurredAt < endOfDay
+        dayEvents.append(contentsOf: try fetchBathEvents(
+            childID: childID,
+            occurringFrom: startOfDay,
+            to: endOfDay,
+            includingDeleted: includingDeleted
+        ).map { .bath(mapBath($0)) })
+        dayEvents.append(contentsOf: try fetchBreastFeedEvents(
+            childID: childID,
+            overlapping: startOfDay,
+            to: endOfDay,
+            includingDeleted: includingDeleted
+        ).map { .breastFeed(try mapBreastFeed($0)) })
+        dayEvents.append(contentsOf: try fetchBottleFeedEvents(
+            childID: childID,
+            occurringFrom: startOfDay,
+            to: endOfDay,
+            includingDeleted: includingDeleted
+        ).map { .bottleFeed(try mapBottleFeed($0)) })
+        dayEvents.append(contentsOf: try fetchSleepEvents(
+            childID: childID,
+            overlapping: startOfDay,
+            to: endOfDay,
+            includingDeleted: includingDeleted
+        ).map { .sleep(try mapSleep($0)) })
+        dayEvents.append(contentsOf: try fetchNappyEvents(
+            childID: childID,
+            occurringFrom: startOfDay,
+            to: endOfDay,
+            includingDeleted: includingDeleted
+        ).map { .nappy(try mapNappy($0)) })
+        dayEvents.append(contentsOf: try fetchMedicationEvents(
+            childID: childID,
+            occurringFrom: startOfDay,
+            to: endOfDay,
+            includingDeleted: includingDeleted
+        ).map { .medication(try mapMedication($0)) })
+
+        return dayEvents.sorted { left, right in
+            left.metadata.occurredAt > right.metadata.occurredAt
         }
     }
 
     public func loadActiveSleepEvent(for childID: UUID) throws -> SleepEvent? {
-        try modelContext.fetch(FetchDescriptor<StoredSleepEvent>())
-            .filter { storedEvent in
-                storedEvent.childID == childID &&
-                !isSoftDeleted(
-                    isDeleted: storedEvent.isDeleted,
-                    deletedAt: storedEvent.deletedAt
-                ) &&
-                storedEvent.endedAt == nil
-            }
-            .map(mapSleep)
-            .sorted { left, right in left.startedAt > right.startedAt }
-            .first
+        let predicate = #Predicate<StoredSleepEvent> { storedEvent in
+            storedEvent.childID == childID &&
+            storedEvent.endedAt == nil &&
+            !storedEvent.isDeleted &&
+            storedEvent.deletedAt == nil
+        }
+        var descriptor = FetchDescriptor<StoredSleepEvent>(predicate: predicate)
+        descriptor.sortBy = [SortDescriptor(\.startedAt, order: .reverse)]
+
+        guard let storedEvent = try modelContext.fetch(descriptor).first else {
+            return nil
+        }
+        return try mapSleep(storedEvent)
     }
 
     public func softDeleteEvent(
@@ -227,6 +183,278 @@ public final class SwiftDataEventRepository: EventRepository {
 
     private var modelContext: ModelContext {
         store.modelContainer.mainContext
+    }
+
+    // MARK: - Timeline fetches (childID-scoped, unbounded by date)
+
+    private func fetchBathEvents(childID: UUID, includingDeleted: Bool) throws -> [StoredBathEvent] {
+        let predicate: Predicate<StoredBathEvent>
+        if includingDeleted {
+            predicate = #Predicate<StoredBathEvent> { $0.childID == childID }
+        } else {
+            predicate = #Predicate<StoredBathEvent> { storedEvent in
+                storedEvent.childID == childID &&
+                !storedEvent.isDeleted &&
+                storedEvent.deletedAt == nil
+            }
+        }
+        return try modelContext.fetch(FetchDescriptor<StoredBathEvent>(predicate: predicate))
+    }
+
+    private func fetchBreastFeedEvents(childID: UUID, includingDeleted: Bool) throws -> [StoredBreastFeedEvent] {
+        let predicate: Predicate<StoredBreastFeedEvent>
+        if includingDeleted {
+            predicate = #Predicate<StoredBreastFeedEvent> { $0.childID == childID }
+        } else {
+            predicate = #Predicate<StoredBreastFeedEvent> { storedEvent in
+                storedEvent.childID == childID &&
+                !storedEvent.isDeleted &&
+                storedEvent.deletedAt == nil
+            }
+        }
+        return try modelContext.fetch(FetchDescriptor<StoredBreastFeedEvent>(predicate: predicate))
+    }
+
+    private func fetchBottleFeedEvents(childID: UUID, includingDeleted: Bool) throws -> [StoredBottleFeedEvent] {
+        let predicate: Predicate<StoredBottleFeedEvent>
+        if includingDeleted {
+            predicate = #Predicate<StoredBottleFeedEvent> { $0.childID == childID }
+        } else {
+            predicate = #Predicate<StoredBottleFeedEvent> { storedEvent in
+                storedEvent.childID == childID &&
+                !storedEvent.isDeleted &&
+                storedEvent.deletedAt == nil
+            }
+        }
+        return try modelContext.fetch(FetchDescriptor<StoredBottleFeedEvent>(predicate: predicate))
+    }
+
+    private func fetchSleepEvents(childID: UUID, includingDeleted: Bool) throws -> [StoredSleepEvent] {
+        let predicate: Predicate<StoredSleepEvent>
+        if includingDeleted {
+            predicate = #Predicate<StoredSleepEvent> { $0.childID == childID }
+        } else {
+            predicate = #Predicate<StoredSleepEvent> { storedEvent in
+                storedEvent.childID == childID &&
+                !storedEvent.isDeleted &&
+                storedEvent.deletedAt == nil
+            }
+        }
+        return try modelContext.fetch(FetchDescriptor<StoredSleepEvent>(predicate: predicate))
+    }
+
+    private func fetchNappyEvents(childID: UUID, includingDeleted: Bool) throws -> [StoredNappyEvent] {
+        let predicate: Predicate<StoredNappyEvent>
+        if includingDeleted {
+            predicate = #Predicate<StoredNappyEvent> { $0.childID == childID }
+        } else {
+            predicate = #Predicate<StoredNappyEvent> { storedEvent in
+                storedEvent.childID == childID &&
+                !storedEvent.isDeleted &&
+                storedEvent.deletedAt == nil
+            }
+        }
+        return try modelContext.fetch(FetchDescriptor<StoredNappyEvent>(predicate: predicate))
+    }
+
+    private func fetchMedicationEvents(childID: UUID, includingDeleted: Bool) throws -> [StoredMedicationEvent] {
+        let predicate: Predicate<StoredMedicationEvent>
+        if includingDeleted {
+            predicate = #Predicate<StoredMedicationEvent> { $0.childID == childID }
+        } else {
+            predicate = #Predicate<StoredMedicationEvent> { storedEvent in
+                storedEvent.childID == childID &&
+                !storedEvent.isDeleted &&
+                storedEvent.deletedAt == nil
+            }
+        }
+        return try modelContext.fetch(FetchDescriptor<StoredMedicationEvent>(predicate: predicate))
+    }
+
+    // MARK: - Day-range fetches (childID + date-window scoped)
+    //
+    // Instant events (bath/bottle feed/nappy/medication) are filtered on
+    // `occurredAt` falling within [startOfDay, endOfDay). Sleep and breast
+    // feed events have a duration and must use overlap semantics instead of a
+    // single-instant comparison, since a session can span the day boundary.
+
+    private func fetchBathEvents(
+        childID: UUID,
+        occurringFrom startOfDay: Date,
+        to endOfDay: Date,
+        includingDeleted: Bool
+    ) throws -> [StoredBathEvent] {
+        let predicate: Predicate<StoredBathEvent>
+        if includingDeleted {
+            predicate = #Predicate<StoredBathEvent> { storedEvent in
+                storedEvent.childID == childID &&
+                storedEvent.occurredAt >= startOfDay &&
+                storedEvent.occurredAt < endOfDay
+            }
+        } else {
+            predicate = #Predicate<StoredBathEvent> { storedEvent in
+                storedEvent.childID == childID &&
+                storedEvent.occurredAt >= startOfDay &&
+                storedEvent.occurredAt < endOfDay &&
+                !storedEvent.isDeleted &&
+                storedEvent.deletedAt == nil
+            }
+        }
+        return try modelContext.fetch(FetchDescriptor<StoredBathEvent>(predicate: predicate))
+    }
+
+    private func fetchBottleFeedEvents(
+        childID: UUID,
+        occurringFrom startOfDay: Date,
+        to endOfDay: Date,
+        includingDeleted: Bool
+    ) throws -> [StoredBottleFeedEvent] {
+        let predicate: Predicate<StoredBottleFeedEvent>
+        if includingDeleted {
+            predicate = #Predicate<StoredBottleFeedEvent> { storedEvent in
+                storedEvent.childID == childID &&
+                storedEvent.occurredAt >= startOfDay &&
+                storedEvent.occurredAt < endOfDay
+            }
+        } else {
+            predicate = #Predicate<StoredBottleFeedEvent> { storedEvent in
+                storedEvent.childID == childID &&
+                storedEvent.occurredAt >= startOfDay &&
+                storedEvent.occurredAt < endOfDay &&
+                !storedEvent.isDeleted &&
+                storedEvent.deletedAt == nil
+            }
+        }
+        return try modelContext.fetch(FetchDescriptor<StoredBottleFeedEvent>(predicate: predicate))
+    }
+
+    private func fetchNappyEvents(
+        childID: UUID,
+        occurringFrom startOfDay: Date,
+        to endOfDay: Date,
+        includingDeleted: Bool
+    ) throws -> [StoredNappyEvent] {
+        let predicate: Predicate<StoredNappyEvent>
+        if includingDeleted {
+            predicate = #Predicate<StoredNappyEvent> { storedEvent in
+                storedEvent.childID == childID &&
+                storedEvent.occurredAt >= startOfDay &&
+                storedEvent.occurredAt < endOfDay
+            }
+        } else {
+            predicate = #Predicate<StoredNappyEvent> { storedEvent in
+                storedEvent.childID == childID &&
+                storedEvent.occurredAt >= startOfDay &&
+                storedEvent.occurredAt < endOfDay &&
+                !storedEvent.isDeleted &&
+                storedEvent.deletedAt == nil
+            }
+        }
+        return try modelContext.fetch(FetchDescriptor<StoredNappyEvent>(predicate: predicate))
+    }
+
+    private func fetchMedicationEvents(
+        childID: UUID,
+        occurringFrom startOfDay: Date,
+        to endOfDay: Date,
+        includingDeleted: Bool
+    ) throws -> [StoredMedicationEvent] {
+        let predicate: Predicate<StoredMedicationEvent>
+        if includingDeleted {
+            predicate = #Predicate<StoredMedicationEvent> { storedEvent in
+                storedEvent.childID == childID &&
+                storedEvent.occurredAt >= startOfDay &&
+                storedEvent.occurredAt < endOfDay
+            }
+        } else {
+            predicate = #Predicate<StoredMedicationEvent> { storedEvent in
+                storedEvent.childID == childID &&
+                storedEvent.occurredAt >= startOfDay &&
+                storedEvent.occurredAt < endOfDay &&
+                !storedEvent.isDeleted &&
+                storedEvent.deletedAt == nil
+            }
+        }
+        return try modelContext.fetch(FetchDescriptor<StoredMedicationEvent>(predicate: predicate))
+    }
+
+    private func fetchBreastFeedEvents(
+        childID: UUID,
+        overlapping startOfDay: Date,
+        to endOfDay: Date,
+        includingDeleted: Bool
+    ) throws -> [StoredBreastFeedEvent] {
+        // endedAt is non-optional for breast feeds (a feed is only ever saved
+        // once it has an end time), so a plain overlap comparison is safe.
+        let predicate: Predicate<StoredBreastFeedEvent>
+        if includingDeleted {
+            predicate = #Predicate<StoredBreastFeedEvent> { storedEvent in
+                storedEvent.childID == childID &&
+                storedEvent.startedAt < endOfDay &&
+                storedEvent.endedAt > startOfDay
+            }
+        } else {
+            predicate = #Predicate<StoredBreastFeedEvent> { storedEvent in
+                storedEvent.childID == childID &&
+                storedEvent.startedAt < endOfDay &&
+                storedEvent.endedAt > startOfDay &&
+                !storedEvent.isDeleted &&
+                storedEvent.deletedAt == nil
+            }
+        }
+        return try modelContext.fetch(FetchDescriptor<StoredBreastFeedEvent>(predicate: predicate))
+    }
+
+    private func fetchSleepEvents(
+        childID: UUID,
+        overlapping startOfDay: Date,
+        to endOfDay: Date,
+        includingDeleted: Bool
+    ) throws -> [StoredSleepEvent] {
+        // Sleep's `endedAt` is optional (nil while a session is ongoing), and
+        // SwiftData's #Predicate macro does not reliably support comparing an
+        // Optional<Date> against a Date. Splitting into two predicates avoids
+        // that: one for still-active sessions (endedAt == nil, a nil-check is
+        // well supported) and one for completed sessions, which relies on the
+        // app-wide invariant (enforced by SleepEvent.updating/LogSleepUseCase)
+        // that `occurredAt == endedAt` once a session has ended, letting us
+        // compare the non-optional `occurredAt` instead of `endedAt`.
+        let activePredicate: Predicate<StoredSleepEvent>
+        let endedPredicate: Predicate<StoredSleepEvent>
+
+        if includingDeleted {
+            activePredicate = #Predicate<StoredSleepEvent> { storedEvent in
+                storedEvent.childID == childID &&
+                storedEvent.endedAt == nil &&
+                storedEvent.startedAt < endOfDay
+            }
+            endedPredicate = #Predicate<StoredSleepEvent> { storedEvent in
+                storedEvent.childID == childID &&
+                storedEvent.endedAt != nil &&
+                storedEvent.startedAt < endOfDay &&
+                storedEvent.occurredAt > startOfDay
+            }
+        } else {
+            activePredicate = #Predicate<StoredSleepEvent> { storedEvent in
+                storedEvent.childID == childID &&
+                storedEvent.endedAt == nil &&
+                storedEvent.startedAt < endOfDay &&
+                !storedEvent.isDeleted &&
+                storedEvent.deletedAt == nil
+            }
+            endedPredicate = #Predicate<StoredSleepEvent> { storedEvent in
+                storedEvent.childID == childID &&
+                storedEvent.endedAt != nil &&
+                storedEvent.startedAt < endOfDay &&
+                storedEvent.occurredAt > startOfDay &&
+                !storedEvent.isDeleted &&
+                storedEvent.deletedAt == nil
+            }
+        }
+
+        let activeEvents = try modelContext.fetch(FetchDescriptor<StoredSleepEvent>(predicate: activePredicate))
+        let endedEvents = try modelContext.fetch(FetchDescriptor<StoredSleepEvent>(predicate: endedPredicate))
+        return activeEvents + endedEvents
     }
 
     private func saveBath(_ event: BathEvent) throws {
@@ -425,33 +653,33 @@ public final class SwiftDataEventRepository: EventRepository {
     }
 
     private func fetchStoredBathEvent(id: UUID) throws -> StoredBathEvent? {
-        try modelContext.fetch(FetchDescriptor<StoredBathEvent>())
-            .first { $0.id == id }
+        let predicate = #Predicate<StoredBathEvent> { $0.id == id }
+        return try modelContext.fetch(FetchDescriptor<StoredBathEvent>(predicate: predicate)).first
     }
 
     private func fetchStoredBreastFeedEvent(id: UUID) throws -> StoredBreastFeedEvent? {
-        try modelContext.fetch(FetchDescriptor<StoredBreastFeedEvent>())
-            .first { $0.id == id }
+        let predicate = #Predicate<StoredBreastFeedEvent> { $0.id == id }
+        return try modelContext.fetch(FetchDescriptor<StoredBreastFeedEvent>(predicate: predicate)).first
     }
 
     private func fetchStoredBottleFeedEvent(id: UUID) throws -> StoredBottleFeedEvent? {
-        try modelContext.fetch(FetchDescriptor<StoredBottleFeedEvent>())
-            .first { $0.id == id }
+        let predicate = #Predicate<StoredBottleFeedEvent> { $0.id == id }
+        return try modelContext.fetch(FetchDescriptor<StoredBottleFeedEvent>(predicate: predicate)).first
     }
 
     private func fetchStoredSleepEvent(id: UUID) throws -> StoredSleepEvent? {
-        try modelContext.fetch(FetchDescriptor<StoredSleepEvent>())
-            .first { $0.id == id }
+        let predicate = #Predicate<StoredSleepEvent> { $0.id == id }
+        return try modelContext.fetch(FetchDescriptor<StoredSleepEvent>(predicate: predicate)).first
     }
 
     private func fetchStoredNappyEvent(id: UUID) throws -> StoredNappyEvent? {
-        try modelContext.fetch(FetchDescriptor<StoredNappyEvent>())
-            .first { $0.id == id }
+        let predicate = #Predicate<StoredNappyEvent> { $0.id == id }
+        return try modelContext.fetch(FetchDescriptor<StoredNappyEvent>(predicate: predicate)).first
     }
 
     private func fetchStoredMedicationEvent(id: UUID) throws -> StoredMedicationEvent? {
-        try modelContext.fetch(FetchDescriptor<StoredMedicationEvent>())
-            .first { $0.id == id }
+        let predicate = #Predicate<StoredMedicationEvent> { $0.id == id }
+        return try modelContext.fetch(FetchDescriptor<StoredMedicationEvent>(predicate: predicate)).first
     }
 
     private func mapBath(_ storedEvent: StoredBathEvent) -> BathEvent {


### PR DESCRIPTION
## Summary

Investigated general app-wide lag reported once event history reaches ~2500 events. Root cause was structural, in both the data layer and the view layer:

- `SwiftDataEventRepository.loadTimeline()` fetched **all** rows from **all 6** event tables (no predicate) and filtered by `childID`/deleted-state in Swift. `loadEvents(on:)` reloaded that entire timeline internally just to return one day's events, and `AppModel`'s 7-day visible timeline triggered that ~9 times per refresh.
- Summary/Trends/Advanced-summary calculators and `EventHistoryViewModel.sections` recomputed multi-pass O(n) aggregations over the full event history on every SwiftUI render, with no memoization.

### Changes

- **Persistence layer**: replace full-table-scan `FetchDescriptor<T>()` + in-memory filtering with predicate-based (`#Predicate`) fetches scoped by `childID` and date range where applicable. Add `#Index` on `childID`/date fields to all 6 `Stored*Event` models — a lightweight, non-destructive schema change (no column shape change, so no explicit migration plan needed; verified all models already have default values on every property).
- **AppModel**: eliminate the 7x redundant full-timeline reloads when building the visible timeline pages — filter the already-loaded event array in memory instead of re-querying the repository per day.
- **Shared day-overlap logic**: extracted into `BabyEvent.overlaps(startOfDay:endOfDay:)` in `BabyTrackerDomain`, used by both the repository and `AppModel`, and used to fix a parity gap in the `InMemoryEventRepository` test double (it previously used same-day matching instead of overlap semantics for sessions spanning midnight).
- **View-layer caching**: `SummaryViewModel` now caches `TodaySummaryCalculator`/`TrendsSummaryCalculator`/`AdvancedSummaryMetricsCalculator` output keyed on the exact inputs that produced it, and `EventHistoryViewModel.sections` is similarly cached, so unrelated `AppModel` mutations or repeat SwiftUI body evaluations don't force a full recompute over the entire event history.
- `HomeViewModel.recentEvents` now truncates to the 6 most recent events before mapping instead of after, avoiding an unnecessary full-array transform.

### Tests

Added repository tests for: breast-feed sessions spanning midnight (mirroring the existing sleep test), soft-deleted events being excluded/included correctly on day-scoped loads, and multi-child isolation (predicates must not leak another child's events).

## Test plan

- [ ] CI (`unit-tests.yml`) passes — this environment has no Swift/Xcode toolchain, so changes were reviewed by hand but not locally compiled; relying on CI to catch build errors
- [ ] Manually verify History, Summary (Today/Trends), and Advanced Summary screens against a populated device/simulator store — numbers should match pre-change values
- [ ] Verify events spanning midnight (active/ended sleep, breast feeds) still show on both days
- [ ] Verify soft-deleted events remain excluded from normal loads
- [ ] Confirm app launches cleanly against an existing local store (validates the `#Index` schema change doesn't require an unexpected migration)


---
_Generated by [Claude Code](https://claude.ai/code/session_014TcDQ4ft3VBU47fKR5XXos)_