### PR TITLE
Auto-create TestFlight tag when a PR is merged

### DIFF
--- a/.github/workflows/pr-comment-tags.yml
+++ b/.github/workflows/pr-comment-tags.yml
@@ -4,6 +4,9 @@ on:
   issue_comment:
     types:
       - created
+  pull_request:
+    types:
+      - closed
   workflow_dispatch:
     inputs:
       command:
@@ -24,7 +27,7 @@ permissions:
 
 jobs:
   tag:
-    if: ${{ github.event_name == 'workflow_dispatch' || (github.event.issue.pull_request && startsWith(github.event.comment.body, 'tag ')) }}
+    if: ${{ github.event_name == 'workflow_dispatch' || (github.event_name == 'pull_request' && github.event.pull_request.merged == true && github.event.pull_request.base.ref == 'main') || (github.event.issue.pull_request && startsWith(github.event.comment.body, 'tag ')) }}
     runs-on: ubuntu-latest
 
     steps:
@@ -47,6 +50,16 @@ jobs:
               core.setOutput('release_bump', dispatchRelease ? dispatchRelease[1] : '');
               core.setOutput('head_sha', context.sha);
               core.setOutput('head_ref', context.ref.replace(/^refs\/heads\//, ''));
+              return;
+            }
+
+            if (context.eventName === 'pull_request') {
+              const pr = context.payload.pull_request;
+
+              core.setOutput('request_type', 'testflight');
+              core.setOutput('release_bump', '');
+              core.setOutput('head_sha', pr.merge_commit_sha);
+              core.setOutput('head_ref', pr.base.ref);
               return;
             }
 
@@ -177,7 +190,7 @@ jobs:
           } >> "${GITHUB_STEP_SUMMARY}"
 
       - name: Comment with TestFlight tag details
-        if: ${{ steps.request.outputs.request_type == 'testflight' && github.event_name == 'issue_comment' }}
+        if: ${{ steps.request.outputs.request_type == 'testflight' && (github.event_name == 'issue_comment' || github.event_name == 'pull_request') }}
         uses: actions/github-script@v7
         env:
           TAG_NAME: ${{ steps.testflight.outputs.tag_name }}
@@ -408,7 +421,7 @@ jobs:
             }
 
       - name: Comment with failure details
-        if: ${{ failure() && steps.request.outcome == 'success' && github.event_name == 'issue_comment' }}
+        if: ${{ failure() && steps.request.outcome == 'success' && (github.event_name == 'issue_comment' || github.event_name == 'pull_request') }}
         uses: actions/github-script@v7
         with:
           script: |


### PR DESCRIPTION
## Summary
- Adds a `pull_request` (`closed`) trigger to `.github/workflows/pr-comment-tags.yml` so merging any PR into `main` automatically drops the next numerical `TestFlight-N` tag on the merge commit.
- Reuses the existing TestFlight tag-creation logic (previously only reachable via the `tag TestFlight` PR comment command or manual `workflow_dispatch`) instead of duplicating it.
- Posts the same "TestFlight tag created" confirmation comment on the merged PR, and a failure comment if tag creation fails.

## How it works
- `Resolve tag request` now recognizes `context.eventName === 'pull_request'`, setting `request_type=testflight`, `head_sha` to the PR's `merge_commit_sha`, and `head_ref` to the base branch (`main`).
- The job only runs for this new trigger when `github.event.pull_request.merged == true` and the base branch is `main`, so unmerged/closed PRs don't trigger a tag.

## Test plan
- [ ] Merge a PR into `main` and confirm a new `TestFlight-N` tag is created at the next available number and a confirmation comment is posted on the PR.
- [ ] Confirm the existing `tag TestFlight` comment command and `workflow_dispatch` paths still work unchanged.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Dvatf5M1vfeTq3FJWwzHjz)_